### PR TITLE
Remove bow upgrades

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/BlueLanternSystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/BlueLanternSystem.java
@@ -44,7 +44,7 @@ public class BlueLanternSystem implements Listener {
     private boolean isSoulWeapon(ItemStack item) {
         if (item == null) return false;
         Material type = item.getType();
-        return type.name().endsWith("_SWORD") || type == Material.BOW;
+        return type.name().endsWith("_SWORD");
     }
 
     private void applyLantern(Player player, ItemStack lantern, ItemStack weapon) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SoulApplicationSystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SoulApplicationSystem.java
@@ -40,8 +40,8 @@ public class SoulApplicationSystem implements Listener {
 
         if (!isSoulItem(cursor)) return;
         if (!isSoulWeapon(clicked)) {
-            if (clicked.getType().name().contains("SWORD") || clicked.getType() == Material.BOW) {
-                player.sendMessage(ChatColor.RED + "Only swords or bows can harness Soul Power!");
+            if (clicked.getType().name().contains("SWORD")) {
+                player.sendMessage(ChatColor.RED + "Only swords can harness Soul Power!");
                 event.setCancelled(true);
             }
             return;
@@ -78,7 +78,7 @@ public class SoulApplicationSystem implements Listener {
     private boolean isSoulWeapon(ItemStack item) {
         if (item == null) return false;
         Material m = item.getType();
-        return m.name().endsWith("_SWORD") || m == Material.BOW;
+        return m.name().endsWith("_SWORD");
     }
 
     private boolean applySoulItem(ItemStack soul, ItemStack weapon, Player player) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/UltimateEnchantingSystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/UltimateEnchantingSystem.java
@@ -326,7 +326,7 @@ public class UltimateEnchantingSystem implements Listener {
      * Creates a soul upgrade button for weapons with Soul Power.
      */
     private ItemStack createSoulUpgradeButton(ItemStack weapon) {
-        ItemStack button = new ItemStack(weapon.getType() == Material.BOW ? Material.BOW : Material.DIAMOND_SWORD);
+        ItemStack button = new ItemStack(Material.DIAMOND_SWORD);
         ItemMeta meta = button.getItemMeta();
         if (meta != null) {
             meta.setDisplayName(ChatColor.DARK_AQUA + "Soul Upgrades");
@@ -370,10 +370,10 @@ public class UltimateEnchantingSystem implements Listener {
     }
 
     /**
-     * Returns true if the material is a sword or bow for soul power.
+     * Returns true if the material is a sword for soul power.
      */
     private boolean isSoulWeapon(Material material) {
-        return material.toString().endsWith("_SWORD") || material == Material.BOW;
+        return material.toString().endsWith("_SWORD");
     }
 
     /**
@@ -492,7 +492,7 @@ public class UltimateEnchantingSystem implements Listener {
                 }
                 return;
             }
-            if ((clickedItem.getType() == Material.BOW || clickedItem.getType() == Material.DIAMOND_SWORD) && isSoulWeapon(handItem.getType())) {
+            if (clickedItem.getType() == Material.DIAMOND_SWORD && isSoulWeapon(handItem.getType())) {
                 SoulUpgradeSystem upgradeSystem = new SoulUpgradeSystem(MinecraftNew.getInstance());
                 upgradeSystem.openUpgradeGUI(player, handItem);
                 return;

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -3672,7 +3672,7 @@ public class ItemRegistry {
                 Arrays.asList(
                         ChatColor.BLUE + "Power: " + ChatColor.WHITE + "+1 Soul Power",
                         "",
-                        ChatColor.YELLOW + "Click onto a sword or bow",
+                        ChatColor.YELLOW + "Click onto a sword",
                         ChatColor.YELLOW + "to infuse its Soul Power.",
                         ChatColor.GREEN + "Soul Item"
                 ),
@@ -3690,7 +3690,7 @@ public class ItemRegistry {
                 Arrays.asList(
                         ChatColor.BLUE + "Power: " + ChatColor.AQUA + "+3 Soul Power",
                         "",
-                        ChatColor.YELLOW + "Click onto a sword or bow",
+                        ChatColor.YELLOW + "Click onto a sword",
                         ChatColor.YELLOW + "to infuse its Soul Power.",
                         ChatColor.GREEN + "Soul Item"
                 ),
@@ -3708,7 +3708,7 @@ public class ItemRegistry {
                 Arrays.asList(
                         ChatColor.BLUE + "Power: " + ChatColor.YELLOW + "+7 Soul Power",
                         "",
-                        ChatColor.YELLOW + "Click onto a sword or bow",
+                        ChatColor.YELLOW + "Click onto a sword",
                         ChatColor.YELLOW + "to infuse its Soul Power.",
                         ChatColor.GREEN + "Soul Item"
                 ),
@@ -3726,7 +3726,7 @@ public class ItemRegistry {
                 Arrays.asList(
                         ChatColor.BLUE + "Power: " + ChatColor.LIGHT_PURPLE + "+10 Soul Power",
                         "",
-                        ChatColor.YELLOW + "Click onto a sword or bow",
+                        ChatColor.YELLOW + "Click onto a sword",
                         ChatColor.YELLOW + "to infuse its Soul Power.",
                         ChatColor.GREEN + "Soul Item"
                 ),
@@ -3744,7 +3744,7 @@ public class ItemRegistry {
                 Arrays.asList(
                         ChatColor.BLUE + "Power: " + ChatColor.GOLD + "+20 Soul Power",
                         "",
-                        ChatColor.YELLOW + "Click onto a sword or bow",
+                        ChatColor.YELLOW + "Click onto a sword",
                         ChatColor.YELLOW + "to infuse its Soul Power.",
                         ChatColor.GREEN + "Soul Item"
                 ),
@@ -3766,7 +3766,7 @@ public class ItemRegistry {
                         ChatColor.YELLOW + "Effect: " + ChatColor.WHITE + "+100% Soul Cap",
                         ChatColor.YELLOW + "Maximum: " + ChatColor.WHITE + "500% Total Cap",
                         "",
-                        ChatColor.DARK_PURPLE + "Drag onto swords or bows to apply"
+                        ChatColor.DARK_PURPLE + "Drag onto swords to apply"
                 ),
                 1,
                 false,


### PR DESCRIPTION
## Summary
- drop bow upgrade functionality from the soul system
- update soul application and blue lantern logic for swords only
- remove bow checks in enchanting subsystem
- tweak item lore to mention only swords

## Testing
- `mvn package -DskipTests` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f7e276f188332a60047877ca71ef6