### PR TITLE
Add Potion of Riptide

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -173,6 +173,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new PotionOfRecurve(), this);
         getServer().getPluginManager().registerEvents(new PotionOfSolarFury(), this);
         getServer().getPluginManager().registerEvents(new PotionOfNightVision(), this);
+        getServer().getPluginManager().registerEvents(new PotionOfRiptide(), this);
 
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
@@ -259,6 +259,14 @@ public class PotionBrewingSubsystem implements Listener {
                 new PotionRecipe("Potion of Solar Fury", solarFuryIngredients, 60*10, new ItemStack(Material.POTION), solarFuryColor, solarFuryLore)
         );
 
+        // Potion of Riptide
+        List<String> riptideIngredients = Arrays.asList("Glass Bottle", "Nether Wart", "Heart of the Sea", "Kelp", "Tide");
+        List<String> riptideLore = Arrays.asList("Boosts riptide velocity", "Base Duration of " + 60*30);
+        Color riptideColor = Color.fromRGB(173, 216, 230);
+        recipeRegistry.add(
+                new PotionRecipe("Potion of Riptide", riptideIngredients, 60*10, new ItemStack(Material.POTION), riptideColor, riptideLore)
+        );
+
         // Potion of Night Vision
         List<String> nightVisionIngredients = Arrays.asList("Glass Bottle", "Nether Wart", "Starlight", "Fermented Spider Eye");
         List<String> nightVisionLore = Arrays.asList("Grants Night Vision while moving", "Base Duration of " + 60*30);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfRiptide.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfRiptide.java
