### PR TITLE
Implement consumable resurrection perks

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/meritperks/Resurrection.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/meritperks/Resurrection.java
@@ -1,7 +1,10 @@
 package goat.minecraft.minecraftnew.other.meritperks;
 
 import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
 /**
@@ -20,5 +23,25 @@ public class Resurrection implements Listener {
         this.playerData = playerData;
     }
 
-    // TODO: Apply totem-like protection and consume the perk on use.
+    /**
+     * Checks incoming damage and prevents death if the player has any
+     * resurrection charges available.
+     */
+    @EventHandler
+    public void onPlayerDamage(EntityDamageEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+        if (!(event.getEntity() instanceof Player player)) {
+            return;
+        }
+
+        double newHealth = player.getHealth() - event.getFinalDamage();
+        if (newHealth <= 0) {
+            boolean resurrected = ResurrectionUtil.tryResurrect(player, playerData);
+            if (resurrected) {
+                event.setCancelled(true);
+            }
+        }
+    }
 }

--- a/src/main/java/goat/minecraft/minecraftnew/other/meritperks/ResurrectionCharge2.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/meritperks/ResurrectionCharge2.java
@@ -1,7 +1,10 @@
 package goat.minecraft.minecraftnew.other.meritperks;
 
 import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
 /**
@@ -20,5 +23,25 @@ public class ResurrectionCharge2 implements Listener {
         this.playerData = playerData;
     }
 
-    // TODO: Provide second use of the Resurrection effect.
+    /**
+     * Identical logic to the base Resurrection perk; this class exists to
+     * provide an additional charge that is consumed on use.
+     */
+    @EventHandler
+    public void onPlayerDamage(EntityDamageEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+        if (!(event.getEntity() instanceof Player player)) {
+            return;
+        }
+
+        double newHealth = player.getHealth() - event.getFinalDamage();
+        if (newHealth <= 0) {
+            boolean resurrected = ResurrectionUtil.tryResurrect(player, playerData);
+            if (resurrected) {
+                event.setCancelled(true);
+            }
+        }
+    }
 }

--- a/src/main/java/goat/minecraft/minecraftnew/other/meritperks/ResurrectionCharge3.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/meritperks/ResurrectionCharge3.java
@@ -1,7 +1,10 @@
 package goat.minecraft.minecraftnew.other.meritperks;
 
 import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
 /**
@@ -20,5 +23,24 @@ public class ResurrectionCharge3 implements Listener {
         this.playerData = playerData;
     }
 
-    // TODO: Provide third use of the Resurrection effect.
+    /**
+     * Provides a third resurrection charge that is consumed when used.
+     */
+    @EventHandler
+    public void onPlayerDamage(EntityDamageEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+        if (!(event.getEntity() instanceof Player player)) {
+            return;
+        }
+
+        double newHealth = player.getHealth() - event.getFinalDamage();
+        if (newHealth <= 0) {
+            boolean resurrected = ResurrectionUtil.tryResurrect(player, playerData);
+            if (resurrected) {
+                event.setCancelled(true);
+            }
+        }
+    }
 }

--- a/src/main/java/goat/minecraft/minecraftnew/other/meritperks/ResurrectionUtil.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/meritperks/ResurrectionUtil.java
@@ -1,0 +1,64 @@
+package goat.minecraft.minecraftnew.other.meritperks;
+
+import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import java.util.UUID;
+
+/**
+ * Helper class that provides the core resurrection logic shared by all
+ * resurrection perk listeners.
+ */
+public final class ResurrectionUtil {
+
+    private ResurrectionUtil() {
+        // Utility class
+    }
+
+    /**
+     * Attempts to consume one resurrection charge for the given player and
+     * applies the totem of undying effects. The highest available charge is
+     * consumed first.
+     *
+     * @param player     The player to resurrect.
+     * @param playerData The merit manager used to check and remove perks.
+     * @return {@code true} if a charge was consumed and the player was
+     *         resurrected, {@code false} otherwise.
+     */
+    public static boolean tryResurrect(Player player, PlayerMeritManager playerData) {
+        UUID uuid = player.getUniqueId();
+
+        String perkToConsume = null;
+        if (playerData.hasPerk(uuid, "Resurrection Charge 3")) {
+            perkToConsume = "Resurrection Charge 3";
+        } else if (playerData.hasPerk(uuid, "Resurrection Charge 2")) {
+            perkToConsume = "Resurrection Charge 2";
+        } else if (playerData.hasPerk(uuid, "Resurrection")) {
+            perkToConsume = "Resurrection";
+        }
+
+        if (perkToConsume == null) {
+            return false; // No available charges
+        }
+
+        // Consume the perk
+        playerData.removePerk(uuid, perkToConsume);
+
+        // Apply totem of undying effects
+        player.setFireTicks(0);
+        player.setHealth(Math.max(1.0, Math.min(player.getMaxHealth(), 1.0)));
+        player.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, 45 * 20, 1));
+        player.addPotionEffect(new PotionEffect(PotionEffectType.ABSORPTION, 5 * 20, 1));
+        player.addPotionEffect(new PotionEffect(PotionEffectType.FIRE_RESISTANCE, 40 * 20, 0));
+
+        player.getWorld().playSound(player.getLocation(), Sound.ITEM_TOTEM_USE, 1f, 1f);
+        player.getWorld().spawnParticle(Particle.TOTEM, player.getLocation().add(0, 1, 0), 30);
+
+        return true;
+    }
+}
+

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/MeritCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/MeritCommand.java
@@ -244,7 +244,7 @@ public class MeritCommand implements CommandExecutor, Listener {
             new Perk(ChatColor.DARK_GRAY + "Resurrection Charge 3", 1, Material.TOTEM_OF_UNDYING,
                     Arrays.asList(
                             ChatColor.GRAY + "Allows a third resurrection charge.",
-                            ChatColor.BLUE + "On Purchase: " + ChatColor.GRAY + "Adds another charge (max 3)."
+                            ChatColor.BLUE + "On Purchase: " + ChatColor.GRAY + "Adds another charge (max 3).",
                             ChatColor.GRAY + "Grants arrows when holding a bow with none left."
                     )),
             new Perk(ChatColor.DARK_GRAY + "Rebreather", 1, Material.TURTLE_HELMET,

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/PlayerMeritManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/PlayerMeritManager.java
@@ -105,4 +105,19 @@ public class PlayerMeritManager {
         dataConfig.set(uuid.toString() + ".perks", perks);
         saveConfig();
     }
+
+    /**
+     * Remove a perk from the player's list of purchased perks.
+     *
+     * @param uuid      The player's UUID.
+     * @param perkTitle The perk name to remove.
+     */
+    public void removePerk(UUID uuid, String perkTitle) {
+        List<String> perks = dataConfig.getStringList(uuid.toString() + ".perks");
+        if (perks.contains(perkTitle)) {
+            perks.remove(perkTitle);
+            dataConfig.set(uuid.toString() + ".perks", perks);
+            saveConfig();
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add removal helper in `PlayerMeritManager`
- implement resurrection effect shared by all perks
- activate perk logic for Resurrection, Resurrection Charge 2 and 3
- fix description typo in `MeritCommand`

## Testing
- `gradle test` *(fails: Directory does not contain a Gradle build)*


------
https://chatgpt.com/codex/tasks/task_e_68400b9a96f48332957fd851eb51b8aa