### PR TITLE
Implement Master Brewer perk

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
@@ -2,6 +2,7 @@ package goat.minecraft.minecraftnew.subsystems.brewing;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
 import org.bukkit.*;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -462,6 +463,12 @@ public class PotionBrewingSubsystem implements Listener {
             brewing = true;
             if (!resuming) {
                 brewTimeRemaining = recipe.getBrewTime();
+                if (player != null) {
+                    PlayerMeritManager meritManager = PlayerMeritManager.getInstance(plugin);
+                    if (meritManager.hasPerk(player.getUniqueId(), "Master Brewer")) {
+                        brewTimeRemaining = (int) Math.ceil(brewTimeRemaining * 0.5);
+                    }
+                }
             }
             spawnTimerArmorStand();
             startBrewTimer();


### PR DESCRIPTION
## Summary
- integrate PlayerMeritManager with PotionBrewingSubsystem
- halve brew timer when player has the **Master Brewer** perk

## Testing
- `mvn package -DskipTests` *(fails: PluginResolutionException - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68400940f77c833287bc029a6a71bdf6