### PR TITLE
Fix shred stacks not increasing on kill

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/UltimateEnchantmentListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/UltimateEnchantmentListener.java
@@ -686,6 +686,19 @@ public class UltimateEnchantmentListener implements Listener {
         }
     }
 
+    @EventHandler
+    public void onEntityDeath(EntityDeathEvent event) {
+        Player killer = event.getEntity().getKiller();
+        if (killer == null) return;
+
+        ItemStack weapon = killer.getInventory().getItemInMainHand();
+        CustomEnchantmentManager.UltimateEnchantmentData data =
+                CustomEnchantmentManager.getUltimateEnchantment(weapon);
+        if (data == null || !data.getName().equalsIgnoreCase("Shred")) return;
+
+        addShredCharges(killer, 3);
+    }
+
     private void spawnReboundArrow(Player shooter, Location from, double damage, int remaining) {
         double radius = 20.0;
         Monster nearest = null;


### PR DESCRIPTION
## Summary
- award shred ultimate charges when a player kills an entity

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f8b5b31188332b0a2afc818bd8142