### PR TITLE
Cache last summoned pet

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -60,6 +60,7 @@ import goat.minecraft.minecraftnew.utils.dimensions.end.BetterEnd;
 import goat.minecraft.minecraftnew.subsystems.music.PigStepArena;
 import goat.minecraft.minecraftnew.subsystems.realms.Tropic;
 import org.bukkit.*;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -378,6 +379,13 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         });
         // Load pets
         petManager.loadPets();
+        // Re-summon pets for players already online (e.g., on reload)
+        for (Player online : Bukkit.getOnlinePlayers()) {
+            String lastPet = petManager.getLastActivePetName(online.getUniqueId());
+            if (lastPet != null) {
+                petManager.summonPet(online, lastPet);
+            }
+        }
 
 //        disableFlightForAllPlayers();
 //        Bukkit.getWorlds().forEach(world -> {
@@ -584,6 +592,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         }
 
         PetManager.getInstance(this).savePets();
+        PetManager.getInstance(this).saveLastActivePets();
         anvilRepair.saveAllInventories();
         cancelBrewing.saveAllInventories();
         if (doubleEnderchest != null) {


### PR DESCRIPTION
## Summary
- cache players' last summoned pet in `pets.yml`
- reload that pet when the player joins or the plugin is reloaded
- add saving of cached pets on shutdown

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a63d458fc8332b33b2d18e3989010