### PR TITLE
Fix shred ability and XP level cap

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/UltimateEnchantmentListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/UltimateEnchantmentListener.java
@@ -566,7 +566,8 @@ public class UltimateEnchantmentListener implements Listener {
 
     private void activateShred(Player player, ItemStack sword){
         if(sword.getType().getMaxDurability() > 0){
-            short dmg = (short)(sword.getDurability() + 10);
+            // Shred only costs 5 durability on activation
+            short dmg = (short)(sword.getDurability() + 5);
             if(dmg > sword.getType().getMaxDurability()) dmg = sword.getType().getMaxDurability();
             sword.setDurability(dmg);
         }
@@ -581,16 +582,22 @@ public class UltimateEnchantmentListener implements Listener {
         Vector dir = player.getLocation().getDirection().normalize();
         new BukkitRunnable(){
             int tick=0;
+            double spin=0;
             @Override
             public void run(){
                 if(!stand.isValid()){ cancel(); return; }
                 stand.teleport(stand.getLocation().add(dir));
+                // Spin the sword end over end while flying
+                spin += Math.toRadians(20);
+                stand.setRightArmPose(new EulerAngle(spin, 0, 0));
                 for(Entity e : stand.getNearbyEntities(0.5,0.5,0.5)){
                     if(e instanceof LivingEntity && e!=player){
                         LivingEntity le=(LivingEntity)e;
                         XPManager xp = new XPManager(plugin);
                         int combat = xp.getPlayerLevel(player, "Combat");
                         le.damage(combat/2.0, player);
+                        // Play a sound when the shred strikes an enemy
+                        player.getWorld().playSound(le.getLocation(), Sound.ENTITY_PLAYER_ATTACK_SWEEP, 1.0f, 1.0f);
                         if(sword.getType().getMaxDurability()>0 && sword.getDurability()>0){
                             sword.setDurability((short)(sword.getDurability()-1));
                         }

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/XPManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/XPManager.java
@@ -398,6 +398,11 @@ public class XPManager implements CommandExecutor {
             }
             level++;
         }
+        // Safety check in case XP somehow exceeds our configured thresholds
+        // so levels never go beyond 100.
+        if (level > 100) {
+            level = 100;
+        }
         return level;
     }
 


### PR DESCRIPTION
## Summary
- update `calculateLevel` to hard cap levels at 100
- lower shred enchantment durability cost to 5 and add attack sound
- spin shred sword as it flies toward enemies

## Testing
- `mvn -q test` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684d181d27d0833298db39153c07e302