### PR TITLE
Align Effigy upgrade color levels

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/EffigyUpgradeSystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/EffigyUpgradeSystem.java
@@ -412,7 +412,8 @@ public class EffigyUpgradeSystem implements Listener {
 
     private String getColoredSymbol(UpgradeType t, int level) {
         ChatColor color = ChatColor.WHITE;
-        if (level >= 5) color = ChatColor.GOLD;
+        if (level >= 6) color = ChatColor.DARK_RED;
+        else if (level >= 5) color = ChatColor.GOLD;
         else if (level >= 4) color = ChatColor.LIGHT_PURPLE;
         else if (level >= 3) color = ChatColor.AQUA;
         else if (level >= 2) color = ChatColor.GREEN;


### PR DESCRIPTION
## Summary
- match the effigy upgrade color scheme to GemstoneUpgradeSystem

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684e856b34cc83328a15ebcf5dc3615d