### PR TITLE
Buff Water Aspect vs fire mobs

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/enchantingeffects/WaterAspect.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/enchantingeffects/WaterAspect.java
@@ -31,7 +31,8 @@ public class WaterAspect implements Listener {
         double multiplier = 0.0;
         EntityType type = target.getType();
         if (type == EntityType.GUARDIAN || type == EntityType.ELDER_GUARDIAN
-                || type == EntityType.ENDERMAN || type == EntityType.ENDERMITE) {
+                || type == EntityType.ENDERMAN || type == EntityType.ENDERMITE
+                || type == EntityType.MAGMA_CUBE || type == EntityType.BLAZE) {
             multiplier = 0.10 * level;
         } else if (target.hasMetadata("SEA_CREATURE")) {
             multiplier = 0.05 * level;


### PR DESCRIPTION
## Summary
- extend Water Aspect enchantment to hurt Blazes and Magma Cubes

## Testing
- `mvn -q -DskipTests=true package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_684f7a9a2bdc8332a480f3b66e67639d