### PR TITLE
Add Forbidden Book drop chances

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/KillMonster.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/KillMonster.java
@@ -5,6 +5,7 @@ import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.other.additionalfunctionality.Pathfinder;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import goat.minecraft.minecraftnew.subsystems.combat.utils.EntityLevelExtractor;
+import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
 import me.gamercoder215.mobchip.EntityBrain;
 import me.gamercoder215.mobchip.ai.EntityAI;
 import me.gamercoder215.mobchip.bukkit.BukkitBrain;
@@ -85,10 +86,16 @@ public class KillMonster implements Listener {
     
             // Add XP to the player
             xpManager.addXP(playerKiller, "Combat", xpGain);
-    
+
             // 20% chance for loot to drop normally, else clear drops
             Random random = new Random();
             if (entity instanceof Monster) {
+                Monster monsterEntity = (Monster) entity;
+                if (!monsterEntity.hasMetadata("SEA_CREATURE") && !monsterEntity.hasMetadata("forestSpirit")) {
+                    if (random.nextInt(100) < 4) {
+                        e.getDrops().add(ItemRegistry.getForbiddenBook());
+                    }
+                }
                 if (random.nextInt(100) < 20) {
                     return; // Allow normal drops
                 } else {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureDeathEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureDeathEvent.java
@@ -93,6 +93,11 @@ public class SeaCreatureDeathEvent implements Listener {
 
         fishingPetManager.incrementSeaCreatureKills(player);
 
+        // 16% chance to drop a Forbidden Book
+        if (random.nextInt(100) < 16) {
+            event.getDrops().add(ItemRegistry.getForbiddenBook());
+        }
+
         Bukkit.getLogger().info("Player " + killer.getName() + " gained " + boostedXP + " Fishing XP.");
 
         if(seaCreature.getSkullName().equals("Pirate")){

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/ForestSpiritManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/ForestSpiritManager.java
@@ -6,6 +6,7 @@ import goat.minecraft.minecraftnew.subsystems.combat.SpawnMonsters;
 import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
+import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
 import goat.minecraft.minecraftnew.subsystems.forestry.EffigyUpgradeSystem;
 import org.bukkit.*;
 import org.bukkit.block.Block;
@@ -403,6 +404,9 @@ public class ForestSpiritManager implements Listener {
         if (killer != null) {
             event.setDroppedExp(tier * 50);
             xpManager.addXP(killer, "Forestry", 10 * tier);
+            if (random.nextInt(100) < 16) {
+                event.getDrops().add(ItemRegistry.getForbiddenBook());
+            }
         }
 
         // Clear normal drops.


### PR DESCRIPTION
## Summary
- add Forbidden Book drop chance for monsters
- add Forbidden Book drop chance for sea creatures
- add Forbidden Book drop chance for forest spirits

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f71552fdc8332a0e966976c01daa7