### PR TITLE
Add Strong Digestion perk functionality

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/meritperks/StrongDigestion.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/meritperks/StrongDigestion.java
@@ -1,7 +1,16 @@
 package goat.minecraft.minecraftnew.other.meritperks;
 
 import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 import org.bukkit.plugin.java.JavaPlugin;
 
 /**
@@ -19,5 +28,62 @@ public class StrongDigestion implements Listener {
         this.playerData = playerData;
     }
 
-    // TODO: Extend potion effect durations after consumption.
+    /**
+     * When a player drinks any potion, double the resulting potion effect
+     * durations if they own this perk.
+     */
+    @EventHandler
+    public void onPotionDrink(PlayerItemConsumeEvent event) {
+        ItemStack item = event.getItem();
+
+        // Only care about potion items
+        if (item == null ||
+                !(item.getType() == Material.POTION || item.getType() == Material.SPLASH_POTION || item.getType() == Material.LINGERING_POTION)) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+
+        // Verify the player owns the perk
+        if (!playerData.hasPerk(player.getUniqueId(), "Strong Digestion")) {
+            return;
+        }
+
+        // Capture the potion effect types applied by this item
+        PotionMeta meta = (item.getItemMeta() instanceof PotionMeta pm) ? pm : null;
+        if (meta == null) {
+            return;
+        }
+
+        // Build list of effects we expect to be applied
+        java.util.Set<PotionEffectType> types = new java.util.HashSet<>();
+        // Base potion effect
+        PotionEffectType baseType = meta.getBasePotionData().getType().getEffectType();
+        if (baseType != null) {
+            types.add(baseType);
+        }
+        // Custom effects present on the potion item
+        for (PotionEffect effect : meta.getCustomEffects()) {
+            types.add(effect.getType());
+        }
+
+        // After the potion has been consumed and effects applied (next tick),
+        // extend the duration of each matching effect
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            for (PotionEffectType type : types) {
+                PotionEffect current = player.getPotionEffect(type);
+                if (current != null) {
+                    int newDuration = current.getDuration() * 2;
+                    player.addPotionEffect(new PotionEffect(
+                            type,
+                            newDuration,
+                            current.getAmplifier(),
+                            current.isAmbient(),
+                            current.hasParticles(),
+                            current.hasIcon()
+                    ), true);
+                }
+            }
+        }, 1L);
+    }
 }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionManager.java
@@ -1,5 +1,6 @@
 package goat.minecraft.minecraftnew.subsystems.brewing;
 
+import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.ConfigurationSection;
@@ -36,6 +37,12 @@ public class PotionManager {
      * @param duration duration in seconds
      */
     public static void addCustomPotionEffect(String name, Player player, int duration) {
+        // Check for Strong Digestion perk and double duration if present
+        PlayerMeritManager meritManager = PlayerMeritManager.getInstance(plugin);
+        if (meritManager.hasPerk(player.getUniqueId(), "Strong Digestion")) {
+            duration *= 2;
+        }
+
         UUID uuid = player.getUniqueId();
         Map<String, Integer> playerEffects = activeEffects.getOrDefault(uuid, new HashMap<>());
         // If the effect is already active, add the new duration to the current duration


### PR DESCRIPTION
## Summary
- implement Strong Digestion perk logic
- double custom potion effect durations when perk owned
- extend vanilla potion effects after drinking

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68400b2b62a48332a94ae50725704af9