### PR TITLE
Remove shredder capacity notification

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/UltimateEnchantmentListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/UltimateEnchantmentListener.java
@@ -948,14 +948,10 @@ public class UltimateEnchantmentListener implements Listener {
         UUID id = player.getUniqueId();
         int current = shredCharges.getOrDefault(id, MAX_SHRED_SWORDS);
         if (current >= MAX_SHRED_SWORDS) {
-            player.sendMessage(ChatColor.GREEN + "Your Shredders are at maximum capacity!");
             return;
         }
         int newTotal = Math.min(MAX_SHRED_SWORDS, current + amount);
         shredCharges.put(id, newTotal);
-        if (newTotal == MAX_SHRED_SWORDS) {
-            player.sendMessage(ChatColor.GREEN + "Your Shredders are at maximum capacity!");
-        }
     }
     private void loadCooldowns() {
         FileConfiguration config = plugin.getConfig();


### PR DESCRIPTION
## Summary
- remove "Your Shredders are at maximum capacity" chat message

## Testing
- `mvn -q package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin from https://repo.maven.apache.org/maven2)*

------
https://chatgpt.com/codex/tasks/task_e_684e8580ca60833287c411256b32c7d3