### PR TITLE
Implement Master Duelist delayed strike effect

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/meritperks/MasterDuelist.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/meritperks/MasterDuelist.java
@@ -1,7 +1,13 @@
 package goat.minecraft.minecraftnew.other.meritperks;
 
 import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
+import org.bukkit.Sound;
+import org.bukkit.Particle;
+import org.bukkit.entity.Monster;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
 /**
@@ -14,11 +20,30 @@ public class MasterDuelist implements Listener {
 
     private final JavaPlugin plugin;
     private final PlayerMeritManager playerData;
+    private static final double PROC_CHANCE = 0.20;
 
     public MasterDuelist(JavaPlugin plugin, PlayerMeritManager playerData) {
         this.plugin = plugin;
         this.playerData = playerData;
     }
 
+    @EventHandler
+    public void onEntityDamage(EntityDamageByEntityEvent event) {
+        if (!(event.getDamager() instanceof Player player)) return;
+        if (!(event.getEntity() instanceof Monster target)) return;
+        if (!playerData.hasPerk(player.getUniqueId(), "Master Duelist")) return;
+
+        if (Math.random() > PROC_CHANCE) return;
+
+        double initialDamage = event.getDamage();
+
+        plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
+            if (!target.isValid() || target.isDead()) return;
+            double extraDamage = initialDamage * 0.20;
+            target.damage(extraDamage, player);
+            target.getWorld().playSound(target.getLocation(), Sound.ENTITY_PLAYER_ATTACK_CRIT, 1.0f, 1.0f);
+            target.getWorld().spawnParticle(Particle.CRIT, target.getLocation().add(0, 1, 0), 15, 0.3, 0.3, 0.3, 0.05);
+        }, 3L);
+    }
     // TODO: Inject critical hit logic into combat system when implemented.
 }


### PR DESCRIPTION
## Summary
- add combat logic for `Master Duelist` perk
- damage struck monsters a second time with sound/particles after a short delay

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_68400a1ff87c8332857368103ceef4b2