### PR TITLE
Implement persistent double ender chest perk

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -84,6 +84,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
     private RecipeManager recipeManager;
     private ForestryPetManager forestryPetManager;
     private ShelfManager shelfManager;
+    private DoubleEnderchest doubleEnderchest;
 
 
 
@@ -201,7 +202,8 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new MasterTrader(this, playerData), this);
         getServer().getPluginManager().registerEvents(new MasterEmployer(this, playerData), this);
         getServer().getPluginManager().registerEvents(new LoyaltyII(this, playerData), this);
-        getServer().getPluginManager().registerEvents(new DoubleEnderchest(this, playerData), this);
+        doubleEnderchest = new DoubleEnderchest(this, playerData);
+        getServer().getPluginManager().registerEvents(doubleEnderchest, this);
         getServer().getPluginManager().registerEvents(new StrongDigestion(this, playerData), this);
         getServer().getPluginManager().registerEvents(new Icarus(this, playerData), this);
         getServer().getPluginManager().registerEvents(new AutoStrad(this, playerData), this);
@@ -572,6 +574,9 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         PetManager.getInstance(this).savePets();
         anvilRepair.saveAllInventories();
         cancelBrewing.saveAllInventories();
+        if (doubleEnderchest != null) {
+            doubleEnderchest.saveAllInventories();
+        }
         System.out.println("[MinecraftNew] Plugin disabled.");//
     }
     public static MinecraftNew getInstance() {

--- a/src/main/java/goat/minecraft/minecraftnew/other/meritperks/DoubleEnderchest.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/meritperks/DoubleEnderchest.java
@@ -1,8 +1,24 @@
 package goat.minecraft.minecraftnew.other.meritperks;
 
 import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 /**
  * Double Enderchest merit perk.
@@ -14,11 +30,89 @@ public class DoubleEnderchest implements Listener {
 
     private final JavaPlugin plugin;
     private final PlayerMeritManager playerData;
+    private final Map<UUID, Inventory> enderInventories = new HashMap<>();
+    private final File inventoriesFile;
+    private final FileConfiguration inventoriesConfig;
 
     public DoubleEnderchest(JavaPlugin plugin, PlayerMeritManager playerData) {
         this.plugin = plugin;
         this.playerData = playerData;
+        inventoriesFile = new File(plugin.getDataFolder(), "double_enderchests.yml");
+        if (!inventoriesFile.exists()) {
+            try {
+                inventoriesFile.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        inventoriesConfig = YamlConfiguration.loadConfiguration(inventoriesFile);
     }
 
-    // TODO: Replace ender chest open behaviour with custom storage GUI.
+    @EventHandler
+    public void onEnderChestInteract(PlayerInteractEvent event) {
+        if (event.getClickedBlock() == null || event.getClickedBlock().getType() != Material.ENDER_CHEST) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        UUID uuid = player.getUniqueId();
+
+        if (!playerData.hasPerk(uuid, "Double Enderchest")) {
+            return;
+        }
+
+        event.setCancelled(true);
+
+        Inventory inv = enderInventories.get(uuid);
+        if (inv == null) {
+            inv = loadInventory(uuid);
+            enderInventories.put(uuid, inv);
+        }
+
+        player.openInventory(inv);
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (!event.getView().getTitle().equals("Ender Chest")) return;
+
+        Player player = (Player) event.getPlayer();
+        UUID uuid = player.getUniqueId();
+        Inventory inv = event.getInventory();
+        enderInventories.put(uuid, inv);
+        saveInventory(uuid, inv);
+    }
+
+    private Inventory createInventory() {
+        return Bukkit.createInventory(null, 54, "Ender Chest");
+    }
+
+    public Inventory loadInventory(UUID uuid) {
+        Inventory inv = createInventory();
+        for (int i = 0; i < 54; i++) {
+            String path = "players." + uuid + ".slot" + i;
+            if (inventoriesConfig.contains(path)) {
+                inv.setItem(i, inventoriesConfig.getItemStack(path));
+            }
+        }
+        return inv;
+    }
+
+    public void saveInventory(UUID uuid, Inventory inv) {
+        for (int i = 0; i < 54; i++) {
+            ItemStack item = inv.getItem(i);
+            inventoriesConfig.set("players." + uuid + ".slot" + i, item);
+        }
+        try {
+            inventoriesConfig.save(inventoriesFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void saveAllInventories() {
+        for (Map.Entry<UUID, Inventory> entry : enderInventories.entrySet()) {
+            saveInventory(entry.getKey(), entry.getValue());
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- implement DoubleEnderchest listener with file-backed 54-slot inventory
- register listener instance and save persistent storage on shutdown

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin resolution due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68400b1a84508332bfad7fcfceaf2fd6