### PR TITLE
Fix hostility manager initialization during shutdown

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/HostilityManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/HostilityManager.java
@@ -53,6 +53,17 @@ public class HostilityManager implements Listener {
         return instance;
     }
 
+    /**
+     * Returns the current HostilityManager instance without creating a new one.
+     * Used during shutdown to avoid registering events when the plugin is
+     * already disabled.
+     *
+     * @return the existing HostilityManager instance, or null if not initialized
+     */
+    public static synchronized HostilityManager getExistingInstance() {
+        return instance;
+    }
+
     public int getPlayerDifficultyTier(Player player) {
         if(player == null){
             return 1;

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/music/MusicDiscManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/music/MusicDiscManager.java
@@ -460,8 +460,11 @@ public class MusicDiscManager implements Listener {
     }
 
     public void resetHostilityLevelsOnDisable() {
+        HostilityManager hostilityManager = HostilityManager.getExistingInstance();
+        if (hostilityManager == null) {
+            return; // HostilityManager was never initialized while enabled
+        }
         Bukkit.getOnlinePlayers().forEach(player -> {
-            HostilityManager hostilityManager = HostilityManager.getInstance(plugin);
             int currentTier = hostilityManager.getPlayerDifficultyTier(player);
             if (currentTier > 10) {
                 hostilityManager.setPlayerTier(player, 10);


### PR DESCRIPTION
## Summary
- add `getExistingInstance` accessor in `HostilityManager`
- avoid creating `HostilityManager` when the plugin is disabling

## Testing
- `mvn -q test` *(fails: PluginResolutionException, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68464be6eae08332a2536376cc1a56db