### PR TITLE
Add paged merit perk system

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/MeritCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/MeritCommand.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
@@ -26,27 +27,6 @@ public class MeritCommand implements CommandExecutor, Listener {
 
     private final JavaPlugin plugin;
     private final PlayerMeritManager playerData;
-
-    private enum Category {
-        COMBAT("Combat", Material.IRON_SWORD),
-        SMITHING("Smithing", Material.ANVIL),
-        FARMING("Farming", Material.WHEAT),
-        BREWING("Brewing", Material.BREWING_STAND),
-        FISHING("Fishing", Material.FISHING_ROD),
-        VILLAGER("Villager", Material.EMERALD),
-        UTILITY("Utility", Material.REDSTONE);
-
-        private final String display;
-        private final Material icon;
-
-        Category(String display, Material icon) {
-            this.display = display;
-            this.icon = icon;
-        }
-
-        public String getDisplay() { return display; }
-        public Material getIcon() { return icon; }
-    }
 
     /**
      * Simple container for perk data: supports & color codes in name,
@@ -289,54 +269,6 @@ public class MeritCommand implements CommandExecutor, Listener {
                     ))
             );
 
-    private static final java.util.Map<Category, java.util.List<Perk>> categoryMap = new java.util.EnumMap<>(Category.class);
-    static {
-        for(Category c : Category.values()) {
-            categoryMap.put(c, new java.util.ArrayList<>());
-        }
-        int i = 0;
-        // manually assign perks to categories
-        categoryMap.get(Category.UTILITY).add(perks.get(i++)); // EnderMind
-        categoryMap.get(Category.UTILITY).add(perks.get(i++)); // Workbench
-        categoryMap.get(Category.UTILITY).add(perks.get(i++)); // Shulkl Box
-        categoryMap.get(Category.UTILITY).add(perks.get(i++)); // Motion Sensor
-        categoryMap.get(Category.SMITHING).add(perks.get(i++)); // Unbreaking
-        categoryMap.get(Category.SMITHING).add(perks.get(i++)); // Unbreaking II
-        categoryMap.get(Category.SMITHING).add(perks.get(i++)); // Unbreaking III
-        categoryMap.get(Category.SMITHING).add(perks.get(i++)); // Excavator
-        categoryMap.get(Category.COMBAT).add(perks.get(i++)); // Berserkers Rage
-        categoryMap.get(Category.COMBAT).add(perks.get(i++)); // Tactical Retreat
-        categoryMap.get(Category.COMBAT).add(perks.get(i++)); // Vampiric Strike
-        categoryMap.get(Category.COMBAT).add(perks.get(i++)); // Lord of Thunder
-        categoryMap.get(Category.FISHING).add(perks.get(i++)); // Deep Hook
-        categoryMap.get(Category.COMBAT).add(perks.get(i++)); // Instant Transmission
-        categoryMap.get(Category.UTILITY).add(perks.get(i++)); // Deep Breath
-        categoryMap.get(Category.UTILITY).add(perks.get(i++)); // Trainer
-        categoryMap.get(Category.UTILITY).add(perks.get(i++)); // QuickSwap
-        categoryMap.get(Category.COMBAT).add(perks.get(i++)); // Restock
-        categoryMap.get(Category.UTILITY).add(perks.get(i++)); // Rebreather
-        categoryMap.get(Category.UTILITY).add(perks.get(i++)); // Keepinventory
-        categoryMap.get(Category.SMITHING).add(perks.get(i++)); // Master Smith
-        categoryMap.get(Category.FARMING).add(perks.get(i++)); // Master Botanist
-        categoryMap.get(Category.BREWING).add(perks.get(i++)); // Master Brewer
-        categoryMap.get(Category.BREWING).add(perks.get(i++)); // Master Chef
-        categoryMap.get(Category.COMBAT).add(perks.get(i++)); // Master Thief
-        categoryMap.get(Category.COMBAT).add(perks.get(i++)); // Master Duelist
-        categoryMap.get(Category.FISHING).add(perks.get(i++)); // Master Angler
-        categoryMap.get(Category.VILLAGER).add(perks.get(i++)); // Master Diplomat
-        categoryMap.get(Category.COMBAT).add(perks.get(i++)); // Master Diffuser
-        categoryMap.get(Category.VILLAGER).add(perks.get(i++)); // Master Trader
-        categoryMap.get(Category.VILLAGER).add(perks.get(i++)); // Haggler
-        categoryMap.get(Category.VILLAGER).add(perks.get(i++)); // Master Employer
-        categoryMap.get(Category.VILLAGER).add(perks.get(i++)); // Loyalty II
-        categoryMap.get(Category.BREWING).add(perks.get(i++)); // Strong Digestion
-        categoryMap.get(Category.UTILITY).add(perks.get(i++)); // Icarus
-        categoryMap.get(Category.UTILITY).add(perks.get(i++)); // AutoStrad
-        categoryMap.get(Category.COMBAT).add(perks.get(i++)); // Resurrection
-        categoryMap.get(Category.COMBAT).add(perks.get(i++)); // Resurrection Charge 2
-        categoryMap.get(Category.COMBAT).add(perks.get(i++)); // Resurrection Charge 3
-        categoryMap.get(Category.VILLAGER).add(perks.get(i++)); // Tuxedo
-    }
 
 
     public MeritCommand(JavaPlugin plugin, PlayerMeritManager playerData) {
@@ -351,7 +283,7 @@ public class MeritCommand implements CommandExecutor, Listener {
             return true;
         }
         Player player = (Player) sender;
-        openMeritGUI(player, Category.COMBAT);
+        openMeritGUI(player, 1);
         return true;
     }
 
@@ -359,11 +291,16 @@ public class MeritCommand implements CommandExecutor, Listener {
      * Create and open the 54-slot "Merit" GUI for the player.
      */
     private void openMeritGUI(Player player) {
-        openMeritGUI(player, Category.COMBAT);
+        openMeritGUI(player, 1);
     }
 
-    private void openMeritGUI(Player player, Category category) {
-        Inventory inv = Bukkit.createInventory(null, 54, ChatColor.DARK_GREEN + "Merits: " + category.getDisplay());
+    private void openMeritGUI(Player player, int page) {
+        int totalPages = (int) Math.ceil(perks.size() / 40.0);
+        if (page < 1) page = 1;
+        if (page > totalPages) page = totalPages;
+
+        Inventory inv = Bukkit.createInventory(null, 54,
+                ChatColor.DARK_GREEN + "Merits: Page " + page + "/" + totalPages);
 
         // === prepare a black‐pane template ===
         ItemStack blackGlass = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
@@ -381,16 +318,13 @@ public class MeritCommand implements CommandExecutor, Listener {
             inv.setItem(9 + row * 9, blackGlass.clone());
         }
 
-        // === place category tabs only in the top row ===
-        int tab = 0;
-        for (Category c : Category.values()) {
-            if (tab >= 9) break;
-            ItemStack icon = new ItemStack(c.getIcon());
+        // === place page selectors in the top row ===
+        for (int p = 1; p <= totalPages && p <= 8; p++) {
+            ItemStack icon = new ItemStack(Material.PAPER);
             ItemMeta im = icon.getItemMeta();
-            im.setDisplayName(ChatColor.GOLD + c.getDisplay());
+            im.setDisplayName(ChatColor.GOLD + "Page " + p);
             icon.setItemMeta(im);
-            inv.setItem(tab, icon);
-            tab++;
+            inv.setItem(p - 1, icon);
         }
 
         // === diamond in slot 8 to show available points ===
@@ -402,8 +336,11 @@ public class MeritCommand implements CommandExecutor, Listener {
         inv.setItem(8, diamond);
 
         // === populate perks starting just below the top row ===
+        int startIndex = (page - 1) * 40;
+        int endIndex = Math.min(perks.size(), startIndex + 40);
         int slotIndex = 9;  // first slot of second row
-        for (Perk perk : categoryMap.get(category)) {
+        for (int i = startIndex; i < endIndex; i++) {
+            Perk perk = perks.get(i);
             // skip the left‐column pane
             if (slotIndex % 9 == 0) slotIndex++;
             if (slotIndex >= 54) break;
@@ -448,12 +385,12 @@ public class MeritCommand implements CommandExecutor, Listener {
             event.setCancelled(true);
 
             String title = ChatColor.stripColor(event.getView().getTitle());
-            Category current = Category.COMBAT;
-            for (Category c : Category.values()) {
-                if (title.endsWith(c.getDisplay())) {
-                    current = c;
-                    break;
-                }
+            int currentPage = 1;
+            if (title.contains("Page")) {
+                try {
+                    String pagePart = title.substring(title.indexOf("Page") + 5);
+                    currentPage = Integer.parseInt(pagePart.split("/")[0]);
+                } catch (Exception ignored) { }
             }
 
             ItemStack clickedItem = event.getCurrentItem();
@@ -472,11 +409,12 @@ public class MeritCommand implements CommandExecutor, Listener {
                 return;
 
             String name = ChatColor.stripColor(meta.getDisplayName());
-            for (Category c : Category.values()) {
-                if (name.equals(c.getDisplay())) {
-                    openMeritGUI(player, c);
-                    return;
-                }
+            if (name.startsWith("Page ")) {
+                try {
+                    int page = Integer.parseInt(name.replace("Page ", ""));
+                    openMeritGUI(player, page);
+                } catch (NumberFormatException ignored) { }
+                return;
             }
 
             // Extract cost from lore
@@ -495,6 +433,19 @@ public class MeritCommand implements CommandExecutor, Listener {
 
             // Get the perk title (using stripped name)
             String perkTitle = ChatColor.stripColor(meta.getDisplayName());
+
+            ClickType click = event.getClick();
+
+            if (click.isRightClick() && player.isOp()) {
+                if (playerData.hasPerk(player.getUniqueId(), perkTitle)) {
+                    playerData.removePerk(player.getUniqueId(), perkTitle);
+                    int pts = playerData.getMeritPoints(player.getUniqueId());
+                    playerData.setMeritPoints(player.getUniqueId(), pts + cost);
+                    player.sendMessage(ChatColor.GREEN + "Refunded perk: " + perkTitle);
+                }
+                openMeritGUI(player, currentPage);
+                return;
+            }
 
             // If already purchased, inform the player
             if (playerData.hasPerk(player.getUniqueId(), perkTitle)) {
@@ -517,7 +468,7 @@ public class MeritCommand implements CommandExecutor, Listener {
                     + " for " + cost + " merit points!");
 
             // Refresh the GUI to update the available points and add the enchant glow to the purchased perk
-            openMeritGUI(player, current);
+            openMeritGUI(player, currentPage);
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove unused merit category tabs
- implement paged merit perks instead of tabs
- allow ops to refund perks by right‑clicking

## Testing
- `mvn -q -DskipTests compile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e3dd883d483328807e6a3f26d912f