### PR TITLE
Implement Master Chef perk double drops

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/meritperks/MasterChef.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/meritperks/MasterChef.java
@@ -8,7 +8,8 @@ import org.bukkit.plugin.java.JavaPlugin;
  * Master Chef merit perk.
  * <p>
  * Provides a 50% chance to produce two culinary delights instead of one when a
- * recipe completes. Implementation to be added later.
+ * recipe completes. The logic is handled inside the CulinarySubsystem
+ * finalizeRecipe method.
  */
 public class MasterChef implements Listener {
 
@@ -20,5 +21,5 @@ public class MasterChef implements Listener {
         this.playerData = playerData;
     }
 
-    // TODO: Hook into culinary system and double outputs when chance succeeds.
+    // Functionality implemented directly in CulinarySubsystem.finalizeRecipe()
 }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/culinary/CulinarySubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/culinary/CulinarySubsystem.java
@@ -1,6 +1,7 @@
 package goat.minecraft.minecraftnew.subsystems.culinary;
 
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
 import org.bukkit.*;
 import org.bukkit.entity.*;
 import org.bukkit.event.*;
@@ -764,8 +765,12 @@ public class CulinarySubsystem implements Listener {
             removeEntityByUUID(u);
         }
 
-        // Drop final output
+        // Drop final output with Master Chef perk consideration
         ItemStack result = createOutputItem(session.recipe);
+        PlayerMeritManager meritManager = PlayerMeritManager.getInstance(plugin);
+        if (meritManager.hasPerk(player.getUniqueId(), "Master Chef") && Math.random() < 0.5) {
+            result.setAmount(2);
+        }
         session.tableLocation.getWorld().dropItem(session.tableLocation.clone().add(0.5, 1, 0.5), result);
         XPManager xpManager = new XPManager(plugin);
         xpManager.addXP(player, "Culinary", session.recipe.getXpReward());


### PR DESCRIPTION
## Summary
- integrate PlayerMeritManager in `CulinarySubsystem`
- implement 50% chance for Master Chef perk to drop two items
- document perk logic in `MasterChef` class

## Testing
- `mvn -q package -DskipTests` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840096e281c8332a774d94b6b56a27d