### PR TITLE
Fix Angler Energy bar refresh in upgrade GUI

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/AnglerUpgradeSystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/AnglerUpgradeSystem.java
@@ -244,7 +244,15 @@ public class AnglerUpgradeSystem implements Listener {
 
     UpgradeType clicked = null;
     for (UpgradeType u : UpgradeType.values()) if (u.getSlot() == e.getSlot()) clicked = u;
-    if (clicked == null) return;
+    if (clicked == null) {
+      // Refresh the energy display when clicking non-upgrade slots
+      e.getInventory()
+          .setItem(
+              49,
+              createPowerDisplay(
+                  getTotalEnergy(rod), getPowerCap(rod), calcAvailable(rod)));
+      return;
+    }
     int avail = calcAvailable(rod);
     int cost = getUpgradeCost(clicked);
     int lvl = getUpgradeLevel(rod, clicked);


### PR DESCRIPTION
## Summary
- refresh the angler energy display when clicking non-upgrade slots in the Fishing Upgrades GUI

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:2.6)*

------
https://chatgpt.com/codex/tasks/task_e_684eaea0abdc83328d9e3c149dc29ebd