### PR TITLE
Add Master Diplomat forestry perk effect

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/meritperks/MasterDiplomat.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/meritperks/MasterDiplomat.java
@@ -7,8 +7,9 @@ import org.bukkit.plugin.java.JavaPlugin;
 /**
  * Master Diplomat merit perk.
  * <p>
- * Reduces all notoriety gains for the player by 60%.
- * Implementation detail will be added later when the notoriety system is hooked up.
+ * Grants a chance to avoid notoriety when chopping logs.
+ * Players with this perk have a 60% chance to ignore
+ * forestry notoriety gained from breaking wood blocks.
  */
 public class MasterDiplomat implements Listener {
 
@@ -20,5 +21,5 @@ public class MasterDiplomat implements Listener {
         this.playerData = playerData;
     }
 
-    // TODO: Reduce notoriety gain events when this perk is active.
+    // Logic handled in Forestry.incrementNotoriety()
 }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/Forestry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/Forestry.java
@@ -3,6 +3,7 @@ package goat.minecraft.minecraftnew.subsystems.forestry;
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
 import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
+import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -100,6 +101,10 @@ public class Forestry implements Listener {
      * @param player The player whose notoriety is incremented.
      */
     public void incrementNotoriety(Player player) {
+        PlayerMeritManager playerMeritManager = PlayerMeritManager.getInstance(plugin);
+        if (playerMeritManager.hasPerk(player.getUniqueId(), "Master Diplomat") && random.nextDouble() < 0.60) {
+            return; // 60% chance to ignore notoriety gain
+        }
         UUID uuid = player.getUniqueId();
         int currentNotoriety = notorietyMap.getOrDefault(uuid, 0);
         int currentTier = getNotorietyTier(currentNotoriety);


### PR DESCRIPTION
## Summary
- implement notoriety reduction for Master Diplomat in `Forestry.incrementNotoriety`
- document the new chance-based behavior in `MasterDiplomat` perk class

## Testing
- `javac @sources.txt` *(fails: invalid syntax in unrelated file)*

------
https://chatgpt.com/codex/tasks/task_e_68400a62eb608332bdff4bee004e8125