### PR TITLE
Fix angler upgrade access and add common bait item

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/UltimateEnchantingSystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/UltimateEnchantingSystem.java
@@ -5,6 +5,7 @@ import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import goat.minecraft.minecraftnew.subsystems.forestry.EffigyApplicationSystem;
 import goat.minecraft.minecraftnew.subsystems.forestry.EffigyUpgradeSystem;
+import goat.minecraft.minecraftnew.subsystems.fishing.BaitApplicationSystem;
 import org.bukkit.*;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
@@ -170,6 +171,12 @@ public class UltimateEnchantingSystem implements Listener {
             inv.setItem(52, createEffigyUpgradeButton(heldItem));
         }
 
+        // Add Angler Upgrade button for fishing rods with energy
+        if (heldItem.getType() == Material.FISHING_ROD &&
+                BaitApplicationSystem.getRodAnglerEnergyStatic(heldItem) > 0) {
+            inv.setItem(51, createAnglerUpgradeButton(heldItem));
+        }
+
         // ----------------------------
         // Add the Upgrade Segment (slots 47–51)
         // ----------------------------
@@ -272,6 +279,24 @@ public class UltimateEnchantingSystem implements Listener {
                 lore.add(ChatColor.GRAY + "Apply gemstones to this tool first.");
             }
             
+            meta.setLore(lore);
+            button.setItemMeta(meta);
+        }
+        return button;
+    }
+
+    /**
+     * Creates an angler upgrade button for fishing rods.
+     */
+    private ItemStack createAnglerUpgradeButton(ItemStack rod) {
+        ItemStack button = new ItemStack(Material.PRISMARINE_CRYSTALS);
+        ItemMeta meta = button.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.AQUA + "Angler Upgrades");
+            List<String> lore = new ArrayList<>();
+            int energy = BaitApplicationSystem.getRodAnglerEnergyStatic(rod);
+            lore.add(ChatColor.GRAY + "Angler Energy: " + ChatColor.WHITE + energy + "%");
+            lore.add(ChatColor.YELLOW + "Click to open upgrade tree!");
             meta.setLore(lore);
             button.setItemMeta(meta);
         }
@@ -441,6 +466,17 @@ public class UltimateEnchantingSystem implements Listener {
                 EffigyUpgradeSystem effigyUpgradeSystem =
                         new EffigyUpgradeSystem(MinecraftNew.getInstance());
                 effigyUpgradeSystem.openUpgradeGUI(player, handItem);
+                return;
+            }
+        }
+
+        // Handle Angler Upgrade Button Click (slot 51)
+        if (event.getSlot() == 51 && clickedItem.getType() == Material.PRISMARINE_CRYSTALS) {
+            if (handItem.getType() == Material.FISHING_ROD &&
+                    BaitApplicationSystem.getRodAnglerEnergyStatic(handItem) > 0) {
+                goat.minecraft.minecraftnew.subsystems.fishing.AnglerUpgradeSystem upgradeSystem =
+                        new goat.minecraft.minecraftnew.subsystems.fishing.AnglerUpgradeSystem(MinecraftNew.getInstance());
+                upgradeSystem.openUpgradeGUI(player, handItem);
                 return;
             }
         }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/BaitApplicationSystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/BaitApplicationSystem.java
@@ -20,6 +20,7 @@ public class BaitApplicationSystem implements Listener {
     private static final Map<String, Integer> BAIT_POWER_VALUES = new HashMap<>();
     static {
         BAIT_POWER_VALUES.put("Fish Bait", 1);
+        BAIT_POWER_VALUES.put("Common Bait", 1);
         BAIT_POWER_VALUES.put("Shrimp Bait", 3);
         BAIT_POWER_VALUES.put("Leech Bait", 7);
         BAIT_POWER_VALUES.put("Frog Bait", 10);

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -1567,6 +1567,24 @@ public class ItemRegistry {
         );
     }
 
+    /**
+     * Basic bait used as an ingredient for higher tiers.
+     */
+    public static ItemStack getCommonBait() {
+        return createCustomItem(
+                Material.WHEAT_SEEDS,
+                ChatColor.YELLOW + "Common Bait",
+                Arrays.asList(
+                        ChatColor.GRAY + "Simple feed that attracts small fish.",
+                        ChatColor.BLUE + "Energy: " + ChatColor.WHITE + "+1 Angler Energy",
+                        ChatColor.GREEN + "Bait"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
     public static ItemStack getShrimpBait() {
         return createCustomItem(
                 Material.SALMON,


### PR DESCRIPTION
## Summary
- add new `Common Bait` item in `ItemRegistry`
- recognize "Common Bait" in `BaitApplicationSystem`
- provide Angler Upgrade button in the Ultimate Enchanting GUI
- handle opening the Angler Upgrade GUI from the enchanting system

## Testing
- `mvn -q package -DskipTests` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e990c82788332bc42ece4603f3608