### PR TITLE
Add Forbidden Book purchase for librarians

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -488,6 +488,7 @@ public class VillagerTradeManager implements Listener {
         librarianPurchases.add(createTradeMap("LIBRARIAN_ENCHANT", 1, 32, 3)); // Custom Item
         librarianPurchases.add(createTradeMap("LIBRARIAN_ENCHANTMENT_TWO", 1, 16, 3)); // Custom Item
         librarianPurchases.add(createTradeMap("IRON_GOLEM", 1, 16, 4)); // Custom Item
+        librarianPurchases.add(createTradeMap("FORBIDDEN_BOOK", 1, 8, 2)); // Custom Item
 
 
         defaultConfig.set("LIBRARIAN.purchases", librarianPurchases);


### PR DESCRIPTION
## Summary
- expand default librarian purchases to include a Forbidden Book trade

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68410975c7bc8332902d16da01961523