### PR TITLE
Buff stun enchantment

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/enchantingeffects/Stun.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/enchantingeffects/Stun.java
@@ -1,8 +1,10 @@
 package goat.minecraft.minecraftnew.subsystems.enchanting.enchantingeffects;
 
+import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.enchanting.CustomEnchantmentManager;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Arrow;
+import org.bukkit.entity.Creature;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -12,12 +14,9 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-
-import java.util.Random;
+import org.bukkit.scheduler.BukkitRunnable;
 
 public class Stun implements Listener {
-
-    private final Random random = new Random();
 
     @EventHandler
     public void onEntityHitByArrow(EntityDamageByEntityEvent event) {
@@ -32,24 +31,33 @@ public class Stun implements Listener {
 
         // Check if the bow has the "Stun" enchantment
         if (CustomEnchantmentManager.hasEnchantment(bow, "Stun")) {
-            int stunLevel = CustomEnchantmentManager.getEnchantmentLevel(bow, "Stun");
+            Entity hitEntity = event.getEntity();
+            if (hitEntity instanceof LivingEntity) {
+                LivingEntity target = (LivingEntity) hitEntity;
 
-            // Calculate chance based on stun level
-            int chance = stunLevel;
-            if (random.nextInt(100) < chance) {
-                Entity hitEntity = event.getEntity();
-                if (hitEntity instanceof LivingEntity) {
-                    LivingEntity target = (LivingEntity) hitEntity;
+                // Always apply stun for 10 seconds
+                target.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 10 * 20, 255));
+                if (target instanceof Creature creature) {
+                    new BukkitRunnable() {
+                        int ticks = 10 * 20;
 
-                    // Apply Slowness V for 30 seconds
-                    target.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 30 * 20, 4)); // Slowness V is amplifier 4
-
-                    // Notify shooter about the successful stun
-                    shooter.sendMessage(ChatColor.AQUA + "Stun effect applied to " + target.getName() + "!");
-                    int enchantmentLevel = CustomEnchantmentManager.getEnchantmentLevel(bow, "Stun");
-                    shooter.getInventory().getItemInMainHand().setDurability((short) (shooter.getInventory().getItemInMainHand().getDurability() +(1*enchantmentLevel)));
-
+                        @Override
+                        public void run() {
+                            if (ticks-- <= 0 || creature.isDead() || !creature.isValid()) {
+                                creature.setAI(true);
+                                this.cancel();
+                                return;
+                            }
+                            creature.setTarget(null);
+                        }
+                    }.runTaskTimer(MinecraftNew.getInstance(), 0L, 1L);
+                    creature.setAI(false);
                 }
+
+                // Notify shooter about the successful stun
+                shooter.sendMessage(ChatColor.AQUA + "Stun effect applied to " + target.getName() + "!");
+                int enchantmentLevel = CustomEnchantmentManager.getEnchantmentLevel(bow, "Stun");
+                shooter.getInventory().getItemInMainHand().setDurability((short) (shooter.getInventory().getItemInMainHand().getDurability() +(1*enchantmentLevel)));
             }
         }
     }


### PR DESCRIPTION
## Summary
- buff stun enchant for bows: always stuns target for 10s
- repeatedly clears monster target and disables AI during stun

## Testing
- `mvn -q package -DskipTests` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:2.6 due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6852662f83e883329787fdba2b298aa5