### PR TITLE
Add Solar Fury potion and Sunflare relic

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -171,6 +171,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new PotionOfFountains(), this);
         getServer().getPluginManager().registerEvents(new PotionOfSwiftStep(), this);
         getServer().getPluginManager().registerEvents(new PotionOfRecurve(), this);
+        getServer().getPluginManager().registerEvents(new PotionOfSolarFury(), this);
 
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
@@ -249,6 +249,14 @@ public class PotionBrewingSubsystem implements Listener {
         recipeRegistry.add(
                 new PotionRecipe("Potion of Recurve", recurveIngredients, 5, new ItemStack(Material.POTION), recurveColor, recurveLore)
         );
+
+        // Potion of Solar Fury
+        List<String> solarFuryIngredients = Arrays.asList("Glass Bottle", "Sunflare", "Magma Cream", "Nether Wart");
+        List<String> solarFuryLore = Arrays.asList("Doubles fire level gains to monsters.", "Base Duration of " + baseDuration);
+        Color solarFuryColor = Color.fromRGB(255, 120, 0);
+        recipeRegistry.add(
+                new PotionRecipe("Potion of Solar Fury", solarFuryIngredients, 60*10, new ItemStack(Material.POTION), solarFuryColor, solarFuryLore)
+        );
     }
 
     private PotionRecipe findRecipeByName(String potionName) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfSolarFury.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfSolarFury.java
