### PR TITLE
Add Water Aspect enchantment

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -469,6 +469,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new Bloodlust(this), this);
         getServer().getPluginManager().registerEvents(new Rappel(), this);
         getServer().getPluginManager().registerEvents(new Preservation(), this);
+        getServer().getPluginManager().registerEvents(new WaterAspect(), this);
 
         CustomEnchantmentManager.registerEnchantment("Feed", 3, true);
         CustomEnchantmentManager.registerEnchantment("Merit", 5, true);
@@ -488,6 +489,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         CustomEnchantmentManager.registerEnchantment("Experience", 5, true);
         CustomEnchantmentManager.registerEnchantment("Rappel", 1, true);
         CustomEnchantmentManager.registerEnchantment("Preservation", 1, true);
+        CustomEnchantmentManager.registerEnchantment("Water Aspect", 4, true);
 
 
         getServer().getPluginManager().registerEvents(new KnightMob(this), this);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/RareCombatDrops.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/RareCombatDrops.java
@@ -39,6 +39,7 @@ public class RareCombatDrops implements Listener {
     ItemStack witchDrop = ItemRegistry.getWitchDrop();
     ItemStack witherSkeletonDrop = ItemRegistry.getWitherSkeletonDrop();
     ItemStack guardianDrop = ItemRegistry.getGuardianDrop();
+    ItemStack waterAspectEnchant = ItemRegistry.getWaterAspectEnchant();
     ItemStack elderGuardianDrop = ItemRegistry.getElderGuardianDrop();
     ItemStack pillagerDrop = ItemRegistry.getPillagerDrop();
     ItemStack vindicatorDrop = ItemRegistry.getVindicatorDrop();
@@ -311,6 +312,9 @@ public class RareCombatDrops implements Listener {
         int hostilityLevel = hostilityManager.getPlayerDifficultyTier(player);
         if (rollChance(1,4, hostilityLevel)) { // 1-4% chance
             addRareDrop(player, event, guardianDrop);
+        }
+        if (random.nextInt(20) == 0) { // 5% base chance
+            addRareDrop(player, event, waterAspectEnchant);
         }
         if (rollChance(1,1, hostilityLevel)) { // 1-4% chance
             petRegistry.addPetByName(player, "Guardian");

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/enchantingeffects/WaterAspect.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/enchantingeffects/WaterAspect.java
@@ -1,0 +1,44 @@
+package goat.minecraft.minecraftnew.subsystems.enchanting.enchantingeffects;
+
+import goat.minecraft.minecraftnew.subsystems.enchanting.CustomEnchantmentManager;
+import org.bukkit.entity.*;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class WaterAspect implements Listener {
+
+    @EventHandler
+    public void onEntityDamage(EntityDamageByEntityEvent event) {
+        Entity damager = event.getDamager();
+        Entity target = event.getEntity();
+
+        Player player = null;
+        if (damager instanceof Player) {
+            player = (Player) damager;
+        } else if (damager instanceof Projectile && ((Projectile) damager).getShooter() instanceof Player) {
+            player = (Player) ((Projectile) damager).getShooter();
+        }
+        if (player == null) return;
+
+        ItemStack weapon = player.getInventory().getItemInMainHand();
+        if (!CustomEnchantmentManager.hasEnchantment(weapon, "Water Aspect")) return;
+
+        int level = CustomEnchantmentManager.getEnchantmentLevel(weapon, "Water Aspect");
+        if (level < 1) return;
+
+        double multiplier = 0.0;
+        EntityType type = target.getType();
+        if (type == EntityType.GUARDIAN || type == EntityType.ELDER_GUARDIAN
+                || type == EntityType.ENDERMAN || type == EntityType.ENDERMITE) {
+            multiplier = 0.10 * level;
+        } else if (target.hasMetadata("SEA_CREATURE")) {
+            multiplier = 0.05 * level;
+        }
+
+        if (multiplier > 0.0) {
+            event.setDamage(event.getDamage() * (1 + multiplier));
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
@@ -959,6 +959,10 @@ public class AnvilRepair implements Listener {
             CustomEnchantmentManager.addEnchantment(player, billItem, repairee, "Experience", CustomEnchantmentManager.getEnchantmentLevel(repairee, "Experience") +1);
             player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
             return;
+        }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Water Aspect") && isSword(repairee)){
+            CustomEnchantmentManager.addEnchantment(player, billItem, repairee, "Water Aspect", CustomEnchantmentManager.getEnchantmentLevel(repairee, "Water Aspect") +1);
+            player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
+            return;
         }
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -240,6 +240,7 @@ public class VillagerTradeManager implements Listener {
         weaponsmithSells.add(createTradeMap("BLAZE_DROP", 1, 8, 1)); // blazeDrop
         weaponsmithSells.add(createTradeMap("ENDER_DROP", 1, 24, 1)); // enderDrop
         weaponsmithSells.add(createTradeMap("GUARDIAN_DROP", 1, 8, 1)); // guardianDrop
+        weaponsmithSells.add(createTradeMap("WATER_ASPECT_ENCHANT", 1, 8, 1)); // water aspect enchant
         weaponsmithSells.add(createTradeMap("ELDER_GUARDIAN_DROP", 1, 4, 1)); // elderGuardianDrop
         weaponsmithSells.add(createTradeMap("PIGLIN_BRUTE_DROP", 1, 8, 1)); // piglinBruteDrop
         weaponsmithSells.add(createTradeMap("PIGLIN_DROP", 1, 8, 1)); // piglinDrop
@@ -941,6 +942,8 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getEnderDrop();
             case "GUARDIAN_DROP":
                 return ItemRegistry.getGuardianDrop();
+            case "WATER_ASPECT_ENCHANT":
+                return ItemRegistry.getWaterAspectEnchant();
             case "ELDER_GUARDIAN_DROP":
                 return ItemRegistry.getElderGuardianDrop();
             case "PIGLIN_DROP":

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -753,6 +753,15 @@ public class ItemRegistry {
         ), 1, false, true);
     }
 
+    public static ItemStack getWaterAspectEnchant() {
+        return createCustomItem(Material.PRISMARINE_CRYSTALS, ChatColor.YELLOW +
+                "Water Aspect", Arrays.asList(
+                ChatColor.GRAY + "Max level of IV",
+                ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Adds 1 Level of Water Aspect to items.",
+                ChatColor.DARK_PURPLE + "Smithing Item"
+        ), 1, false, true);
+    }
+
     public static ItemStack getIronGolem() {
         return createCustomItem(Material.IRON_BLOCK, ChatColor.YELLOW +
                 "Iron Golem", Arrays.asList(


### PR DESCRIPTION
## Summary
- implement `Water Aspect` enchantment with damage bonuses
- register new enchantment and smithing item
- drop Water Aspect from guardians
- allow selling Water Aspect to weaponsmith
- enable smithing of Water Aspect via anvil

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447ce56498833287ab2653bb7a0118