### PR TITLE
Adjust bait drop system by rarity

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureDeathEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureDeathEvent.java
@@ -125,15 +125,31 @@ public class SeaCreatureDeathEvent implements Listener {
                         event.getDrops().add(drop);
                     }
                 }
-                // guaranteed bait drop
-                ItemStack bait = ItemRegistry.getBait();
-                int amount = 1;
+                // Drop bait based on creature rarity
+                ItemStack rarityBait = switch (seaCreature.getRarity()) {
+                    case COMMON -> ItemRegistry.getCommonBait();
+                    case UNCOMMON -> ItemRegistry.getShrimpBait();
+                    case RARE -> ItemRegistry.getLeechBait();
+                    case EPIC -> ItemRegistry.getFrogBait();
+                    case LEGENDARY -> ItemRegistry.getCaviarBait();
+                    default -> ItemRegistry.getBait();
+                };
+
                 PlayerMeritManager merit = PlayerMeritManager.getInstance(plugin);
+                int amount = 1;
                 if (merit.hasPerk(killer.getUniqueId(), "Double Bait") && random.nextDouble() < 0.5) {
                     amount = 2;
                 }
-                bait.setAmount(amount);
-                event.getDrops().add(bait);
+                rarityBait.setAmount(amount);
+                event.getDrops().add(rarityBait);
+
+                // Generic bait now drops at 50% chance
+                if (random.nextDouble() < 0.5) {
+                    ItemStack bait = ItemRegistry.getBait();
+                    bait.setAmount(amount);
+                    event.getDrops().add(bait);
+                }
+
                 killer.playSound(killer.getLocation(), Sound.BLOCK_CHEST_OPEN, 1.0f, 10.f);
             }
         }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureRegistry.java
@@ -156,7 +156,7 @@ public class SeaCreatureRegistry implements Listener {
         poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getTrident(), 1, 1, 4));
         poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getRiptide(), 1, 1, 3));
         poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getChanneling(), 1, 1, 6));
-        poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getBait(), 1, 1, 1));
+        poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getBait(), 1, 1, 2));
         poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getLoyaltyContract(), 1, 1, 5));
         poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getVerdantRelicTideSeed(), 1, 1, 5));
         SEA_CREATURES.add(new SeaCreature(
@@ -171,7 +171,7 @@ public class SeaCreatureRegistry implements Listener {
         List<SeaCreature.DropItem> sharkDrops = new ArrayList<>();
         sharkDrops.add(new SeaCreature.DropItem(ItemRegistry.getTooth(), 12, 1, 5));
         sharkDrops.add(new SeaCreature.DropItem(ItemRegistry.getSeaSalt(), 6, 1, 5));
-        sharkDrops.add(new SeaCreature.DropItem(ItemRegistry.getBait(), 3, 1, 3));
+        sharkDrops.add(new SeaCreature.DropItem(ItemRegistry.getBait(), 3, 1, 6));
         SEA_CREATURES.add(new SeaCreature(
                 "Shark",
                 Rarity.RARE,
@@ -186,7 +186,7 @@ public class SeaCreatureRegistry implements Listener {
         pirateDrops.add(new SeaCreature.DropItem(ItemRegistry.getSeaSalt(), 6, 1, 5));
         pirateDrops.add(new SeaCreature.DropItem(ItemRegistry.getImpaling(), 1, 1, 2));
         pirateDrops.add(new SeaCreature.DropItem(ItemRegistry.getLuck(), 1, 1, 2));
-        pirateDrops.add(new SeaCreature.DropItem(ItemRegistry.getBait(), 1, 1, 1));
+        pirateDrops.add(new SeaCreature.DropItem(ItemRegistry.getBait(), 1, 1, 2));
 
         SEA_CREATURES.add(new SeaCreature(
                 "Pirate",
@@ -231,7 +231,7 @@ public class SeaCreatureRegistry implements Listener {
         greatWhiteSharkDrops.add(new SeaCreature.DropItem(ItemRegistry.getFishBone(), 14, 1, 5));
         greatWhiteSharkDrops.add(new SeaCreature.DropItem(ItemRegistry.getTooth(), 14, 1, 4));
         greatWhiteSharkDrops.add(new SeaCreature.DropItem(ItemRegistry.getRespiration(), 2, 1, 2));
-        greatWhiteSharkDrops.add(new SeaCreature.DropItem(ItemRegistry.getBait(), 1, 1, 1));
+        greatWhiteSharkDrops.add(new SeaCreature.DropItem(ItemRegistry.getBait(), 1, 1, 2));
         SEA_CREATURES.add(new SeaCreature(
                 "Great White Shark",
                 Rarity.EPIC,


### PR DESCRIPTION
## Summary
- rarity-specific bait drops for sea creatures
- reduce generic `Fish Bait` drop rates by ~50%

## Testing
- `mvn -q package -DskipTests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eda5796f0833294b8fba726e3c1d5