### PR TITLE
Add extended effigy energy display

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/EffigyUpgradeSystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/EffigyUpgradeSystem.java
@@ -115,7 +115,7 @@ public class EffigyUpgradeSystem implements Listener {
             gui.setItem(t.getSlot(), createUpgradeItem(t, axe, getUpgradeCost(t), available));
         }
 
-        gui.setItem(49, createEnergyDisplay(totalEnergy, getEnergyCap(axe), available));
+        gui.setItem(49, createExtendedEnergyDisplay(totalEnergy, getEnergyCap(axe), available));
 
         // Add respec button similar to Gemstone upgrade GUI
         ItemStack respecItem = new ItemStack(Material.BARRIER);
@@ -372,6 +372,51 @@ public class EffigyUpgradeSystem implements Listener {
                 " / " + ChatColor.YELLOW + cap + "%");
         lore.add(ChatColor.GRAY + "Available: " + ChatColor.GREEN + available + "%");
         lore.add(bar);
+        meta.setLore(lore);
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    /**
+     * Creates an extended energy display supporting caps beyond 100%.
+     * Mirrors the implementation used in the gemstone and fishing upgrade systems.
+     */
+    private ItemStack createExtendedEnergyDisplay(int total, int cap, int available) {
+        ItemStack item = new ItemStack(Material.SOUL_TORCH);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName(ChatColor.AQUA + "Spirit Energy");
+
+        int baseBarLength = 20;
+        int extraSegments = (cap - 100) / 100; // each +100% adds 5 bars
+        int totalBarLength = baseBarLength + extraSegments * 5;
+
+        int filled = (int) ((double) total / cap * totalBarLength);
+        int spent = (int) ((double) (total - available) / cap * totalBarLength);
+
+        StringBuilder bar = new StringBuilder();
+        bar.append(ChatColor.DARK_GRAY + "[");
+        for (int i = 0; i < spent; i++) bar.append(ChatColor.RED + "|");
+        for (int i = spent; i < filled; i++) bar.append(ChatColor.GREEN + "|");
+        for (int i = filled; i < totalBarLength; i++) bar.append(ChatColor.GRAY + "|");
+        bar.append(ChatColor.DARK_GRAY + "]");
+
+        List<String> lore = new ArrayList<>();
+        lore.add(ChatColor.GRAY + "Total Energy: " + ChatColor.WHITE + total + "%" +
+                ChatColor.GRAY + " / " + ChatColor.YELLOW + cap + "%");
+        lore.add(ChatColor.GRAY + "Available: " + ChatColor.GREEN + available + "% " +
+                ChatColor.GRAY + "Spent: " + ChatColor.RED + (total - available) + "%");
+        lore.add("");
+        lore.add(bar.toString());
+        lore.add("");
+
+        if (cap > 100) {
+            lore.add(ChatColor.AQUA + "Enhanced Power Cap: " + ChatColor.YELLOW + cap + "%");
+            lore.add(ChatColor.GRAY + "Apply " + ChatColor.LIGHT_PURPLE + "Ent Bark" + ChatColor.GRAY + " to increase cap");
+        } else {
+            lore.add(ChatColor.GRAY + "Apply " + ChatColor.LIGHT_PURPLE + "Ent Bark" + ChatColor.GRAY + " to increase cap beyond 100%");
+        }
+        lore.add(ChatColor.GRAY + "Apply effigies to increase current energy");
+
         meta.setLore(lore);
         item.setItemMeta(meta);
         return item;


### PR DESCRIPTION
## Summary
- upgrade effigy GUI to use an extended energy display
- implement `createExtendedEnergyDisplay` for spirit energy

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_684edd973f2883329e7cc50b2887f013