### PR TITLE
Limit Shulkl Box usage to backpacks

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/ShulkerBox.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/ShulkerBox.java
@@ -36,6 +36,10 @@ public class ShulkerBox implements Listener {
         ItemStack clicked = e.getCurrentItem();
         if (clicked == null || !ALL_SHULKERS.contains(clicked.getType())) return;
 
+        // Only allow shulker boxes inside the Backpack inventory
+        if (!e.getView().getTitle().equals("Backpack")) return;
+        if (e.getClickedInventory() == null || e.getClickedInventory() != e.getView().getTopInventory()) return;
+
         Player p = (Player)e.getWhoClicked();
         // perk check
         PlayerMeritManager mgr = PlayerMeritManager.getInstance(MinecraftNew.getInstance());

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/MeritCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/MeritCommand.java
@@ -69,8 +69,8 @@ public class MeritCommand implements CommandExecutor, Listener {
     private static final List<Perk> perks = Arrays.asList(
             new Perk(ChatColor.DARK_GRAY + "Shulkl Box", 7, Material.SHULKER_SHELL,
                     Arrays.asList(
-                            ChatColor.GRAY + "Enables Backpack Shulker Box usage.",
-                            ChatColor.BLUE + "On Right Click Shulker Box In Backpack: " + ChatColor.GRAY + "Opens it."
+                            ChatColor.GRAY + "Allows opening Shulker Boxes only inside backpacks.",
+                            ChatColor.BLUE + "Right Click Shulker Box in Backpack: " + ChatColor.GRAY + "Opens it."
                     )),
             new Perk(ChatColor.DARK_GRAY + "Motion Sensor", 1, Material.OAK_DOOR,
                     Arrays.asList(


### PR DESCRIPTION
## Summary
- restrict Shulkl Box perk so shulker boxes open only from backpacks
- update perk description to explain the limitation

## Testing
- `mvn -version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6852a7c619488332b6f7ac88d525b47a