### PR TITLE
Fix level parsing for mobs

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/KillMonster.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/KillMonster.java
@@ -4,6 +4,7 @@ import goat.minecraft.minecraftnew.MinecraftNew;
 
 import goat.minecraft.minecraftnew.other.additionalfunctionality.Pathfinder;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import goat.minecraft.minecraftnew.subsystems.combat.utils.EntityLevelExtractor;
 import me.gamercoder215.mobchip.EntityBrain;
 import me.gamercoder215.mobchip.ai.EntityAI;
 import me.gamercoder215.mobchip.bukkit.BukkitBrain;
@@ -18,6 +19,7 @@ import java.util.Random;
 public class KillMonster implements Listener {
     private final MinecraftNew plugin = MinecraftNew.getInstance();
     public XPManager xpManager = new XPManager(plugin);
+    private final EntityLevelExtractor levelExtractor = new EntityLevelExtractor();
 
     // Blood Moon Mechanics
     private boolean isBloodMoon = false;
@@ -65,7 +67,7 @@ public class KillMonster implements Listener {
             }
     
             // Get the monster's level (ensure it's at least 1)
-            int monsterLevel = extractIntegerFromEntityName(entity);
+            int monsterLevel = levelExtractor.extractLevelFromName(entity);
             monsterLevel = Math.max(monsterLevel, 1);
     
             // Calculate base XP gain
@@ -98,18 +100,7 @@ public class KillMonster implements Listener {
 
 
     public int extractIntegerFromEntityName(Entity entity) {
-        String name = entity.getName();
-        String cleanedName = name.replaceAll("(?i)§[0-9a-f]", "");
-        String numberString = cleanedName.replaceAll("[^0-9]", "");
-        if (numberString.isEmpty()) {
-            return 0;
-        }
-        try {
-            return Integer.parseInt(numberString);
-        } catch (NumberFormatException e) {
-            e.printStackTrace();
-            return 0;
-        }
+        return levelExtractor.extractLevelFromName(entity);
     }
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/MobDamageHandler.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/MobDamageHandler.java
@@ -6,11 +6,13 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Monster;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
+import goat.minecraft.minecraftnew.subsystems.combat.utils.EntityLevelExtractor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 
 public class MobDamageHandler implements Listener {
+    private final EntityLevelExtractor levelExtractor = new EntityLevelExtractor();
 
     @EventHandler
     public void onEntityDamage(EntityDamageByEntityEvent event) {
@@ -38,7 +40,7 @@ public class MobDamageHandler implements Listener {
 
                 // Check if the attacker is a monster (e.g., Skeleton, Zombie, etc.)
                 if (attacker instanceof Monster) {
-                    int attackerLevel = extractIntegerFromEntityName(attacker); // Extract the attacker's level
+                    int attackerLevel = levelExtractor.extractLevelFromName(attacker); // Extract the attacker's level
                     double originalDamage = event.getDamage();
                     // Calculate the damage multiplier (4% per level)
                         double damageMultiplier = 1 + (attackerLevel * 0.06); // Multiplier should be 1 + (percentage increase)
@@ -51,25 +53,6 @@ public class MobDamageHandler implements Listener {
 
 
     public int extractIntegerFromEntityName(Entity entity) {
-        String name = entity.getName(); // Get the entity's name
-        System.out.println("Entity Name: " + name); // Debug output
-
-        // Remove color codes (e.g., "§a") and all non-numeric characters
-        String cleanedName = name.replaceAll("(?i)§[0-9a-f]", ""); // Remove color codes
-        String numberString = cleanedName.replaceAll("[^0-9]", ""); // Remove all non-numeric characters
-        System.out.println("Cleaned Name: " + cleanedName); // Debug output
-        System.out.println("Extracted Number String: " + numberString); // Debug output
-
-        // Check if the resulting string is empty, and return 0 or parse the integer
-        if (numberString.isEmpty()) {
-            return 0; // Return 0 if no numbers found
-        }
-
-        try {
-            return Integer.parseInt(numberString); // Parse the remaining string to an integer
-        } catch (NumberFormatException e) {
-            e.printStackTrace();
-            return 0; // Return 0 if parsing fails
-        }
+        return levelExtractor.extractLevelFromName(entity);
     }
 }


### PR DESCRIPTION
## Summary
- use `EntityLevelExtractor` when reading monster levels in `KillMonster` and `MobDamageHandler`
- remove old regex-based parsing

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bdbea858483328d5ee58451473422