### PR TITLE
Fix angler energy cap scaling

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/BaitApplicationSystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/BaitApplicationSystem.java
@@ -152,8 +152,10 @@ public class BaitApplicationSystem implements Listener {
 
     private String createBar(int current, int cap) {
         int base = 20;
-        int extra = (cap - 100) / 100;
-        int len = base + extra * 5;
+        // Scale bar length gradually for caps above 100%
+        // Matches logic used in the Effigy and Gemstone GUIs
+        int extra = (cap - 100) / 20;
+        int len = base + extra;
         int filled = (int) ((double) current / cap * len);
         int empty = len - filled;
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/FishingUpgradeSystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/FishingUpgradeSystem.java
@@ -333,9 +333,9 @@ public class FishingUpgradeSystem implements Listener {
     }
 
     private String createBar(int total, int cap, int available) {
-        // Match the scaling used by the gemstone upgrade system
-        int extraSegments = (cap - 100) / 100; // +5 bars for each 100% above the base
-        int len = 20 + extraSegments * 5;
+        // Scale bar length similarly to the effigy and gemstone GUIs
+        int extraSegments = (cap - 100) / 20;
+        int len = 20 + extraSegments;
         int filled = (int)((double)total / cap * len);
         int spent = (int)((double)(total - available) / cap * len);
         StringBuilder b = new StringBuilder(ChatColor.DARK_GRAY + "[");

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/PearlOfTheDeepSystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/PearlOfTheDeepSystem.java
@@ -114,8 +114,9 @@ public class PearlOfTheDeepSystem implements Listener {
 
     private String createBar(int current, int cap) {
         int base = 20;
-        int extra = (cap - 100) / 100;
-        int len = base + extra * 5;
+        // Use the same scaling approach as other upgrade GUIs
+        int extra = (cap - 100) / 20;
+        int len = base + extra;
         int filled = (int) ((double) current / cap * len);
         int empty = len - filled;
         StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
## Summary
- extend progress bar calculation for angler energy
- match effigy/gemstone GUI logic when scaling over 100%

## Testing
- `javac @sources.txt` *(fails: package org.bukkit does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_684ebd1893588332afc9aaed9bd30a2b