### PR TITLE
Add Potion of Night Vision

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -172,6 +172,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new PotionOfSwiftStep(), this);
         getServer().getPluginManager().registerEvents(new PotionOfRecurve(), this);
         getServer().getPluginManager().registerEvents(new PotionOfSolarFury(), this);
+        getServer().getPluginManager().registerEvents(new PotionOfNightVision(), this);
 
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
@@ -257,6 +257,14 @@ public class PotionBrewingSubsystem implements Listener {
         recipeRegistry.add(
                 new PotionRecipe("Potion of Solar Fury", solarFuryIngredients, 60*10, new ItemStack(Material.POTION), solarFuryColor, solarFuryLore)
         );
+
+        // Potion of Night Vision
+        List<String> nightVisionIngredients = Arrays.asList("Glass Bottle", "Nether Wart", "Starlight");
+        List<String> nightVisionLore = Arrays.asList("Grants Night Vision while moving", "Base Duration of " + 60*30);
+        Color nightVisionColor = Color.fromRGB(255, 255, 255);
+        recipeRegistry.add(
+                new PotionRecipe("Potion of Night Vision", nightVisionIngredients, 60*10, new ItemStack(Material.POTION), nightVisionColor, nightVisionLore)
+        );
     }
 
     private PotionRecipe findRecipeByName(String potionName) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfNightVision.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfNightVision.java
