### PR TITLE
Add Satchel trinkets and leatherworker trades

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -58,6 +58,7 @@ import goat.minecraft.minecraftnew.utils.developercommands.*;
 import goat.minecraft.minecraftnew.utils.devtools.*;
 import goat.minecraft.minecraftnew.utils.dimensions.end.BetterEnd;
 import goat.minecraft.minecraftnew.other.trinkets.BankAccountManager;
+import goat.minecraft.minecraftnew.other.trinkets.SatchelManager;
 import goat.minecraft.minecraftnew.other.trinkets.TrinketManager;
 
 import goat.minecraft.minecraftnew.subsystems.music.PigStepArena;
@@ -248,6 +249,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
 
         CustomBundleGUI.init(this);
         BankAccountManager.init(this);
+        SatchelManager.init(this);
         TrinketManager.init(this);
         //getServer().getPluginManager().registerEvents(new GamblingTable(this), this);
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/SatchelManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/SatchelManager.java
@@ -1,0 +1,92 @@
+package goat.minecraft.minecraftnew.other.trinkets;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+
+public class SatchelManager implements Listener {
+    private static SatchelManager instance;
+    private final JavaPlugin plugin;
+    private File satchelFile;
+    private FileConfiguration satchelConfig;
+
+    private SatchelManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        initFile();
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    public static void init(JavaPlugin plugin) {
+        if (instance == null) {
+            instance = new SatchelManager(plugin);
+        }
+    }
+
+    public static SatchelManager getInstance() {
+        return instance;
+    }
+
+    private void initFile() {
+        satchelFile = new File(plugin.getDataFolder(), "satchels.yml");
+        if (!satchelFile.exists()) {
+            try {
+                plugin.getDataFolder().mkdirs();
+                satchelFile.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        satchelConfig = YamlConfiguration.loadConfiguration(satchelFile);
+    }
+
+    public void openSatchel(Player player, String color) {
+        Inventory inv = Bukkit.createInventory(null, 54, color + " Satchel");
+        String base = player.getUniqueId() + "." + color;
+        if (satchelConfig.contains(base)) {
+            for (int i = 0; i < 54; i++) {
+                ItemStack stack = satchelConfig.getItemStack(base + "." + i);
+                if (stack != null) {
+                    inv.setItem(i, stack);
+                }
+            }
+        }
+        player.openInventory(inv);
+    }
+
+    @EventHandler
+    public void onClose(InventoryCloseEvent event) {
+        String title = event.getView().getTitle();
+        if (!title.endsWith(" Satchel")) return;
+        Player player = (Player) event.getPlayer();
+        String color = title.split(" ")[0];
+        saveSatchel(player, event.getInventory(), color);
+    }
+
+    private void saveSatchel(Player player, Inventory inv, String color) {
+        String base = player.getUniqueId() + "." + color;
+        for (int i = 0; i < 54; i++) {
+            ItemStack item = inv.getItem(i);
+            if (item != null && item.getType() != Material.AIR) {
+                satchelConfig.set(base + "." + i, item);
+            } else {
+                satchelConfig.set(base + "." + i, null);
+            }
+        }
+        try {
+            satchelConfig.save(satchelFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TrinketManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TrinketManager.java
@@ -66,6 +66,24 @@ public class TrinketManager implements Listener {
                     event.setCancelled(true);
                 }
             }
+            case "Blue Satchel" -> {
+                if (event.getClick().isLeftClick()) {
+                    SatchelManager.getInstance().openSatchel(player, "Blue");
+                    event.setCancelled(true);
+                }
+            }
+            case "Black Satchel" -> {
+                if (event.getClick().isLeftClick()) {
+                    SatchelManager.getInstance().openSatchel(player, "Black");
+                    event.setCancelled(true);
+                }
+            }
+            case "Green Satchel" -> {
+                if (event.getClick().isLeftClick()) {
+                    SatchelManager.getInstance().openSatchel(player, "Green");
+                    event.setCancelled(true);
+                }
+            }
         }
     }
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -367,6 +367,12 @@ public class VillagerTradeManager implements Listener {
         List<Map<String, Object>> leatherworkerSells = new ArrayList<>();
         leatherworkerSells.add(createTradeMap("SADDLE", 1, 12, 1)); // Material
         leatherworkerSells.add(createTradeMap("LEATHER_BOOTS", 1, 1, 1)); // Material
+        leatherworkerSells.add(createTradeMap("WORKBENCH_TRINKET", 1, 90, 1));
+        leatherworkerSells.add(createTradeMap("DIVIDER_TRINKET", 1, 90, 1));
+        leatherworkerSells.add(createTradeMap("BANK_ACCOUNT_TRINKET", 1, 90, 1));
+        leatherworkerSells.add(createTradeMap("BLUE_SATCHEL", 1, 90, 1));
+        leatherworkerSells.add(createTradeMap("BLACK_SATCHEL", 1, 90, 1));
+        leatherworkerSells.add(createTradeMap("GREEN_SATCHEL", 1, 90, 1));
         defaultConfig.set("LEATHERWORKER.sells", leatherworkerSells);
 // Shepherd Purchases
         List<Map<String, Object>> shepherdPurchases = new ArrayList<>();
@@ -835,6 +841,18 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getLeatherworkerEnchant();
             case "LEATHERWORKER_ARTIFACT":
                 return ItemRegistry.getLeatherworkerArtifact();
+            case "WORKBENCH_TRINKET":
+                return ItemRegistry.getWorkbenchTrinket();
+            case "DIVIDER_TRINKET":
+                return ItemRegistry.getDividerTrinket();
+            case "BANK_ACCOUNT_TRINKET":
+                return ItemRegistry.getBankAccountTrinket();
+            case "BLUE_SATCHEL":
+                return ItemRegistry.getBlueSatchelTrinket();
+            case "BLACK_SATCHEL":
+                return ItemRegistry.getBlackSatchelTrinket();
+            case "GREEN_SATCHEL":
+                return ItemRegistry.getGreenSatchelTrinket();
             case "CLERIC_ENCHANT":
                 return ItemRegistry.getClericEnchant();
             case "SUNFLARE":

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -1030,6 +1030,48 @@ public class ItemRegistry {
         );
     }
 
+    public static ItemStack getBlueSatchelTrinket() {
+        return createCustomItem(
+                Material.BLUE_WOOL,
+                ChatColor.YELLOW + "Blue Satchel",
+                List.of(
+                        ChatColor.BLUE + "Left-click" + ChatColor.GRAY + ": Open",
+                        ChatColor.BLUE + "Right-click" + ChatColor.GRAY + ": Pick up"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
+    public static ItemStack getBlackSatchelTrinket() {
+        return createCustomItem(
+                Material.BLACK_WOOL,
+                ChatColor.YELLOW + "Black Satchel",
+                List.of(
+                        ChatColor.BLUE + "Left-click" + ChatColor.GRAY + ": Open",
+                        ChatColor.BLUE + "Right-click" + ChatColor.GRAY + ": Pick up"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
+    public static ItemStack getGreenSatchelTrinket() {
+        return createCustomItem(
+                Material.GREEN_WOOL,
+                ChatColor.YELLOW + "Green Satchel",
+                List.of(
+                        ChatColor.BLUE + "Left-click" + ChatColor.GRAY + ": Open",
+                        ChatColor.BLUE + "Right-click" + ChatColor.GRAY + ": Pick up"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
     public static ItemStack getClericEnchant() {
         return createCustomItem(Material.SUGAR_CANE, ChatColor.YELLOW +
                 "Alchemical Bundle", Arrays.asList(


### PR DESCRIPTION
## Summary
- implement SatchelManager for persistent satchel inventories
- expose blue, black and green Satchel trinkets
- open satchels via new cases in TrinketManager
- register SatchelManager in the plugin main class
- sell all trinkets from the Leatherworker for 90 emeralds each

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a530c204833289b604bee0ce59ef