### PR TITLE
Reduce pet particle effect duration

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/qol/ParticlePetEffects.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/qol/ParticlePetEffects.java
@@ -48,13 +48,27 @@ public class ParticlePetEffects implements Listener {
         // Play particle explosion around the damaged entity
         if (event.getEntity() instanceof LivingEntity) {
             LivingEntity target = (LivingEntity) event.getEntity();
-            target.getWorld().spawnParticle(
-                    particle,
-                    target.getLocation().add(0, 1, 0), // Slightly above the target
-                    level, // Number of particles is the pet's level
-                    0.5, 0.5, 0.5, // Spread around the target
-                    0.25 // Speed
-            );
+
+            new org.bukkit.scheduler.BukkitRunnable() {
+                int ticks = 0;
+
+                @Override
+                public void run() {
+                    if (ticks >= 5 || !target.isValid()) {
+                        cancel();
+                        return;
+                    }
+
+                    target.getWorld().spawnParticle(
+                            particle,
+                            target.getLocation().add(0, 1, 0),
+                            level,
+                            0.5, 0.5, 0.5,
+                            0.25
+                    );
+                    ticks++;
+                }
+            }.runTaskTimer(plugin, 0L, 1L);
         }
     }
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/FlameTrail.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/FlameTrail.java
@@ -92,7 +92,7 @@ public class FlameTrail implements Listener {
             int ticks = 0;
             @Override
             public void run() {
-                if (ticks >= 20) { // Run for 1 second
+                if (ticks >= 5) { // Run for only 5 ticks
                     cancel();
                     return;
                 }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/PhoenixRebirth.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/PhoenixRebirth.java
@@ -85,7 +85,7 @@ public class PhoenixRebirth implements Listener {
             int ticks = 0;
             @Override
             public void run() {
-                if (!player.isOnline() || ticks >= 60) { // 3 seconds of particles
+                if (!player.isOnline() || ticks >= 5) { // Last only 5 ticks
                     cancel();
                     return;
                 }


### PR DESCRIPTION
## Summary
- shorten PhoenixRebirth particle duration
- shorten FlameTrail particle duration
- limit ParticlePetEffects particles to only 5 ticks

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:pom:2.6 transfer failed)*

------
https://chatgpt.com/codex/tasks/task_e_68412fddae3c83329abefc2c67c6b626