### PR TITLE
Fix iron whitelist bonus repair

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
@@ -682,7 +682,6 @@ public class AnvilRepair implements Listener {
         }
         // Determine the type of repair material and set the repair amount accordingly
         if (billItem.getType() == Material.IRON_INGOT) {
-            repairAmount = 25 + smithingLevel; // Just use this calculated repairAmount
             xpManager.addXP(player, "Smithing", repairAmount);
         } else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.LIGHT_PURPLE + "Shallow Shell")){
             repairAmount = 100;


### PR DESCRIPTION
## Summary
- ensure whitelisted iron items keep their repair bonus when using iron ingots

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464d4fa6a08332b4f7b813571f449b