### PR TITLE
Add Unlooting merit perk

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -187,6 +187,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new QuickSwap(this, playerData), this);
         getServer().getPluginManager().registerEvents(new Trainer(playerData), this);
         getServer().getPluginManager().registerEvents(new Restock(this, playerData), this);
+        getServer().getPluginManager().registerEvents(new Unlooting(this, playerData), this);
         getServer().getPluginManager().registerEvents(new Rebreather(this, playerData), this);
         getServer().getPluginManager().registerEvents(new Keepinventory(this, playerData), this);
         getServer().getPluginManager().registerEvents(new MasterSmith(this, playerData), this);

--- a/src/main/java/goat/minecraft/minecraftnew/other/meritperks/Unlooting.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/meritperks/Unlooting.java
@@ -1,0 +1,59 @@
+package goat.minecraft.minecraftnew.other.meritperks;
+
+import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Unlooting merit perk.
+ *
+ * When enabled, the player will automatically discard common mob drops
+ * like rotten flesh and bones instead of picking them up.
+ * This helps keep the inventory clear of clutter.
+ */
+public class Unlooting implements Listener {
+
+    private final JavaPlugin plugin;
+    private final PlayerMeritManager playerData;
+
+    private static final Set<Material> TRASH_ITEMS = EnumSet.of(
+            Material.ROTTEN_FLESH,
+            Material.BONE,
+            Material.ARROW,
+            Material.GUNPOWDER,
+            Material.STRING,
+            Material.SPIDER_EYE
+    );
+
+    public Unlooting(JavaPlugin plugin, PlayerMeritManager playerData) {
+        this.plugin = plugin;
+        this.playerData = playerData;
+    }
+
+    @EventHandler
+    public void onItemPickup(EntityPickupItemEvent event) {
+        if (!(event.getEntity() instanceof Player player)) {
+            return;
+        }
+
+        UUID playerId = player.getUniqueId();
+        if (!playerData.hasPerk(playerId, "Unlooting")) {
+            return;
+        }
+
+        ItemStack item = event.getItem().getItemStack();
+        if (TRASH_ITEMS.contains(item.getType())) {
+            event.setCancelled(true);
+            event.getItem().remove();
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/MeritCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/MeritCommand.java
@@ -329,7 +329,12 @@ public class MeritCommand implements CommandExecutor, Listener {
                     )),
             new Perk(ChatColor.DARK_GRAY + "Resurrection Charge 3", 1, Material.TOTEM_OF_UNDYING,
                     Arrays.asList(
-                            ChatColor.GRAY + "Allows a third resurrection charge." 
+                            ChatColor.GRAY + "Allows a third resurrection charge."
+                    )),
+            new Perk(ChatColor.DARK_GRAY + "Unlooting", 0, Material.BARRIER,
+                    Arrays.asList(
+                            ChatColor.GRAY + "Destroys junk drops automatically.",
+                            ChatColor.BLUE + "On Pickup: " + ChatColor.GRAY + "Rotten flesh and similar items vanish."
                     ))
             );
 


### PR DESCRIPTION
## Summary
- add `Unlooting` merit perk class which removes common junk drops from pickups
- register the new perk in the main plugin and GUI

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684009e975b48332901fe8571790ea08