@@ -1,0 +1,43 @@
+package goat.minecraft.minecraftnew.subsystems.brewing.custompotions;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
+import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.bukkit.event.player.PlayerRiptideEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
+
+public class PotionOfRiptide implements Listener {
+
+    @EventHandler
+    public void onPotionDrink(PlayerItemConsumeEvent event) {
+        ItemStack item = event.getItem();
+        if (item != null && item.hasItemMeta() && item.getItemMeta().hasDisplayName()) {
+            String displayName = ChatColor.stripColor(item.getItemMeta().getDisplayName());
+            if (displayName.equals("Potion of Riptide")) {
+                Player player = event.getPlayer();
+                XPManager xpManager = new XPManager(MinecraftNew.getInstance());
+                int brewingLevel = xpManager.getPlayerLevel(player, "Brewing");
+                int duration = (60 * 30) + (brewingLevel * 10);
+                PotionManager.addCustomPotionEffect("Potion of Riptide", player, duration);
+                player.sendMessage(ChatColor.AQUA + "Potion of Riptide activated for " + duration + " seconds!");
+                xpManager.addXP(player, "Brewing", 100);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onRiptide(PlayerRiptideEvent event) {
+        Player player = event.getPlayer();
+        if (PotionManager.isActive("Potion of Riptide", player)) {
+            Vector forward = player.getLocation().getDirection().normalize();
+            Vector boost = forward.multiply(0.5);
+            player.setVelocity(player.getVelocity().add(boost));
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/VerdantRelicsSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/VerdantRelicsSubsystem.java
@@ -759,6 +759,9 @@ public class VerdantRelicsSubsystem implements Listener {
             else if (relicType.equalsIgnoreCase("Starlight")) {
                 return ItemRegistry.getStarlight();
             }
+            else if (relicType.equalsIgnoreCase("Tide")) {
+                return ItemRegistry.getTide();
+            }
             // Default fallback yield
             return null;
         }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureRegistry.java
@@ -158,6 +158,7 @@ public class SeaCreatureRegistry implements Listener {
         poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getChanneling(), 1, 1, 6));
         poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getBait(), 1, 1, 1));
         poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getLoyaltyContract(), 1, 1, 5));
+        poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getVerdantRelicTideSeed(), 1, 1, 5));
         SEA_CREATURES.add(new SeaCreature(
                 "Poseidon",
                 Rarity.RARE,

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -326,6 +326,7 @@ public class VillagerTradeManager implements Listener {
         clericPurchases.add(createTradeMap("SOVEREIGNTY", 1, 16, 3)); // Material
         clericPurchases.add(createTradeMap("LIQUID_LUCK", 1, 32, 4)); // Material
         clericPurchases.add(createTradeMap("FOUNTAINS", 1, 32, 4)); // Material
+        clericPurchases.add(createTradeMap("RIPTIDE", 1, 32, 4)); // Material
         clericPurchases.add(createTradeMap("SOLAR_FURY", 1, 32, 4)); // Material
         clericPurchases.add(createTradeMap("NIGHT_VISION", 1, 32, 4)); // Material
 
@@ -673,6 +674,8 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getLiquidLuckRecipePaper();
             case "FOUNTAINS":
                 return ItemRegistry.getFountainsRecipePaper();
+            case "RIPTIDE":
+                return ItemRegistry.getRiptideRecipePaper();
             case "SOLAR_FURY":
                 return ItemRegistry.getSolarFuryRecipePaper();
             case "NIGHT_VISION":
@@ -827,6 +830,8 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getSunflare();
             case "STARLIGHT":
                 return ItemRegistry.getStarlight();
+            case "TIDE":
+                return ItemRegistry.getTide();
             case "PESTICIDE":
                 return ItemRegistry.getPesticide();
             case "CARTOGRAPHER_MINESHAFT":

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -475,6 +475,45 @@ public class ItemRegistry {
         );
     }
 
+    // ------------------------------------------------------------------
+    // Tide Relic & Seed
+    // ------------------------------------------------------------------
+
+    /**
+     * Mature Tide relic used in brewing the Potion of Riptide.
+     */
+    public static ItemStack getTide() {
+        return createCustomItem(
+                Material.HEART_OF_THE_SEA,
+                ChatColor.GOLD + "Tide",
+                Arrays.asList(
+                        ChatColor.GRAY + "A relic pulsing with oceanic power.",
+                        ChatColor.BLUE + "Used in brewing the Potion of Riptide."
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
+    /**
+     * Seed form dropped from Poseidon, plant to grow Tide.
+     */
+    public static ItemStack getVerdantRelicTideSeed() {
+        return createCustomItem(
+                Material.WHEAT_SEEDS,
+                ChatColor.GOLD + "Verdant Relic Tide",
+                Arrays.asList(
+                        ChatColor.GRAY + "A relic seed brimming with ocean energy.",
+                        ChatColor.BLUE + "Dropped by Poseidon.",
+                        ChatColor.BLUE + "Right-click on dirt/grass to plant."
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
 
     public static ItemStack getRecurvePotionRecipePaper() {
         // This returns a piece of PAPER with a custom name + lore that says "Potion of Recurve Recipe".
@@ -557,6 +596,21 @@ public class ItemRegistry {
                 ChatColor.LIGHT_PURPLE + "Potion of Fountains Recipe (Potion Recipe)",
                 Arrays.asList(
                         ChatColor.GRAY + "Brewing instructions for Sea Creature Chance",
+                        ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Right-click a Brewing Stand to begin",
+                        ChatColor.DARK_PURPLE + "Potion Recipe"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
+    public static ItemStack getRiptideRecipePaper() {
+        return createCustomItem(
+                Material.PAPER,
+                ChatColor.LIGHT_PURPLE + "Potion of Riptide Recipe (Potion Recipe)",
+                Arrays.asList(
+                        ChatColor.GRAY + "Brewing instructions for Riptide",
                         ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Right-click a Brewing Stand to begin",
                         ChatColor.DARK_PURPLE + "Potion Recipe"
                 ),


### PR DESCRIPTION
## Summary
- implement Potion of Riptide effect
- register potion effect listener
- add Riptide recipe and relic items
- allow cleric trades for Riptide recipe
- add relic seed drop from Poseidon
- support harvesting Tide relic from Verdant Relics subsystem

## Testing
- `mvn -q test` *(fails: PluginResolutionException due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68447b08d36883329a57b35bc68f9305