### PR TITLE
Add Excavator and expanded Unbreaking perks

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -193,6 +193,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new Trainer(playerData), this);
         getServer().getPluginManager().registerEvents(new Restock(this, playerData), this);
         getServer().getPluginManager().registerEvents(new Unlooting(this, playerData), this);
+        getServer().getPluginManager().registerEvents(new Excavator(playerData), this);
         getServer().getPluginManager().registerEvents(new Rebreather(this, playerData), this);
         getServer().getPluginManager().registerEvents(new Keepinventory(this, playerData), this);
         getServer().getPluginManager().registerEvents(new MasterSmith(this, playerData), this);

--- a/src/main/java/goat/minecraft/minecraftnew/other/meritperks/Excavator.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/meritperks/Excavator.java
@@ -1,0 +1,45 @@
+package goat.minecraft.minecraftnew.other.meritperks;
+
+import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerItemDamageEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Random;
+
+/**
+ * Excavator merit perk.
+ *
+ * Grants shovels a 90% chance to not lose durability when used.
+ */
+public class Excavator implements Listener {
+
+    private final PlayerMeritManager playerData;
+    private final Random random = new Random();
+
+    public Excavator(PlayerMeritManager playerData) {
+        this.playerData = playerData;
+    }
+
+    @EventHandler
+    public void onItemDamage(PlayerItemDamageEvent event) {
+        Player player = event.getPlayer();
+        if (!playerData.hasPerk(player.getUniqueId(), "Excavator")) {
+            return;
+        }
+
+        ItemStack item = event.getItem();
+        if (item == null) {
+            return;
+        }
+        Material type = item.getType();
+        if (type.toString().endsWith("_SHOVEL")) {
+            if (random.nextDouble() < 0.9) {
+                event.setCancelled(true);
+            }
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/other/meritperks/ObsidianPlating.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/meritperks/ObsidianPlating.java
@@ -5,6 +5,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerItemDamageEvent;
+import java.util.UUID;
 
 import java.util.Random;
 
@@ -20,13 +21,21 @@ public class ObsidianPlating implements Listener {
     @EventHandler
     public void onItemDamage(PlayerItemDamageEvent event) {
         Player player = event.getPlayer();
-        // Check if the player has purchased the ObsidianPlating perk
-        if (playerData.hasPerk(player.getUniqueId(), "Unbreaking")) {
-            // 15% chance to cancel durability loss
-            if (random.nextDouble() < 0.15) {
-                event.setCancelled(true);
-                // Optionally, you can notify the player or trigger a visual effect here.
-            }
+        UUID id = player.getUniqueId();
+
+        double chance = 0.0;
+        if (playerData.hasPerk(id, "Unbreaking")) {
+            chance += 0.15;
+        }
+        if (playerData.hasPerk(id, "Unbreaking II")) {
+            chance += 0.15;
+        }
+        if (playerData.hasPerk(id, "Unbreaking III")) {
+            chance += 0.15;
+        }
+
+        if (chance > 0 && random.nextDouble() < chance) {
+            event.setCancelled(true);
         }
     }
 }

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/MeritCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/MeritCommand.java
@@ -91,6 +91,21 @@ public class MeritCommand implements CommandExecutor, Listener {
                             ChatColor.GRAY + "Prevents 15% of durability losses.",
                             ChatColor.BLUE + "On Lose Durability: " + ChatColor.GRAY + "15% chance to refund."
                     )),
+            new Perk(ChatColor.DARK_GRAY + "Unbreaking II", 1, Material.OBSIDIAN,
+                    Arrays.asList(
+                            ChatColor.GRAY + "Stacks with Unbreaking for another 15% chance.",
+                            ChatColor.BLUE + "On Lose Durability: " + ChatColor.GRAY + "Additional 15% refund chance."
+                    )),
+            new Perk(ChatColor.DARK_GRAY + "Unbreaking III", 1, Material.OBSIDIAN,
+                    Arrays.asList(
+                            ChatColor.GRAY + "Further increases durability refund by 15%.",
+                            ChatColor.BLUE + "On Lose Durability: " + ChatColor.GRAY + "Total 45% chance to refund."
+                    )),
+            new Perk(ChatColor.DARK_GRAY + "Excavator", 1, Material.DIAMOND_SHOVEL,
+                    Arrays.asList(
+                            ChatColor.GRAY + "Shovels rarely wear down.",
+                            ChatColor.BLUE + "On Shovel Use: " + ChatColor.GRAY + "90% chance durability is preserved."
+                    )),
             new Perk(ChatColor.DARK_GRAY + "Berserkers Rage", 1, Material.FERMENTED_SPIDER_EYE,
                     Arrays.asList(
                             ChatColor.GRAY + "Enrages you when struck by a competent foe.",


### PR DESCRIPTION
## Summary
- add Excavator merit perk for shovel durability
- expand ObsidianPlating logic to stack Unbreaking perks
- register Excavator listener and list new perks in GUI

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6846cfafe3d08332a44a2bb815cc1871