### PR TITLE
Fix unintended entropy drops

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SpawnMonsters.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SpawnMonsters.java
@@ -646,6 +646,10 @@ public class SpawnMonsters implements Listener {
             return;
         }
         Monster monster = (Monster) event.getEntity();
+        // Skip sea creatures and forest spirits to prevent unintended drops
+        if(monster.hasMetadata("SEA_CREATURE") || monster.hasMetadata("forestSpirit")){
+            return;
+        }
         if (monster.hasPotionEffect(PotionEffectType.SPEED)) {
             Player killer = monster.getKiller();
             if (killer != null) {


### PR DESCRIPTION
## Summary
- ensure speed mutants skip sea creatures & forest spirits before dropping the Entropy relic

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_684ebc9589f483328aa006634a8db6d9