@@ -1,0 +1,34 @@
+package goat.minecraft.minecraftnew.subsystems.brewing.custompotions;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
+import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Potion of Solar Fury - doubles fire level gains on monsters.
+ */
+public class PotionOfSolarFury implements Listener {
+
+    @EventHandler
+    public void onPotionDrink(PlayerItemConsumeEvent event) {
+        ItemStack item = event.getItem();
+        if (item != null && item.hasItemMeta() && item.getItemMeta().hasDisplayName()) {
+            String displayName = ChatColor.stripColor(item.getItemMeta().getDisplayName());
+            XPManager xpManager = new XPManager(MinecraftNew.getInstance());
+            int brewingLevel = xpManager.getPlayerLevel(event.getPlayer(), "Brewing");
+            int duration = (60 * 3) + (brewingLevel * 10);
+            if (displayName.equals("Potion of Solar Fury")) {
+                Player player = event.getPlayer();
+                PotionManager.addCustomPotionEffect("Potion of Solar Fury", player, duration);
+                player.sendMessage(ChatColor.RED + "Potion of Solar Fury effect activated for " + duration + " seconds!");
+                xpManager.addXP(player, "Brewing", 100);
+            }
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/FireDamageHandler.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/FireDamageHandler.java
@@ -1,6 +1,8 @@
 package goat.minecraft.minecraftnew.subsystems.combat;
 
 import goat.minecraft.minecraftnew.subsystems.combat.notification.DamageNotificationService;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
+import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.enchantments.Enchantment;
@@ -64,7 +66,11 @@ public class FireDamageHandler implements Listener {
 
         int level = player.getInventory().getItemInMainHand().getEnchantmentLevel(Enchantment.FIRE_ASPECT);
         if (level > 0) {
-            addFire(target, level * 5);
+            int amount = level * 5;
+            if (PotionManager.isActive("Potion of Solar Fury", player)) {
+                amount *= 2;
+            }
+            addFire(target, amount);
         }
     }
 
@@ -104,7 +110,11 @@ public class FireDamageHandler implements Listener {
                 }
 
                 double damage = level / 2.0;
-                entity.setHealth(Math.max(0.0, entity.getHealth() - damage));
+                double newHealth = Math.max(0.0, entity.getHealth() - damage);
+                entity.setHealth(newHealth);
+                if(newHealth <= 0.0 && entity.getWorld() != null) {
+                    entity.getWorld().dropItemNaturally(entity.getLocation(), ItemRegistry.getVerdantRelicSunflareSeed());
+                }
                 if (entity.getWorld() != null) {
                     entity.getWorld().playSound(entity.getLocation(), Sound.ENTITY_BLAZE_HURT, 1.0f, 1.0f);
                 }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/VerdantRelicsSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/VerdantRelicsSubsystem.java
@@ -205,12 +205,19 @@ public class VerdantRelicsSubsystem implements Listener {
         String locKey = toLocKey(target.getLocation());
         XPManager xpManager = new XPManager(plugin);
         int farmingLevel = xpManager.getPlayerLevel(p, "Farming");
-        // One in-game day is 20 minutes (1,200 seconds)
-        double durationAtLevel1 = 10 * 1200.0;   // 30 days = 36,000 seconds
-        double durationAtLevel100 = 5 * 1200.0;   // 15 days = 18,000 seconds
-        double diff = durationAtLevel1 - durationAtLevel100;
-        double factor = (farmingLevel - 1) / 99.0; // Linear factor from level 1 to 100
-        int growthDuration = (int)(durationAtLevel1 - diff * factor);
+
+        int growthDuration;
+        if(relicName.equalsIgnoreCase("Sunflare")) {
+            // Sunflare grows quicker than other relics
+            growthDuration = 5 * 1200; // 5 in-game days
+        } else {
+            // One in-game day is 20 minutes (1,200 seconds)
+            double durationAtLevel1 = 10 * 1200.0;   // 30 days = 36,000 seconds
+            double durationAtLevel100 = 5 * 1200.0;   // 15 days = 18,000 seconds
+            double diff = durationAtLevel1 - durationAtLevel100;
+            double factor = (farmingLevel - 1) / 99.0; // Linear factor from level 1 to 100
+            growthDuration = (int)(durationAtLevel1 - diff * factor);
+        }
 
         // Apply Master Botanist perk: halve the growth time
         PlayerMeritManager meritManager = PlayerMeritManager.getInstance(plugin);
@@ -743,9 +750,12 @@ public class VerdantRelicsSubsystem implements Listener {
              else if (relicType.equalsIgnoreCase("Treasury")) {
                  return ItemRegistry.getTreasury(); // Ensure this method exists in ItemRegistry
              }
-             else if (relicType.equalsIgnoreCase("Marrow")) {
-                 return ItemRegistry.getMarrow(); // Ensure this method exists in ItemRegistry
-             }
+            else if (relicType.equalsIgnoreCase("Marrow")) {
+                return ItemRegistry.getMarrow(); // Ensure this method exists in ItemRegistry
+            }
+            else if (relicType.equalsIgnoreCase("Sunflare")) {
+                return ItemRegistry.getSunflare();
+            }
             // Default fallback yield
             return null;
         }

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -397,6 +397,45 @@ public class ItemRegistry {
         );
     }
 
+    // ------------------------------------------------------------------
+    // Sunflare Relic & Seed
+    // ------------------------------------------------------------------
+
+    /**
+     * Mature Sunflare relic used in brewing the Potion of Solar Fury.
+     */
+    public static ItemStack getSunflare() {
+        return createCustomItem(
+                Material.BLAZE_POWDER,
+                ChatColor.GOLD + "Sunflare",
+                Arrays.asList(
+                        ChatColor.GRAY + "A blazing relic radiating intense heat.",
+                        ChatColor.BLUE + "Used in brewing the Potion of Solar Fury."
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
+    /**
+     * Seed form dropped from fiery deaths, plant to grow Sunflare.
+     */
+    public static ItemStack getVerdantRelicSunflareSeed() {
+        return createCustomItem(
+                Material.WHEAT_SEEDS,
+                ChatColor.GOLD + "Verdant Relic Sunflare",
+                Arrays.asList(
+                        ChatColor.GRAY + "A relic seed ignited with solar energy.",
+                        ChatColor.BLUE + "Dropped from monsters slain by Fire Level.",
+                        ChatColor.BLUE + "Right-click on dirt/grass to plant."
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
 
     public static ItemStack getRecurvePotionRecipePaper() {
         // This returns a piece of PAPER with a custom name + lore that says "Potion of Recurve Recipe".


### PR DESCRIPTION
## Summary
- add new `Sunflare` relic item and seed
- implement Sunflare growth time and harvesting
- drop Sunflare seeds from fire damage deaths
- add `Potion of Solar Fury` recipe and custom potion
- register Solar Fury events
- boost fire level gain when potion is active

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6843d659895c83328dcc68eb152763f2