@@ -1,0 +1,45 @@
+package goat.minecraft.minecraftnew.subsystems.brewing.custompotions;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
+import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import org.bukkit.ChatColor;
+import org.bukkit.PotionEffect;
+import org.bukkit.PotionEffectType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Potion of Night Vision - grants Night Vision when moving.
+ */
+public class PotionOfNightVision implements Listener {
+
+    @EventHandler
+    public void onPotionDrink(PlayerItemConsumeEvent event) {
+        ItemStack item = event.getItem();
+        if (item != null && item.hasItemMeta() && item.getItemMeta().hasDisplayName()) {
+            String displayName = ChatColor.stripColor(item.getItemMeta().getDisplayName());
+            if (displayName.equals("Potion of Night Vision")) {
+                Player player = event.getPlayer();
+                XPManager xpManager = new XPManager(MinecraftNew.getInstance());
+                int brewingLevel = xpManager.getPlayerLevel(player, "Brewing");
+                int duration = (60 * 30) + (brewingLevel * 10);
+                PotionManager.addCustomPotionEffect("Potion of Night Vision", player, duration);
+                player.sendMessage(ChatColor.AQUA + "Potion of Night Vision activated for " + duration + " seconds!");
+                xpManager.addXP(player, "Brewing", 100);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onPlayerMove(PlayerMoveEvent event) {
+        Player player = event.getPlayer();
+        if (PotionManager.isActive("Potion of Night Vision", player)) {
+            player.addPotionEffect(new PotionEffect(PotionEffectType.NIGHT_VISION, 15 * 20, 0, false, false));
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SpawnMonsters.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SpawnMonsters.java
@@ -695,6 +695,18 @@ public class SpawnMonsters implements Listener {
         }
     }
 
+    @EventHandler
+    public void onInvisibleSpiderDeath(EntityDeathEvent event) {
+        if (!(event.getEntity() instanceof Spider spider)) return;
+        if (!spider.isInvisible()) return;
+
+        Player killer = spider.getKiller();
+        if (killer != null) {
+            spider.getWorld().dropItemNaturally(spider.getLocation(), ItemRegistry.getVerdantRelicStarlightSeed());
+            killer.sendMessage(ChatColor.AQUA + "You found a " + ChatColor.GOLD + "Verdant Relic: Starlight!");
+        }
+    }
+
 
     /**
      * When a Deep Sea Diver is hit, play a metal clang sound.

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/VerdantRelicsSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/VerdantRelicsSubsystem.java
@@ -756,6 +756,9 @@ public class VerdantRelicsSubsystem implements Listener {
             else if (relicType.equalsIgnoreCase("Sunflare")) {
                 return ItemRegistry.getSunflare();
             }
+            else if (relicType.equalsIgnoreCase("Starlight")) {
+                return ItemRegistry.getStarlight();
+            }
             // Default fallback yield
             return null;
         }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -327,6 +327,7 @@ public class VillagerTradeManager implements Listener {
         clericPurchases.add(createTradeMap("LIQUID_LUCK", 1, 32, 4)); // Material
         clericPurchases.add(createTradeMap("FOUNTAINS", 1, 32, 4)); // Material
         clericPurchases.add(createTradeMap("SOLAR_FURY", 1, 32, 4)); // Material
+        clericPurchases.add(createTradeMap("NIGHT_VISION", 1, 32, 4)); // Material
 
         clericPurchases.add(createTradeMap("CLERIC_ENCHANT", 1, 64, 3)); // Custom Item
         defaultConfig.set("CLERIC.purchases", clericPurchases);
@@ -674,6 +675,8 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getFountainsRecipePaper();
             case "SOLAR_FURY":
                 return ItemRegistry.getSolarFuryRecipePaper();
+            case "NIGHT_VISION":
+                return ItemRegistry.getNightVisionRecipePaper();
 
 
             case "LOYAL_DECLARATION":
@@ -822,6 +825,8 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getClericEnchant();
             case "SUNFLARE":
                 return ItemRegistry.getSunflare();
+            case "STARLIGHT":
+                return ItemRegistry.getStarlight();
             case "PESTICIDE":
                 return ItemRegistry.getPesticide();
             case "CARTOGRAPHER_MINESHAFT":

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -436,6 +436,45 @@ public class ItemRegistry {
         );
     }
 
+    // ------------------------------------------------------------------
+    // Starlight Relic & Seed
+    // ------------------------------------------------------------------
+
+    /**
+     * Mature Starlight relic used in brewing the Potion of Night Vision.
+     */
+    public static ItemStack getStarlight() {
+        return createCustomItem(
+                Material.NETHER_STAR,
+                ChatColor.GOLD + "Starlight",
+                Arrays.asList(
+                        ChatColor.GRAY + "A radiant relic shimmering with cosmic energy.",
+                        ChatColor.BLUE + "Used in brewing the Potion of Night Vision."
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
+    /**
+     * Seed form dropped from invisible spiders, plant to grow Starlight.
+     */
+    public static ItemStack getVerdantRelicStarlightSeed() {
+        return createCustomItem(
+                Material.WHEAT_SEEDS,
+                ChatColor.GOLD + "Verdant Relic Starlight",
+                Arrays.asList(
+                        ChatColor.GRAY + "A relic seed infused with celestial light.",
+                        ChatColor.BLUE + "Dropped by invisible spiders.",
+                        ChatColor.BLUE + "Right-click on dirt/grass to plant."
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
 
     public static ItemStack getRecurvePotionRecipePaper() {
         // This returns a piece of PAPER with a custom name + lore that says "Potion of Recurve Recipe".
@@ -533,6 +572,21 @@ public class ItemRegistry {
                 ChatColor.LIGHT_PURPLE + "Potion of Solar Fury Recipe (Potion Recipe)",
                 Arrays.asList(
                         ChatColor.GRAY + "Brewing instructions for Solar Fury",
+                        ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Right-click a Brewing Stand to begin",
+                        ChatColor.DARK_PURPLE + "Potion Recipe"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
+    public static ItemStack getNightVisionRecipePaper() {
+        return createCustomItem(
+                Material.PAPER,
+                ChatColor.LIGHT_PURPLE + "Potion of Night Vision Recipe (Potion Recipe)",
+                Arrays.asList(
+                        ChatColor.GRAY + "Brewing instructions for Night Vision",
                         ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Right-click a Brewing Stand to begin",
                         ChatColor.DARK_PURPLE + "Potion Recipe"
                 ),


### PR DESCRIPTION
## Summary
- add Potion of Night Vision custom listener
- add Starlight relic and seed items
- register Potion of Night Vision recipe
- let Cleric sell the recipe
- spawn Starlight seed from invisible spiders
- expose new relic in farming subsystem
- register listener in main plugin

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f73e5e0c83329a2dba5e65db8ab6