### PR TITLE
Add Trinket system with bank account

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -245,6 +245,8 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         }
 
         CustomBundleGUI.init(this);
+        BankAccountManager.init(this);
+        getServer().getPluginManager().registerEvents(new TrinketListener(), this);
         //getServer().getPluginManager().registerEvents(new GamblingTable(this), this);
 
         forestryPetManager = new ForestryPetManager(this);

--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/BankAccountManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/BankAccountManager.java
@@ -1,0 +1,78 @@
+package goat.minecraft.minecraftnew.other.additionalfunctionality;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+public class BankAccountManager {
+    private static BankAccountManager instance;
+    private final JavaPlugin plugin;
+    private final File file;
+    private final FileConfiguration config;
+
+    private BankAccountManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.file = new File(plugin.getDataFolder(), "bank_accounts.yml");
+        if (!file.exists()) {
+            try {
+                file.getParentFile().mkdirs();
+                file.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        this.config = YamlConfiguration.loadConfiguration(file);
+    }
+
+    public static void init(JavaPlugin plugin) {
+        if (instance == null) {
+            instance = new BankAccountManager(plugin);
+        }
+    }
+
+    public static BankAccountManager getInstance() {
+        return instance;
+    }
+
+    private void save() {
+        try {
+            config.save(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public int getBalance(UUID uuid) {
+        return config.getInt(uuid.toString(), 0);
+    }
+
+    public void deposit(UUID uuid, int amount) {
+        if (amount <= 0) return;
+        int bal = getBalance(uuid) + amount;
+        config.set(uuid.toString(), bal);
+        save();
+    }
+
+    public boolean removeEmeralds(UUID uuid, int amount) {
+        int bal = getBalance(uuid);
+        if (bal < amount) {
+            return false;
+        }
+        config.set(uuid.toString(), bal - amount);
+        save();
+        return true;
+    }
+
+    public int withdrawAll(UUID uuid) {
+        int bal = getBalance(uuid);
+        if (bal > 0) {
+            config.set(uuid.toString(), 0);
+            save();
+        }
+        return bal;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/CustomBundleGUI.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/CustomBundleGUI.java
@@ -413,6 +413,43 @@ public class CustomBundleGUI implements Listener {
         return 0;
     }
 
+    /**
+     * Removes all emeralds and emerald blocks from a player's backpack.
+     *
+     * @param player The player whose backpack should be cleared of emeralds.
+     * @return The total number of emeralds removed (emerald blocks count as 9).
+     */
+    public int removeAllEmeraldItems(Player player) {
+        String playerUUID = player.getUniqueId().toString();
+        if (!storageConfig.contains(playerUUID)) {
+            return 0;
+        }
+
+        int total = 0;
+        for (int slot = 0; slot < 54; slot++) {
+            String path = playerUUID + "." + slot;
+            if (!storageConfig.contains(path)) continue;
+
+            ItemStack stack = storageConfig.getItemStack(path);
+            if (stack == null) continue;
+
+            if (stack.getType() == Material.EMERALD) {
+                total += stack.getAmount();
+                storageConfig.set(path, null);
+            } else if (stack.getType() == Material.EMERALD_BLOCK) {
+                total += stack.getAmount() * 9;
+                storageConfig.set(path, null);
+            }
+        }
+
+        try {
+            storageConfig.save(storageFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return total;
+    }
+
     private static class SlotData {
         int slotIndex;
         int amount;

--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/TrinketListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/TrinketListener.java
@@ -1,0 +1,104 @@
+package goat.minecraft.minecraftnew.other.additionalfunctionality;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TrinketListener implements Listener {
+
+    private final BankAccountManager bankAccountManager;
+
+    public TrinketListener() {
+        this.bankAccountManager = BankAccountManager.getInstance();
+    }
+
+    @EventHandler
+    public void onBackpackClick(InventoryClickEvent event) {
+        if (!event.getView().getTitle().equals("Backpack")) return;
+
+        ItemStack clicked = event.getCurrentItem();
+        if (clicked == null || !clicked.hasItemMeta()) return;
+
+        ItemMeta meta = clicked.getItemMeta();
+        if (meta == null || !meta.hasDisplayName()) return;
+
+        String name = ChatColor.stripColor(meta.getDisplayName());
+        Player player = (Player) event.getWhoClicked();
+        ClickType click = event.getClick();
+
+        switch (name) {
+            case "Workbench":
+                if (click.isLeftClick()) {
+                    event.setCancelled(true);
+                    player.openWorkbench(player.getLocation(), true);
+                }
+                break;
+            case "Divider":
+                if (click.isLeftClick()) {
+                    event.setCancelled(true);
+                }
+                break;
+            case "Bank Account":
+                if (click == ClickType.SHIFT_RIGHT) {
+                    event.setCancelled(true);
+                    int amount = bankAccountManager.withdrawAll(player.getUniqueId());
+                    dropEmeralds(player, amount);
+                    updateBankLore(clicked, meta, player);
+                } else if (click.isLeftClick()) {
+                    event.setCancelled(true);
+                    int total = extractEmeraldsFromInventory(player);
+                    total += CustomBundleGUI.getInstance().removeAllEmeraldItems(player);
+                    bankAccountManager.deposit(player.getUniqueId(), total);
+                    updateBankLore(clicked, meta, player);
+                    if (total > 0) {
+                        player.sendMessage(ChatColor.GREEN + "Deposited " + total + " emeralds.");
+                    }
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void updateBankLore(ItemStack item, ItemMeta meta, Player player) {
+        List<String> lore = new ArrayList<>();
+        lore.add(ChatColor.GRAY + "Stored: " + bankAccountManager.getBalance(player.getUniqueId()));
+        meta.setLore(lore);
+        item.setItemMeta(meta);
+    }
+
+    private int extractEmeraldsFromInventory(Player player) {
+        int total = 0;
+        Inventory inv = player.getInventory();
+        for (int i = 0; i < inv.getSize(); i++) {
+            ItemStack stack = inv.getItem(i);
+            if (stack == null) continue;
+            if (stack.getType() == Material.EMERALD) {
+                total += stack.getAmount();
+                inv.setItem(i, null);
+            } else if (stack.getType() == Material.EMERALD_BLOCK) {
+                total += stack.getAmount() * 9;
+                inv.setItem(i, null);
+            }
+        }
+        return total;
+    }
+
+    private void dropEmeralds(Player player, int amount) {
+        while (amount > 0) {
+            int give = Math.min(64, amount);
+            player.getWorld().dropItemNaturally(player.getLocation(), new ItemStack(Material.EMERALD, give));
+            amount -= give;
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -2,6 +2,7 @@ package goat.minecraft.minecraftnew.subsystems.villagers;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.other.additionalfunctionality.CustomBundleGUI;
+import goat.minecraft.minecraftnew.other.additionalfunctionality.BankAccountManager;
 import goat.minecraft.minecraftnew.other.additionalfunctionality.PlayerTabListUpdater;
 import goat.minecraft.minecraftnew.subsystems.culinary.CulinarySubsystem;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
@@ -1468,15 +1469,14 @@ public class VillagerTradeManager implements Listener {
 
                 int shortfall = finalCostRounded - invEmeraldCount;
 
-                // Attempt removing shortfall from the backpack
-                CustomBundleGUI customBundleGUI = CustomBundleGUI.getInstance();
-                boolean success = customBundleGUI.removeEmeraldsFromBackpack(player, shortfall);
-                if(success){
+                // Attempt removing shortfall from the player's bank account
+                BankAccountManager bank = BankAccountManager.getInstance();
+                boolean success = bank.removeEmeralds(player.getUniqueId(), shortfall);
+                if (success) {
                     removeItems(player.getInventory(), Material.EMERALD, invEmeraldCount);
                 }
                 if (!success) {
-                    // The player can't afford the cost from inventory + backpack
-                    player.sendMessage(ChatColor.RED + "You don't have enough emeralds (in inventory or backpack).");
+                    player.sendMessage(ChatColor.RED + "You don't have enough emeralds.");
                     return;
                 }
             }

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -3838,7 +3838,7 @@ public class ItemRegistry {
         return new ItemStack[]{
             // Common
             getQuartz(), getHematite(), getObsidian(), getAgate(),
-            // Uncommon  
+            // Uncommon
             getTurquoise(), getAmethyst(), getCitrine(), getGarnet(),
             // Rare
             getTopaz(), getPeridot(), getAquamarine(), getTanzanite(),
@@ -3847,5 +3847,40 @@ public class ItemRegistry {
             // Legendary
             getEmerald(), getDiamond()
         };
+    }
+
+    // ===== Trinkets =====
+
+    public static ItemStack getWorkbenchTrinket() {
+        return createCustomItem(
+                Material.CRAFTING_TABLE,
+                ChatColor.YELLOW + "Workbench",
+                List.of(ChatColor.GRAY + "Left Click: open crafting", ChatColor.GRAY + "Right Click: pick up"),
+                1,
+                false,
+                true
+        );
+    }
+
+    public static ItemStack getDividerTrinket() {
+        return createCustomItem(
+                Material.GRAY_STAINED_GLASS_PANE,
+                ChatColor.YELLOW + "Divider",
+                List.of(ChatColor.GRAY + "Layout helper"),
+                1,
+                false,
+                false
+        );
+    }
+
+    public static ItemStack getBankAccountTrinket() {
+        return createCustomItem(
+                Material.EMERALD,
+                ChatColor.YELLOW + "Bank Account",
+                List.of(ChatColor.GRAY + "Stores your emeralds"),
+                1,
+                false,
+                true
+        );
     }
 }


### PR DESCRIPTION
## Summary
- support persistent emerald balance in `BankAccountManager`
- allow backpack removal of all emeralds via `removeAllEmeraldItems`
- implement `TrinketListener` for Workbench, Divider and Bank Account behavior
- initialize new listener and manager in plugin
- use bank account as emerald fallback for villager trades
- add trinket item definitions

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68529270c04c833298a21d9f9479a145