### PR TITLE
Limit Fish Bait drops

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureDeathEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureDeathEvent.java
@@ -155,8 +155,9 @@ public class SeaCreatureDeathEvent implements Listener {
                 rarityBait.setAmount(amount);
                 event.getDrops().add(rarityBait);
 
-                // Generic bait now drops at 50% chance
-                if (random.nextDouble() < 0.5) {
+                // Only sharks provide Fish Bait
+                if (seaCreature.getDisplayName().equalsIgnoreCase("Shark") ||
+                        seaCreature.getDisplayName().equalsIgnoreCase("Great White Shark")) {
                     ItemStack bait = ItemRegistry.getBait();
                     bait.setAmount(amount);
                     event.getDrops().add(bait);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureRegistry.java
@@ -156,7 +156,6 @@ public class SeaCreatureRegistry implements Listener {
         poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getTrident(), 1, 1, 4));
         poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getRiptide(), 1, 1, 3));
         poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getChanneling(), 1, 1, 6));
-        poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getBait(), 1, 1, 2));
         poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getLoyaltyContract(), 1, 1, 5));
         poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getVerdantRelicTideSeed(), 1, 1, 5));
         SEA_CREATURES.add(new SeaCreature(
@@ -171,7 +170,8 @@ public class SeaCreatureRegistry implements Listener {
         List<SeaCreature.DropItem> sharkDrops = new ArrayList<>();
         sharkDrops.add(new SeaCreature.DropItem(ItemRegistry.getTooth(), 12, 1, 5));
         sharkDrops.add(new SeaCreature.DropItem(ItemRegistry.getSeaSalt(), 6, 1, 5));
-        sharkDrops.add(new SeaCreature.DropItem(ItemRegistry.getBait(), 3, 1, 6));
+        // Guaranteed Fish Bait drop
+        sharkDrops.add(new SeaCreature.DropItem(ItemRegistry.getBait(), 1, 1, 1));
         SEA_CREATURES.add(new SeaCreature(
                 "Shark",
                 Rarity.RARE,
@@ -186,7 +186,6 @@ public class SeaCreatureRegistry implements Listener {
         pirateDrops.add(new SeaCreature.DropItem(ItemRegistry.getSeaSalt(), 6, 1, 5));
         pirateDrops.add(new SeaCreature.DropItem(ItemRegistry.getImpaling(), 1, 1, 2));
         pirateDrops.add(new SeaCreature.DropItem(ItemRegistry.getLuck(), 1, 1, 2));
-        pirateDrops.add(new SeaCreature.DropItem(ItemRegistry.getBait(), 1, 1, 2));
 
         SEA_CREATURES.add(new SeaCreature(
                 "Pirate",
@@ -231,7 +230,8 @@ public class SeaCreatureRegistry implements Listener {
         greatWhiteSharkDrops.add(new SeaCreature.DropItem(ItemRegistry.getFishBone(), 14, 1, 5));
         greatWhiteSharkDrops.add(new SeaCreature.DropItem(ItemRegistry.getTooth(), 14, 1, 4));
         greatWhiteSharkDrops.add(new SeaCreature.DropItem(ItemRegistry.getRespiration(), 2, 1, 2));
-        greatWhiteSharkDrops.add(new SeaCreature.DropItem(ItemRegistry.getBait(), 1, 1, 2));
+        // Guaranteed Fish Bait drop
+        greatWhiteSharkDrops.add(new SeaCreature.DropItem(ItemRegistry.getBait(), 1, 1, 1));
         SEA_CREATURES.add(new SeaCreature(
                 "Great White Shark",
                 Rarity.EPIC,


### PR DESCRIPTION
## Summary
- only sharks and great white sharks drop the Fish Bait smithing item
- remove bait drops from other sea creatures

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_684fb4ece0e883328651d614f56d7506