### PR TITLE
Implement Fortune enchantment removal on block break

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -37,6 +37,7 @@ import goat.minecraft.minecraftnew.subsystems.fishing.SeaCreatureRegistry;
 import goat.minecraft.minecraftnew.subsystems.fishing.SpawnSeaCreatureCommand;
 import goat.minecraft.minecraftnew.subsystems.forestry.ForestSpiritManager;
 import goat.minecraft.minecraftnew.subsystems.mining.PlayerOxygenManager;
+import goat.minecraft.minecraftnew.subsystems.mining.FortuneRemover;
 import goat.minecraft.minecraftnew.subsystems.music.MusicDiscManager;
 import goat.minecraft.minecraftnew.other.trims.CustomTrimEffects;
 import goat.minecraft.minecraftnew.subsystems.pets.*;
@@ -491,6 +492,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new Rappel(), this);
         getServer().getPluginManager().registerEvents(new Preservation(), this);
         getServer().getPluginManager().registerEvents(new WaterAspect(), this);
+        getServer().getPluginManager().registerEvents(new FortuneRemover(), this);
 
         CustomEnchantmentManager.registerEnchantment("Feed", 3, true);
         CustomEnchantmentManager.registerEnchantment("Merit", 5, true);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/mining/FortuneRemover.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/mining/FortuneRemover.java
@@ -1,0 +1,24 @@
+package goat.minecraft.minecraftnew.subsystems.mining;
+
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Listener that removes the Fortune enchantment from a player's
+ * tool whenever they break a block.
+ */
+public class FortuneRemover implements Listener {
+
+    @EventHandler
+    public void onBlockBreak(BlockBreakEvent event) {
+        Player player = event.getPlayer();
+        ItemStack tool = player.getInventory().getItemInMainHand();
+        if (tool != null && tool.containsEnchantment(Enchantment.LOOT_BONUS_BLOCKS)) {
+            tool.removeEnchantment(Enchantment.LOOT_BONUS_BLOCKS);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `FortuneRemover` listener
- register `FortuneRemover` in `MinecraftNew`
- remove Fortune enchantment whenever a block is mined

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68528f9a832c83328bbf8900cc11c5c7