### PR TITLE
Fix diamond hook drops

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/FishingEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/FishingEvent.java
@@ -83,8 +83,10 @@ public class FishingEvent implements Listener {
 
         ItemStack rod = player.getInventory().getItemInMainHand();
         int diamondLevel = FishingUpgradeSystem.getUpgradeLevel(rod, FishingUpgradeSystem.UpgradeType.DIAMOND_HOOK);
-        if (diamondLevel > 0 && caught instanceof LivingEntity) {
-            ((LivingEntity) caught).setHealth(0);
+        if (diamondLevel > 0 && caught instanceof LivingEntity living) {
+            // Kill the sea creature while crediting the player as the killer so
+            // that normal loot logic still runs in the death event handler.
+            living.damage(living.getHealth() * 2, player);
         } else {
             caught.remove();
         }


### PR DESCRIPTION
## Summary
- ensure diamond hook kills credit the player so sea creature drops appear

## Testing
- `mvn -q test` *(fails: Could not transfer artifact maven-resources-plugin due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684ebae8af4883329f7b7b794520f8be