### PR TITLE
Implement Master Angler perk bonus

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/FishingEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/FishingEvent.java
@@ -108,7 +108,11 @@ public class FishingEvent implements Listener {
         PlayerMeritManager playerMeritManager = PlayerMeritManager.getInstance(plugin);
 
         if (playerMeritManager.hasPerk(player.getUniqueId(), "Deep Hook")) {
-            seaCreatureChance += 5; // +4% if the item is reforged
+            seaCreatureChance += 5;
+        }
+
+        if (playerMeritManager.hasPerk(player.getUniqueId(), "Master Angler")) {
+            seaCreatureChance += 5;
         }
         // Check active pet perks
         PetManager petManager = PetManager.getInstance(plugin);


### PR DESCRIPTION
## Summary
- add Master Angler perk to fishing sea creature chance calculation

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_68400a3d80088332af15c14a4f084c64