### PR TITLE
Implement CustomTrimEffects perks

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -38,6 +38,7 @@ import goat.minecraft.minecraftnew.subsystems.fishing.SpawnSeaCreatureCommand;
 import goat.minecraft.minecraftnew.subsystems.forestry.ForestSpiritManager;
 import goat.minecraft.minecraftnew.subsystems.mining.PlayerOxygenManager;
 import goat.minecraft.minecraftnew.subsystems.music.MusicDiscManager;
+import goat.minecraft.minecraftnew.other.trims.CustomTrimEffects;
 import goat.minecraft.minecraftnew.subsystems.pets.*;
 import goat.minecraft.minecraftnew.subsystems.pets.perks.*;
 import goat.minecraft.minecraftnew.subsystems.pets.perks.Float;
@@ -451,6 +452,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new ReforgeDurability(), this);
         getServer().getPluginManager().registerEvents(new ReforgeSwiftBlade(), this);
         getServer().getPluginManager().registerEvents(new WaterLogged(this), this);
+        getServer().getPluginManager().registerEvents(new CustomTrimEffects(), this);
 
         getServer().getPluginManager().registerEvents(new Feed(), this);
         getServer().getPluginManager().registerEvents(new Merit(playerData), this);

--- a/src/main/java/goat/minecraft/minecraftnew/other/trims/CustomTrimEffects.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trims/CustomTrimEffects.java
@@ -1,0 +1,168 @@
+package goat.minecraft.minecraftnew.other.trims;
+
+import net.md_5.bungee.api.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Arrow;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityAirChangeEvent;
+import org.bukkit.event.entity.EntityCombustEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+import org.bukkit.event.player.PlayerItemDamageEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import java.util.List;
+import java.util.Random;
+
+public class CustomTrimEffects implements Listener {
+    private final Random random = new Random();
+
+    private static final String[] MATERIALS = {
+            "Diamond", "Iron", "Gold", "Emerald",
+            "Lapis", "Redstone", "Quartz",
+            "Amethyst", "Copper", "Netherite"
+    };
+
+    private static String getTrimMaterial(ItemStack item) {
+        if (item == null || item.getType() == Material.AIR) return null;
+        if (!item.hasItemMeta()) return null;
+        ItemMeta meta = item.getItemMeta();
+        List<String> lore = meta.getLore();
+        if (lore == null) return null;
+        for (String line : lore) {
+            String stripped = ChatColor.stripColor(line);
+            if (stripped == null) continue;
+            for (String mat : MATERIALS) {
+                if (stripped.toLowerCase().contains(mat.toLowerCase() + " material")) {
+                    return mat;
+                }
+            }
+        }
+        return null;
+    }
+
+    public static String getFullTrimMaterial(Player player) {
+        String found = null;
+        for (ItemStack piece : player.getInventory().getArmorContents()) {
+            String mat = getTrimMaterial(piece);
+            if (mat == null) return null;
+            if (found == null) {
+                found = mat;
+            } else if (!found.equalsIgnoreCase(mat)) {
+                return null;
+            }
+        }
+        return found;
+    }
+
+    /* Diamond: 15% damage reduction */
+    @EventHandler
+    public void onPlayerDamage(EntityDamageEvent event) {
+        if (!(event.getEntity() instanceof Player player)) return;
+        String material = getFullTrimMaterial(player);
+        if (material == null) return;
+        if (material.equalsIgnoreCase("Diamond")) {
+            event.setDamage(event.getDamage() * 0.85);
+        }
+        if (material.equalsIgnoreCase("Emerald") && event.getCause() == DamageCause.FALL) {
+            event.setCancelled(true);
+        }
+        if (material.equalsIgnoreCase("Gold")) {
+            if (random.nextDouble() < 0.10) {
+                player.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, 100, 1));
+                player.addPotionEffect(new PotionEffect(PotionEffectType.ABSORPTION, 2400, 0));
+            }
+        }
+        if (material.equalsIgnoreCase("Netherite")) {
+            if (event.getCause() == DamageCause.FIRE || event.getCause() == DamageCause.FIRE_TICK
+                    || event.getCause() == DamageCause.LAVA || event.getCause() == DamageCause.HOT_FLOOR) {
+                player.setFireTicks(0);
+            }
+        }
+    }
+
+    /* Redstone: 25% more damage */
+    @EventHandler
+    public void onPlayerDealDamage(EntityDamageByEntityEvent event) {
+        if (!(event.getDamager() instanceof Player player)) return;
+        String material = getFullTrimMaterial(player);
+        if (material != null && material.equalsIgnoreCase("Redstone")) {
+            event.setDamage(event.getDamage() * 1.25);
+        }
+    }
+
+    /* Quartz: arrows bounce off of you */
+    @EventHandler
+    public void onArrowHit(EntityDamageByEntityEvent event) {
+        if (!(event.getEntity() instanceof Player player)) return;
+        if (!(event.getDamager() instanceof Arrow arrow)) return;
+        String material = getFullTrimMaterial(player);
+        if (material != null && material.equalsIgnoreCase("Quartz")) {
+            event.setCancelled(true);
+            arrow.setVelocity(arrow.getVelocity().multiply(-1));
+        }
+    }
+
+    /* Iron: 50% chance to repair armor when taking durability */
+    @EventHandler
+    public void onItemDamage(PlayerItemDamageEvent event) {
+        Player player = event.getPlayer();
+        String material = getFullTrimMaterial(player);
+        if (material != null && material.equalsIgnoreCase("Iron")) {
+            if (random.nextDouble() < 0.5) {
+                ItemStack item = event.getItem();
+                ItemMeta meta = item.getItemMeta();
+                if (meta instanceof Damageable dmg) {
+                    int current = dmg.getDamage();
+                    if (current > 0) {
+                        dmg.setDamage(current - 1);
+                        item.setItemMeta(meta);
+                    }
+                }
+            }
+        }
+    }
+
+    /* Amethyst: no hunger loss */
+    @EventHandler
+    public void onFoodChange(org.bukkit.event.entity.FoodLevelChangeEvent event) {
+        if (!(event.getEntity() instanceof Player player)) return;
+        String material = getFullTrimMaterial(player);
+        if (material != null && material.equalsIgnoreCase("Amethyst")) {
+            if (event.getFoodLevel() < player.getFoodLevel()) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    /* Copper: restore air when losing it */
+    @EventHandler
+    public void onAirChange(EntityAirChangeEvent event) {
+        if (!(event.getEntity() instanceof Player player)) return;
+        String material = getFullTrimMaterial(player);
+        if (material != null && material.equalsIgnoreCase("Copper")) {
+            if (event.getAmount() < player.getRemainingAir()) {
+                int newAir = Math.min(player.getMaximumAir(), event.getAmount() + 1);
+                event.setAmount(newAir);
+            }
+        }
+    }
+
+    /* Netherite: prevent being set on fire */
+    @EventHandler
+    public void onCombust(EntityCombustEvent event) {
+        if (!(event.getEntity() instanceof Player player)) return;
+        String material = getFullTrimMaterial(player);
+        if (material != null && material.equalsIgnoreCase("Netherite")) {
+            event.setCancelled(true);
+            player.setFireTicks(0);
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/XPManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/XPManager.java
@@ -4,6 +4,7 @@ import java.io.*;
 import java.util.UUID;
 
 import goat.minecraft.minecraftnew.subsystems.enchanting.CustomEnchantmentManager;
+import goat.minecraft.minecraftnew.other.trims.CustomTrimEffects;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.*;
@@ -284,6 +285,11 @@ public class XPManager implements CommandExecutor {
     public void addXP(Player player, String skill, double xp) {
         UUID uuid = player.getUniqueId();
         int currentXP = loadXP(uuid, skill);
+
+        String trimMaterial = CustomTrimEffects.getFullTrimMaterial(player);
+        if (trimMaterial != null && trimMaterial.equalsIgnoreCase("Lapis")) {
+            xp *= 1.25;
+        }
 
         // Count how many 'Savant' enchantment items they have for a bonus.
         int savantCount = 0;


### PR DESCRIPTION
## Summary
- add `CustomTrimEffects` listener that checks armor trim materials via lore
- apply armor set bonuses for diamond, iron, gold, emerald, lapis, redstone, quartz, amethyst, copper and netherite
- register the new listener in plugin init
- boost skill XP when wearing a full lapis set via `XPManager`

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684117eb47488332867101849d83110d