### PR TITLE
Implement forestry effigy upgrades

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -420,6 +420,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         // Effigy upgrade system for forestry axes
         goat.minecraft.minecraftnew.subsystems.forestry.EffigyUpgradeSystem effigyUpgradeSystem = new goat.minecraft.minecraftnew.subsystems.forestry.EffigyUpgradeSystem(this);
         getServer().getPluginManager().registerEvents(effigyUpgradeSystem, this);
+        goat.minecraft.minecraftnew.subsystems.forestry.Forestry.setUpgradeSystemInstance(effigyUpgradeSystem);
 
         // Register all gemstone upgrade listeners
         goat.minecraft.minecraftnew.subsystems.mining.gemstoneupgrades.YieldUpgradeListener yieldUpgradeListener = new goat.minecraft.minecraftnew.subsystems.mining.gemstoneupgrades.YieldUpgradeListener(this);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/EffigyUpgradeSystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/EffigyUpgradeSystem.java
@@ -277,7 +277,7 @@ public class EffigyUpgradeSystem implements Listener {
         }
     }
 
-    private int getUpgradeLevel(ItemStack axe, UpgradeType type) {
+    public int getUpgradeLevel(ItemStack axe, UpgradeType type) {
         if (!axe.hasItemMeta() || !axe.getItemMeta().hasLore()) return 0;
         for (String line : axe.getItemMeta().getLore()) {
             String stripped = ChatColor.stripColor(line);


### PR DESCRIPTION
## Summary
- expose Effigy upgrade level accessor
- hook forestry upgrade system into Forestry
- handle yield, feed, xp boost, fake news, payout and more during log breaks
- tweak forest spirit spawning and damage based on upgrades
- wire upgrade system into plugin startup

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e77a9b9508332ad89d08c26a02bab