### PR TITLE
Add SetSkillLevel dev command

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -402,6 +402,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         this.getCommand("xp").setExecutor(xpManager);
         this.getCommand("loadsubsystems").setExecutor(new LoadSubsystemsCommand(this));
         this.getCommand("skills").setExecutor(new SkillsCommand(xpManager));
+        new SetSkillLevelCommand(this, xpManager);
 
         getCommand("getpet").setExecutor(new PetCommand(petManager));
         getServer().getPluginManager().registerEvents(new FishingEvent(), MinecraftNew.getInstance());

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/SetSkillLevelCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/SetSkillLevelCommand.java
@@ -1,0 +1,62 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class SetSkillLevelCommand implements CommandExecutor {
+
+    private final XPManager xpManager;
+
+    public SetSkillLevelCommand(JavaPlugin plugin, XPManager xpManager) {
+        this.xpManager = xpManager;
+        plugin.getCommand("setskilllevel").setExecutor(this);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("continuity.admin")) {
+            sender.sendMessage(ChatColor.RED + "You do not have permission to use this command.");
+            return true;
+        }
+
+        if (args.length != 3) {
+            sender.sendMessage(ChatColor.RED + "Usage: /setskilllevel <player> <skill> <level>");
+            return true;
+        }
+
+        Player target = Bukkit.getPlayer(args[0]);
+        if (target == null) {
+            sender.sendMessage(ChatColor.RED + "Player " + args[0] + " is not online.");
+            return true;
+        }
+
+        String skill = args[1];
+        int level;
+        try {
+            level = Integer.parseInt(args[2]);
+        } catch (NumberFormatException e) {
+            sender.sendMessage(ChatColor.RED + "Level must be a number.");
+            return true;
+        }
+
+        if (level < 0) {
+            sender.sendMessage(ChatColor.RED + "Level must be non-negative.");
+            return true;
+        }
+
+        int xp = xpManager.getLevelStartXP(level);
+        xpManager.setXP(target, skill, xp);
+
+        sender.sendMessage(ChatColor.GREEN + "Set " + target.getName() + "'s " + skill + " level to " + level + ".");
+        if (!sender.equals(target)) {
+            target.sendMessage(ChatColor.GREEN + "Your " + skill + " level has been set to " + level + ".");
+        }
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -130,3 +130,7 @@ commands:
     description: Repairs the held item to full durability
     usage: /repair
     permission: continuity.admin
+  setskilllevel:
+    description: Sets a player's skill level
+    usage: /setskilllevel <player> <skill> <level>
+    permission: continuity.admin


### PR DESCRIPTION
## Summary
- add a `/setskilllevel` developer command to force a player's skill level
- register the command in plugin.yml
- hook the command up in the plugin enable routine

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e81e85b8c833293adf033cb98c355