### PR TITLE
Disable pet hit particles

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -298,7 +298,6 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         // Initialize the culinary subsystem
         culinarySubsystem = CulinarySubsystem.getInstance(this);
         new CulinaryCauldron(this);
-        new ParticlePetEffects(this);
 
         getLogger().info("MyPlugin has been enabled!");
 


### PR DESCRIPTION
## Summary
- remove ParticlePetEffects registration so pet particle effects on entity damage no longer occur

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_684e21d4c60c8332b8d83067bfba67a6