### PR TITLE
Add Anvil Trinket for remote anvil access

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -105,6 +105,10 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         return shelfManager;
     }
 
+    public AnvilRepair getAnvilRepair() {
+        return anvilRepair;
+    }
+
     @Override
     public void onEnable() {
         instance = this;

--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TrinketManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TrinketManager.java
@@ -1,6 +1,7 @@
 package goat.minecraft.minecraftnew.other.trinkets;
 
 import goat.minecraft.minecraftnew.other.additionalfunctionality.CustomBundleGUI;
+import goat.minecraft.minecraftnew.MinecraftNew;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -43,6 +44,12 @@ public class TrinketManager implements Listener {
             case "Workbench Trinket" -> {
                 if (event.getClick().isLeftClick()) {
                     player.openWorkbench(null, true);
+                    event.setCancelled(true);
+                }
+            }
+            case "Anvil Trinket" -> {
+                if (event.getClick().isLeftClick()) {
+                    MinecraftNew.getInstance().getAnvilRepair().openAnvilGui(player);
                     event.setCancelled(true);
                 }
             }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
@@ -98,6 +98,21 @@ public class AnvilRepair implements Listener {
     }
 
     /**
+     * Opens the Anvil Repair GUI for the given player without requiring an anvil block.
+     * This is used by certain trinkets to access the interface remotely.
+     *
+     * @param player The player for whom to open the GUI.
+     */
+    public void openAnvilGui(Player player) {
+        Inventory anvilInventory = anvilInventories.get(player.getUniqueId());
+        if (anvilInventory == null) {
+            anvilInventory = loadInventory(player.getUniqueId());
+            anvilInventories.put(player.getUniqueId(), anvilInventory);
+        }
+        player.openInventory(anvilInventory);
+    }
+
+    /**
      * Creates a custom anvil inventory with predefined GUI elements.
      *
      * @return The custom anvil inventory.

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -373,6 +373,7 @@ public class VillagerTradeManager implements Listener {
         leatherworkerSells.add(createTradeMap("BLUE_SATCHEL", 1, 90, 1));
         leatherworkerSells.add(createTradeMap("BLACK_SATCHEL", 1, 90, 1));
         leatherworkerSells.add(createTradeMap("GREEN_SATCHEL", 1, 90, 1));
+        leatherworkerSells.add(createTradeMap("ANVIL_TRINKET", 1, 90, 4));
         defaultConfig.set("LEATHERWORKER.sells", leatherworkerSells);
 // Shepherd Purchases
         List<Map<String, Object>> shepherdPurchases = new ArrayList<>();
@@ -847,6 +848,8 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getDividerTrinket();
             case "BANK_ACCOUNT_TRINKET":
                 return ItemRegistry.getBankAccountTrinket();
+            case "ANVIL_TRINKET":
+                return ItemRegistry.getAnvilTrinket();
             case "BLUE_SATCHEL":
                 return ItemRegistry.getBlueSatchelTrinket();
             case "BLACK_SATCHEL":

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -1072,6 +1072,20 @@ public class ItemRegistry {
         );
     }
 
+    public static ItemStack getAnvilTrinket() {
+        return createCustomItem(
+                Material.ANVIL,
+                ChatColor.YELLOW + "Anvil Trinket",
+                List.of(
+                        ChatColor.BLUE + "Left-click" + ChatColor.GRAY + ": Open Anvil",
+                        ChatColor.BLUE + "Right-click" + ChatColor.GRAY + ": Pick up"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
     public static ItemStack getClericEnchant() {
         return createCustomItem(Material.SUGAR_CANE, ChatColor.YELLOW +
                 "Alchemical Bundle", Arrays.asList(


### PR DESCRIPTION
## Summary
- enable accessing anvil repair without a placed anvil
- expose `getAnvilRepair` from the plugin
- create new `Anvil Trinket` item
- support the trinket in the backpack UI
- add leatherworker trade for the new trinket

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a8161aac8332a53fcdde2819ff16