### PR TITLE
Add Haggler merit perk

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -208,6 +208,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new MasterDiplomat(this, playerData), this);
         getServer().getPluginManager().registerEvents(new MasterDiffuser(this, playerData), this);
         getServer().getPluginManager().registerEvents(new MasterTrader(this, playerData), this);
+        getServer().getPluginManager().registerEvents(new Haggler(this, playerData), this);
         getServer().getPluginManager().registerEvents(new MasterEmployer(this, playerData), this);
         getServer().getPluginManager().registerEvents(new LoyaltyII(this, playerData), this);
         doubleEnderchest = new DoubleEnderchest(this, playerData);

--- a/src/main/java/goat/minecraft/minecraftnew/other/meritperks/Haggler.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/meritperks/Haggler.java
@@ -1,0 +1,22 @@
+package goat.minecraft.minecraftnew.other.meritperks;
+
+import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Haggler merit perk.
+ *
+ * Grants a flat 10% discount on villager trades.
+ * The actual discount logic is applied in {@link goat.minecraft.minecraftnew.subsystems.villagers.VillagerTradeManager}.
+ */
+public class Haggler implements Listener {
+
+    private final JavaPlugin plugin;
+    private final PlayerMeritManager playerData;
+
+    public Haggler(JavaPlugin plugin, PlayerMeritManager playerData) {
+        this.plugin = plugin;
+        this.playerData = playerData;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -1013,13 +1013,19 @@ public class VillagerTradeManager implements Listener {
 
         double finalCost = basePrice;
 
-        // Apply Haggle perk
+        // Apply pet Haggle perk
         if (activePet != null && activePet.hasPerk(PetManager.PetPerk.HAGGLE)) {
             int petLevel = activePet.getLevel();
             double maxDiscount = 0.25; // 25% discount
             int maxLevel = 100;
             double discountFactor = maxDiscount * ((double) petLevel / maxLevel);
             finalCost *= (1 - discountFactor);
+        }
+
+        // Apply merit perk discount
+        PlayerMeritManager meritManager = PlayerMeritManager.getInstance(MinecraftNew.getInstance());
+        if (meritManager.hasPerk(player.getUniqueId(), "Haggler")) {
+            finalCost *= 0.9; // 10% discount
         }
 
         // Apply Bartering discount
@@ -1400,7 +1406,7 @@ public class VillagerTradeManager implements Listener {
         int emeraldCost = tradeItem.getEmeraldValue();
         int quantity = tradeItem.getQuantity();
 
-        // --- HAGGLE perk logic ---
+        // --- Pet HAGGLE perk logic ---
         PetManager petManager = PetManager.getInstance(MinecraftNew.getInstance());
         PetManager.Pet activePet = petManager.getActivePet(player);
 
@@ -1412,6 +1418,12 @@ public class VillagerTradeManager implements Listener {
             double discountFactor = maxDiscount * ((double) petLevel / maxLevel);
             finalCost *= (1 - discountFactor);
             finalCost = Math.floor(finalCost);
+        }
+
+        // --- Merit Haggler discount ---
+        PlayerMeritManager meritManager = PlayerMeritManager.getInstance(MinecraftNew.getInstance());
+        if (meritManager.hasPerk(player.getUniqueId(), "Haggler")) {
+            finalCost *= 0.9; // 10% discount
         }
 
         // --- Bartering discount logic ---
@@ -1428,7 +1440,6 @@ public class VillagerTradeManager implements Listener {
         int finalCostRounded = Math.max(1, (int) Math.floor(finalCost));
 
         // --- Master Trader perk: make purchases free ---
-        PlayerMeritManager meritManager = PlayerMeritManager.getInstance(MinecraftNew.getInstance());
         boolean freePurchase = false;
         if (meritManager.hasPerk(player.getUniqueId(), "Master Trader") && Math.random() < 0.05) {
             finalCostRounded = 0;

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/MeritCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/MeritCommand.java
@@ -216,6 +216,11 @@ public class MeritCommand implements CommandExecutor, Listener {
                             ChatColor.GRAY + "5% chance for purchases to be free.",
                             ChatColor.BLUE + "On Purchase: " + ChatColor.GRAY + "5% chance to cost nothing."
                     )),
+            new Perk(ChatColor.DARK_GRAY + "Haggler", 5, Material.EMERALD,
+                    Arrays.asList(
+                            ChatColor.GRAY + "Grants 10% discount on villager trades.",
+                            ChatColor.BLUE + "On Villager Trade: " + ChatColor.GRAY + "Prices reduced by 10%."
+                    )),
             new Perk(ChatColor.DARK_GRAY + "Master Employer", 3, Material.BELL,
                     Arrays.asList(
                             ChatColor.GRAY + "50% chance to halve villager work timers.",


### PR DESCRIPTION
## Summary
- implement **Haggler** merit perk to give players a 10% discount when trading with villagers
- register the perk and show it in the Merits GUI
- include a placeholder perk class

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin resolution via network)*

------
https://chatgpt.com/codex/tasks/task_e_684a81739b2c8332bb2c4e045eb0db9d