### PR TITLE
Add Shred ultimate enchant

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/UltimateEnchantingSystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/UltimateEnchantingSystem.java
@@ -82,6 +82,8 @@ public class UltimateEnchantingSystem implements Listener {
         registerEnchantmentForType("Ultimate: Parry", 1, false, MELEE.toArray(new Material[0]));
         registerEnchantmentForType("Ultimate: Disc Seeker", 1, false, MELEE.toArray(new Material[0]));
         registerEnchantmentForType("Ultimate: Leap", 1, false, MELEE.toArray(new Material[0]));
+        // Simple ghost sword enchantment
+        registerEnchantmentForType("Ultimate: Shred", 1, false, MELEE.toArray(new Material[0]));
         // New Enchantment for thrown sword
         registerEnchantmentForType("Ultimate: Loyal", 1, false, MELEE.toArray(new Material[0]));
         // Leviathan enchantment - advanced thrown sword
@@ -431,6 +433,10 @@ public class UltimateEnchantingSystem implements Listener {
         }
         if(clickedItem.getItemMeta().getDisplayName().equals(ChatColor.GOLD + "Ultimate: Leap")){
             CustomEnchantmentManager.addUltimateEnchantment(player, null, handItem, "Ultimate: Leap", 1);
+            xpManager.addXP(player, "Smithing", 500);
+        }
+        if(clickedItem.getItemMeta().getDisplayName().equals(ChatColor.GOLD + "Ultimate: Shred")){
+            CustomEnchantmentManager.addUltimateEnchantment(player, null, handItem, "Ultimate: Shred", 1);
             xpManager.addXP(player, "Smithing", 500);
         }
         // New check for Loyal enchantment


### PR DESCRIPTION
## Summary
- add Shred ultimate enchant registration and GUI purchase handler
- handle Shred activation in ultimate listener
- implement ghost sword ability that pierces enemies

## Testing
- `mvn -q -DskipTests package` *(fails: plugin download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684d0c3cbdb08332bf8204c5ca168a92