### PR TITLE
Improve fire damage display

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatSubsystemManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatSubsystemManager.java
@@ -10,6 +10,7 @@ import goat.minecraft.minecraftnew.subsystems.combat.hostility.HostilityGUIContr
 import goat.minecraft.minecraftnew.subsystems.combat.hostility.HostilityService;
 import goat.minecraft.minecraftnew.subsystems.combat.notification.DamageNotificationService;
 import goat.minecraft.minecraftnew.subsystems.combat.notification.PlayerFeedbackService;
+import goat.minecraft.minecraftnew.subsystems.combat.FireDamageHandler;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
@@ -38,6 +39,8 @@ public class CombatSubsystemManager implements CommandExecutor {
     private DamageNotificationService notificationService;
     private PlayerFeedbackService feedbackService;
     private HostilityService hostilityService;
+
+    private FireDamageHandler fireDamageHandler;
     
     // Controllers and handlers
     private CombatEventHandler eventHandler;
@@ -251,6 +254,8 @@ public class CombatSubsystemManager implements CommandExecutor {
             hostilityService,
             configuration.getHostilityConfig()
         );
+
+        fireDamageHandler = new FireDamageHandler(plugin, notificationService);
         
         logger.fine("Combat controllers and handlers initialized");
     }
@@ -261,7 +266,8 @@ public class CombatSubsystemManager implements CommandExecutor {
     private void registerEventListeners() {
         Bukkit.getPluginManager().registerEvents(eventHandler, plugin);
         Bukkit.getPluginManager().registerEvents(hostilityGUIController, plugin);
-        
+        Bukkit.getPluginManager().registerEvents(fireDamageHandler, plugin);
+
         logger.fine("Combat event listeners registered");
     }
     

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/FireDamageHandler.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/FireDamageHandler.java
@@ -1,0 +1,156 @@
+package goat.minecraft.minecraftnew.subsystems.combat;
+
+import goat.minecraft.minecraftnew.subsystems.combat.notification.DamageNotificationService;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Boss;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Monster;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.Sound;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Custom fire damage handler for non-boss monsters.
+ * Cancels vanilla fire damage and applies a stacking "Fire" mechanic.
+ */
+public class FireDamageHandler implements Listener {
+
+    private final JavaPlugin plugin;
+    private final DamageNotificationService notificationService;
+    private final Map<UUID, Integer> fireLevels = new ConcurrentHashMap<>();
+    private final Map<UUID, BukkitRunnable> tasks = new ConcurrentHashMap<>();
+
+    public FireDamageHandler(JavaPlugin plugin, DamageNotificationService notificationService) {
+        this.plugin = plugin;
+        this.notificationService = notificationService;
+    }
+
+    @EventHandler
+    public void onFireDamage(EntityDamageEvent event) {
+        if (!(event.getEntity() instanceof LivingEntity entity)) return;
+        if (!(entity instanceof Monster) || isBoss(entity)) return;
+
+        EntityDamageEvent.DamageCause cause = event.getCause();
+        if (cause != EntityDamageEvent.DamageCause.FIRE &&
+            cause != EntityDamageEvent.DamageCause.FIRE_TICK &&
+            cause != EntityDamageEvent.DamageCause.LAVA &&
+            cause != EntityDamageEvent.DamageCause.HOT_FLOOR) {
+            return;
+        }
+
+        event.setCancelled(true);
+        entity.setFireTicks(0);
+
+        addFire(entity, 1);
+    }
+
+    @EventHandler
+    public void onFireAspectHit(EntityDamageByEntityEvent event) {
+        if (!(event.getDamager() instanceof Player player)) return;
+        if (!(event.getEntity() instanceof LivingEntity target)) return;
+        if (!(target instanceof Monster) || isBoss(target)) return;
+
+        int level = player.getInventory().getItemInMainHand().getEnchantmentLevel(Enchantment.FIRE_ASPECT);
+        if (level > 0) {
+            addFire(target, level * 5);
+        }
+    }
+
+    private void addFire(LivingEntity entity, int amount) {
+        UUID id = entity.getUniqueId();
+        int newLevel = fireLevels.getOrDefault(id, 0) + amount;
+        fireLevels.put(id, newLevel);
+
+        spawnFireParticles(entity.getLocation(), newLevel);
+        startTask(entity);
+    }
+
+    private void startTask(LivingEntity entity) {
+        UUID id = entity.getUniqueId();
+        if (tasks.containsKey(id)) return;
+
+        BukkitRunnable task = new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!entity.isValid() || entity.isDead()) {
+                    cleanup();
+                    return;
+                }
+
+                int level = fireLevels.getOrDefault(id, 0);
+                if (level <= 0) {
+                    cleanup();
+                    return;
+                }
+
+                if (level >= 100) {
+                    entity.setHealth(Math.max(0.1, entity.getHealth() / 2.0));
+                    spawnExplosion(entity.getLocation());
+                    fireLevels.put(id, 20);
+                    spreadFire(entity);
+                    level = 20;
+                }
+
+                double damage = level / 2.0;
+                entity.setHealth(Math.max(0.0, entity.getHealth() - damage));
+                if (entity.getWorld() != null) {
+                    entity.getWorld().playSound(entity.getLocation(), Sound.ENTITY_BLAZE_HURT, 1.0f, 1.0f);
+                }
+                notificationService.createFireDamageIndicator(entity.getLocation(), damage, level);
+                spawnFireParticles(entity.getLocation(), level);
+
+                fireLevels.put(id, level - 1);
+            }
+
+            private void cleanup() {
+                BukkitRunnable t = tasks.remove(id);
+                if (t != null) t.cancel();
+                fireLevels.remove(id);
+            }
+        };
+
+        tasks.put(id, task);
+        task.runTaskTimer(plugin, 0L, 20L);
+    }
+
+    private void spawnFireParticles(Location location, int count) {
+        if (location.getWorld() != null) {
+            location.getWorld().spawnParticle(Particle.FLAME, location, count, 0.6, 1.0, 0.6, 0.02);
+        }
+    }
+
+    private void spawnExplosion(Location location) {
+        if (location.getWorld() != null) {
+            location.getWorld().spawnParticle(Particle.EXPLOSION_LARGE, location, 1);
+            location.getWorld().spawnParticle(Particle.FLAME, location, 50, 1, 1, 1, 0.1);
+        }
+    }
+
+    private void spreadFire(LivingEntity source) {
+        if (source.getWorld() == null) return;
+        for (Entity e : source.getWorld().getNearbyEntities(source.getLocation(), 10, 10, 10)) {
+            if (e instanceof LivingEntity le && le instanceof Monster && !isBoss(le) && !le.equals(source)) {
+                addFire(le, 20);
+            }
+        }
+    }
+
+    private boolean isBoss(Entity entity) {
+        return entity instanceof Boss ||
+                entity.getType().name().contains("DRAGON") ||
+                entity.getType().name().contains("WITHER") ||
+                entity.getType().name().contains("ELDER_GUARDIAN");
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/notification/DamageNotificationService.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/notification/DamageNotificationService.java
@@ -75,6 +75,36 @@ public class DamageNotificationService {
     public void createCustomDamageIndicator(Location location, double damage) {
         showDamageIndicator(location, damage);
     }
+
+    /**
+     * Creates a special fire damage indicator with custom styling.
+     *
+     * @param location  The location to display the indicator
+     * @param damage    Damage dealt by the fire tick
+     * @param fireLevel Current fire stack amount
+     */
+    public void createFireDamageIndicator(Location location, double damage, int fireLevel) {
+        if (!config.isEnabled() || location == null || damage <= 0) {
+            return;
+        }
+
+        try {
+            String damageText = DAMAGE_FORMAT.format(damage);
+            String stackText = DAMAGE_FORMAT.format(fireLevel / 100.0);
+            String displayText = ChatColor.RED + "\uD83D\uDD25 " + damageText + " (" + stackText + ")";
+
+            Location spawnLocation = calculateSpawnLocation(location);
+            ArmorStand indicator = createDamageIndicator(spawnLocation, displayText);
+
+            if (indicator != null) {
+                startIndicatorAnimation(indicator);
+                logger.finest(String.format("Created fire damage indicator: %.1f at %s", damage, location));
+            }
+
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "Failed to create fire damage indicator", e);
+        }
+    }
     
     /**
      * Cleans up all active damage indicators.


### PR DESCRIPTION
## Summary
- add special fire damage indicators
- play blaze hurt sound on fire ticks
- widen flame particle spread

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843c9c302d083328f863e0ddf2f2257