### PR TITLE
Implement AutoStrad perk functionality

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/meritperks/AutoStrad.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/meritperks/AutoStrad.java
@@ -1,14 +1,20 @@
 package goat.minecraft.minecraftnew.other.meritperks;
 
 import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
 
 /**
  * AutoStrad merit perk.
  * <p>
- * Automatically repairs all durable items in the player's inventory if they
- * have gone ten minutes without taking damage. Costs 20 merit points.
+ * Automatically repairs all durable items in the player's inventory by
+ * 100 durability every five minutes. Costs 20 merit points.
  */
 public class AutoStrad implements Listener {
 
@@ -18,7 +24,48 @@ public class AutoStrad implements Listener {
     public AutoStrad(JavaPlugin plugin, PlayerMeritManager playerData) {
         this.plugin = plugin;
         this.playerData = playerData;
+        startRepairTask();
     }
 
-    // TODO: Track damage timers and repair inventory items when conditions are met.
+    /**
+     * Starts a repeating task that repairs durable items for players
+     * who own the AutoStrad perk.
+     */
+    private void startRepairTask() {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                for (Player player : Bukkit.getOnlinePlayers()) {
+                    if (!playerData.hasPerk(player.getUniqueId(), "AutoStrad")) {
+                        continue;
+                    }
+                    repairInventory(player);
+                }
+            }
+        }.runTaskTimer(plugin, 0L, 20L * 60 * 5); // every 5 minutes
+    }
+
+    /**
+     * Repairs all damageable items in the player's inventory by up to
+     * 100 durability.
+     */
+    private void repairInventory(Player player) {
+        for (ItemStack item : player.getInventory().getContents()) {
+            if (item == null || item.getType().getMaxDurability() <= 0) {
+                continue;
+            }
+
+            ItemMeta meta = item.getItemMeta();
+            if (meta instanceof Damageable damageable) {
+                if (damageable.hasDamage()) {
+                    int newDamage = damageable.getDamage() - 100;
+                    if (newDamage < 0) {
+                        newDamage = 0;
+                    }
+                    damageable.setDamage(newDamage);
+                    item.setItemMeta((ItemMeta) damageable);
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add working implementation for the AutoStrad merit perk
- schedule a task every five minutes that repairs damageable inventory items

## Testing
- `mvn -q test` *(fails: `mvn` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400b61dc808332b9662163d309b7a1