### PR TITLE
Add Reaper, Librarian and Deal perks

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/KillMonster.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/KillMonster.java
@@ -93,7 +93,14 @@ public class KillMonster implements Listener {
                 Monster monsterEntity = (Monster) entity;
                 if (!monsterEntity.hasMetadata("SEA_CREATURE") && !monsterEntity.hasMetadata("forestSpirit")) {
                     if (random.nextInt(100) < 4) {
-                        e.getDrops().add(ItemRegistry.getForbiddenBook());
+                        int amount = 1;
+                        PlayerMeritManager merit = PlayerMeritManager.getInstance(plugin);
+                        if (merit.hasPerk(playerKiller.getUniqueId(), "Librarian")) {
+                            amount = 2;
+                        }
+                        for (int i = 0; i < amount; i++) {
+                            e.getDrops().add(ItemRegistry.getForbiddenBook());
+                        }
                     }
                 }
                 if (random.nextInt(100) < 20) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/RareCombatDrops.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/RareCombatDrops.java
@@ -5,6 +5,7 @@ import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
 import goat.minecraft.minecraftnew.subsystems.pets.PetRegistry;
 import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
 import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
+import org.bukkit.ChatColor;
 import org.bukkit.Particle;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
@@ -12,6 +13,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.List;
 import java.util.Random;
 
 public class RareCombatDrops implements Listener {
@@ -60,7 +62,22 @@ public class RareCombatDrops implements Listener {
         if (playerMeritManager.hasPerk(player.getUniqueId(), "Master Thief") && random.nextBoolean()) {
             drop.setAmount(2);
         }
+        if (isSoulItem(drop) && playerMeritManager.hasPerk(player.getUniqueId(), "Reaper")) {
+            drop.setAmount(drop.getAmount() * 2);
+        }
         event.getDrops().add(drop);
+    }
+
+    private boolean isSoulItem(ItemStack item) {
+        if (item == null || !item.hasItemMeta() || !item.getItemMeta().hasLore()) return false;
+        List<String> lore = item.getItemMeta().getLore();
+        if (lore == null) return false;
+        for (String line : lore) {
+            if (ChatColor.stripColor(line).equals("Soul Item")) {
+                return true;
+            }
+        }
+        return false;
     }
     @EventHandler
     public void onEntityDeath(EntityDeathEvent event) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureDeathEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureDeathEvent.java
@@ -95,7 +95,14 @@ public class SeaCreatureDeathEvent implements Listener {
 
         // 16% chance to drop a Forbidden Book
         if (random.nextInt(100) < 16) {
-            event.getDrops().add(ItemRegistry.getForbiddenBook());
+            int amount = 1;
+            PlayerMeritManager merit = PlayerMeritManager.getInstance(plugin);
+            if (merit.hasPerk(killer.getUniqueId(), "Librarian")) {
+                amount = 2;
+            }
+            for (int i = 0; i < amount; i++) {
+                event.getDrops().add(ItemRegistry.getForbiddenBook());
+            }
         }
 
         Bukkit.getLogger().info("Player " + killer.getName() + " gained " + boostedXP + " Fishing XP.");

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/ForestSpiritManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/ForestSpiritManager.java
@@ -405,7 +405,14 @@ public class ForestSpiritManager implements Listener {
             event.setDroppedExp(tier * 50);
             xpManager.addXP(killer, "Forestry", 10 * tier);
             if (random.nextInt(100) < 16) {
-                event.getDrops().add(ItemRegistry.getForbiddenBook());
+                int amount = 1;
+                PlayerMeritManager merit = PlayerMeritManager.getInstance(plugin);
+                if (merit.hasPerk(killer.getUniqueId(), "Librarian")) {
+                    amount = 2;
+                }
+                for (int i = 0; i < amount; i++) {
+                    event.getDrops().add(ItemRegistry.getForbiddenBook());
+                }
             }
         }
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -1536,6 +1536,10 @@ public class VillagerTradeManager implements Listener {
     private void processSell(Player player, Villager villager, TradeItem tradeItem) {
         XPManager xpManager = new XPManager(plugin);
         int emeraldReward = tradeItem.getEmeraldValue();
+        PlayerMeritManager merit = PlayerMeritManager.getInstance(plugin);
+        if (merit.hasPerk(player.getUniqueId(), "Deal")) {
+            emeraldReward += (int) Math.floor(emeraldReward * 0.25);
+        }
         int quantity = tradeItem.getQuantity();
         ItemStack tradeItemStack = tradeItem.getItem();
 

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/MeritCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/MeritCommand.java
@@ -237,6 +237,21 @@ public class MeritCommand implements CommandExecutor, Listener {
                             ChatColor.GRAY + "Grants 10% discount on villager trades.",
                             ChatColor.BLUE + "On Villager Trade: " + ChatColor.GRAY + "Prices reduced by 10%."
                     )),
+            new Perk(ChatColor.DARK_GRAY + "Deal", 2, Material.EMERALD_BLOCK,
+                    Arrays.asList(
+                            ChatColor.GRAY + "+25% emeralds when selling items.",
+                            ChatColor.BLUE + "On Sell: " + ChatColor.GRAY + "+25% emerald reward."
+                    )),
+            new Perk(ChatColor.DARK_GRAY + "Reaper", 3, Material.WITHER_SKELETON_SKULL,
+                    Arrays.asList(
+                            ChatColor.GRAY + "Doubles soul item drops from monsters.",
+                            ChatColor.BLUE + "On Monster Kill: " + ChatColor.GRAY + "Soul drops x2."
+                    )),
+            new Perk(ChatColor.DARK_GRAY + "Librarian", 3, Material.BOOKSHELF,
+                    Arrays.asList(
+                            ChatColor.GRAY + "Doubles Forbidden Book drops.",
+                            ChatColor.BLUE + "On Monster Kill: " + ChatColor.GRAY + "Forbidden Books x2."
+                    )),
             new Perk(ChatColor.DARK_GRAY + "Master Employer", 3, Material.BELL,
                     Arrays.asList(
                             ChatColor.GRAY + "50% chance to halve villager work timers.",


### PR DESCRIPTION
## Summary
- add new perks (Deal, Reaper, Librarian)
- double soul drops when Reaper is owned
- double Forbidden Book drops with Librarian
- grant 25% more emeralds on sells with Deal

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f7a26be4c8332b26ebe349d5ec0b1