### PR TITLE
Fix bank account withdraw hotkey

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TrinketManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TrinketManager.java
@@ -58,7 +58,7 @@ public class TrinketManager implements Listener {
                     refreshBankLore(player);
                     player.sendMessage(ChatColor.GREEN + "Deposited " + deposited + " emeralds.");
                     event.setCancelled(true);
-                } else if (event.getClick() == ClickType.RIGHT && event.isShiftClick()) {
+                } else if (event.getClick() == ClickType.SHIFT_RIGHT) {
                     int amount = BankAccountManager.getInstance().withdrawAll(player);
                     dropEmeralds(player, amount);
                     updateBankLore(item, 0);

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -1017,7 +1017,7 @@ public class ItemRegistry {
 
     public static ItemStack getBankAccountTrinket() {
         return createCustomItem(
-                Material.PAPER,
+                Material.GOLD_BLOCK,
                 ChatColor.YELLOW + "Bank Account",
                 List.of(
                         ChatColor.GRAY + "Stores emeralds safely",


### PR DESCRIPTION
## Summary
- switch Bank Account trinket material to a gold block
- handle shift-right click properly for withdrawing funds

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685299e6c0d4833285ad72116b0693bd