### PR TITLE
Align upgrade icons under power caps

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/FishingUpgradeSystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/FishingUpgradeSystem.java
@@ -300,11 +300,25 @@ public class FishingUpgradeSystem implements Listener {
                 sb.append(getColoredSymbol(e.getKey(), e.getValue()));
                 first = false;
             }
-            if (lineIndex < 0) lineIndex = lore.size();
+            if (lineIndex < 0) lineIndex = findUpgradeInsertIndex(lore);
             lore.add(lineIndex, sb.toString());
         }
         meta.setLore(lore);
         rod.setItemMeta(meta);
+    }
+
+    /**
+     * Determines the insertion index for the upgrade line so that it appears
+     * directly under the Power Cap entry if present.
+     */
+    private int findUpgradeInsertIndex(List<String> lore) {
+        for (int i = 0; i < lore.size(); i++) {
+            String stripped = ChatColor.stripColor(lore.get(i));
+            if (stripped.startsWith("Power Cap:")) {
+                return i + 1;
+            }
+        }
+        return lore.size();
     }
 
     private void clearAllUpgrades(ItemStack rod) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/EffigyUpgradeSystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/EffigyUpgradeSystem.java
@@ -331,11 +331,25 @@ public class EffigyUpgradeSystem implements Listener {
                 sb.append(getColoredSymbol(e.getKey(), e.getValue()));
                 first = false;
             }
-            if (lineIndex < 0) lineIndex = lore.size();
+            if (lineIndex < 0) lineIndex = findUpgradeInsertIndex(lore);
             lore.add(lineIndex, sb.toString());
         }
         meta.setLore(lore);
         axe.setItemMeta(meta);
+    }
+
+    /**
+     * Finds the index immediately after the Spirit Cap line to insert upgrades.
+     * If no cap line exists, appends to the end.
+     */
+    private int findUpgradeInsertIndex(List<String> lore) {
+        for (int i = 0; i < lore.size(); i++) {
+            String stripped = ChatColor.stripColor(lore.get(i));
+            if (stripped.startsWith("Spirit Cap:")) {
+                return i + 1;
+            }
+        }
+        return lore.size();
     }
 
     private void clearAllUpgrades(ItemStack axe) {


### PR DESCRIPTION
## Summary
- ensure effigy upgrades insert after the "Spirit Cap" line
- ensure fishing upgrades insert after the "Power Cap" line

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed4d0b1388332baf25fd64cdc112a