### PR TITLE
Implement forestry upgrade effects

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/UltimateEnchantmentListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/UltimateEnchantmentListener.java
@@ -4,6 +4,7 @@ import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.forestry.ForestSpiritManager;
 import goat.minecraft.minecraftnew.subsystems.forestry.Forestry;
 import goat.minecraft.minecraftnew.subsystems.forestry.ForestryPetManager;
+import goat.minecraft.minecraftnew.subsystems.forestry.EffigyUpgradeSystem;
 import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import org.bukkit.*;
@@ -312,7 +313,9 @@ public class UltimateEnchantmentListener implements Listener {
             XPManager xpManager = new XPManager(plugin);
             ForestryPetManager forestryPetManager = MinecraftNew.getInstance().getForestryManager();
             forestryPetManager.incrementForestryCount(player);
-            forestry.processPerfectAppleChance(player, currentBlock, xpManager.getPlayerLevel(player, "Forestry"));
+            ItemStack axe = player.getInventory().getItemInMainHand();
+            int orchard = EffigyUpgradeSystem.getUpgradeLevel(axe, EffigyUpgradeSystem.UpgradeType.ORCHARD);
+            forestry.processPerfectAppleChance(player, currentBlock, xpManager.getPlayerLevel(player, "Forestry"), orchard);
             forestry.processDoubleDropChance(player, currentBlock, xpManager.getPlayerLevel(player, "Forestry"));
 
             if (visitedLogs.size() % 4 == 0) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/EffigyUpgradeSystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/EffigyUpgradeSystem.java
@@ -277,7 +277,7 @@ public class EffigyUpgradeSystem implements Listener {
         }
     }
 
-    private int getUpgradeLevel(ItemStack axe, UpgradeType type) {
+    public static int getUpgradeLevel(ItemStack axe, UpgradeType type) {
         if (!axe.hasItemMeta() || !axe.getItemMeta().hasLore()) return 0;
         for (String line : axe.getItemMeta().getLore()) {
             String stripped = ChatColor.stripColor(line);
@@ -288,7 +288,7 @@ public class EffigyUpgradeSystem implements Listener {
         return 0;
     }
 
-    private int parseLevel(String line, UpgradeType type) {
+    private static int parseLevel(String line, UpgradeType type) {
         String symbol = getSymbol(type);
         String stripped = ChatColor.stripColor(line);
         int idx = stripped.indexOf(symbol);
@@ -385,7 +385,7 @@ public class EffigyUpgradeSystem implements Listener {
         return 100;
     }
 
-    private String getSymbol(UpgradeType t) {
+    private static String getSymbol(UpgradeType t) {
         switch (t) {
             case OAK_YIELD: return "🌳";
             case SPRUCE_YIELD: return "🎄";


### PR DESCRIPTION
## Summary
- expose `EffigyUpgradeSystem.getUpgradeLevel` for other systems
- implement forestry upgrade behaviour including notoriety, yield, feed, payout, xp boost, orchard and golden apple perks
- modify spirit combat to support headhunter, spectral armor and ancient confusion
- hook orchard perk into treecapitator logic

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e77a9b9508332ad89d08c26a02bab