### PR TITLE
Fix Soul upgrade GUI click handling

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -414,6 +414,8 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.forestry.EntBarkSystem(this), this);
         getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.combat.SoulApplicationSystem(this), this);
         getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.combat.BlueLanternSystem(this), this);
+        // Register Soul upgrade system for weapons with Soul Power
+        getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.combat.SoulUpgradeSystem(this), this);
 
         // Effigy upgrade system for forestry axes
         goat.minecraft.minecraftnew.subsystems.forestry.EffigyUpgradeSystem effigyUpgradeSystem = new goat.minecraft.minecraftnew.subsystems.forestry.EffigyUpgradeSystem(this);


### PR DESCRIPTION
## Summary
- register `SoulUpgradeSystem` as a listener during plugin enable

## Testing
- `mvn -q package -DskipTests` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f7e8999c48332a68fa7a9908e75da