### PR TITLE
Add Magnet trinket

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -45,6 +45,7 @@ import goat.minecraft.minecraftnew.subsystems.pets.perks.*;
 import goat.minecraft.minecraftnew.subsystems.pets.perks.Float;
 import goat.minecraft.minecraftnew.subsystems.smithing.talismans.*;
 import goat.minecraft.minecraftnew.subsystems.pets.perks.AutoComposter;
+import goat.minecraft.minecraftnew.other.trinkets.MagnetTrinket;
 import goat.minecraft.minecraftnew.subsystems.fishing.SeaCreatureDeathEvent;
 import goat.minecraft.minecraftnew.subsystems.mining.Mining;
 import goat.minecraft.minecraftnew.subsystems.smithing.AnvilRepair;
@@ -287,6 +288,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
 
 
         autoComposter = new AutoComposter(this);
+        new MagnetTrinket(this);
         VillagerWorkCycleManager.getInstance(this);
 
         if (!getDataFolder().exists()) {

--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/CustomBundleGUI.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/CustomBundleGUI.java
@@ -498,6 +498,30 @@ public class CustomBundleGUI implements Listener {
         }
     }
 
+    /**
+     * Checks if the player's backpack contains an item with the given display name.
+     */
+    public boolean hasItemWithDisplayName(Player player, String name) {
+        String playerUUID = player.getUniqueId().toString();
+        if (!storageConfig.contains(playerUUID)) {
+            return false;
+        }
+
+        for (int slot = 0; slot < 54; slot++) {
+            String path = playerUUID + "." + slot;
+            if (!storageConfig.contains(path)) continue;
+
+            ItemStack stack = storageConfig.getItemStack(path);
+            if (stack == null) continue;
+            ItemMeta meta = stack.getItemMeta();
+            if (meta == null || !meta.hasDisplayName()) continue;
+            if (ChatColor.stripColor(meta.getDisplayName()).equals(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 
     private void saveBundleInventory(Player player, Inventory inventory) {
         String playerUUID = player.getUniqueId().toString();

--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/MagnetTrinket.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/MagnetTrinket.java
@@ -1,0 +1,46 @@
+package goat.minecraft.minecraftnew.other.trinkets;
+
+import goat.minecraft.minecraftnew.other.additionalfunctionality.CustomBundleGUI;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.ExperienceOrb;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+public class MagnetTrinket {
+    private final JavaPlugin plugin;
+
+    public MagnetTrinket(JavaPlugin plugin) {
+        this.plugin = plugin;
+        startTask();
+    }
+
+    private void startTask() {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                for (Player player : Bukkit.getOnlinePlayers()) {
+                    if (hasMagnet(player)) {
+                        attractOrbs(player);
+                    }
+                }
+            }
+        }.runTaskTimer(plugin, 0L, 20L);
+    }
+
+    private boolean hasMagnet(Player player) {
+        return CustomBundleGUI.getInstance().hasItemWithDisplayName(player, "Magnet");
+    }
+
+    private void attractOrbs(Player player) {
+        Location loc = player.getLocation();
+        double radius = 30.0;
+        for (Entity entity : player.getWorld().getNearbyEntities(loc, radius, radius, radius)) {
+            if (entity instanceof ExperienceOrb orb) {
+                orb.setVelocity(loc.toVector().subtract(orb.getLocation().toVector()).normalize().multiply(1.5));
+            }
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -373,6 +373,7 @@ public class VillagerTradeManager implements Listener {
         leatherworkerSells.add(createTradeMap("BLUE_SATCHEL", 1, 90, 1));
         leatherworkerSells.add(createTradeMap("BLACK_SATCHEL", 1, 90, 1));
         leatherworkerSells.add(createTradeMap("GREEN_SATCHEL", 1, 90, 1));
+        leatherworkerSells.add(createTradeMap("MAGNET_TRINKET", 1, 90, 1));
         defaultConfig.set("LEATHERWORKER.sells", leatherworkerSells);
 // Shepherd Purchases
         List<Map<String, Object>> shepherdPurchases = new ArrayList<>();
@@ -853,6 +854,8 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getBlackSatchelTrinket();
             case "GREEN_SATCHEL":
                 return ItemRegistry.getGreenSatchelTrinket();
+            case "MAGNET_TRINKET":
+                return ItemRegistry.getMagnetTrinket();
             case "CLERIC_ENCHANT":
                 return ItemRegistry.getClericEnchant();
             case "SUNFLARE":

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -1072,6 +1072,20 @@ public class ItemRegistry {
         );
     }
 
+    public static ItemStack getMagnetTrinket() {
+        return createCustomItem(
+                Material.IRON_NUGGET,
+                ChatColor.YELLOW + "Magnet",
+                List.of(
+                        ChatColor.GRAY + "Attracts nearby XP orbs",
+                        ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Automatic"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
     public static ItemStack getClericEnchant() {
         return createCustomItem(Material.SUGAR_CANE, ChatColor.YELLOW +
                 "Alchemical Bundle", Arrays.asList(


### PR DESCRIPTION
## Summary
- add `MagnetTrinket` that pulls in nearby experience orbs when kept in Backpack
- expose `hasItemWithDisplayName` in `CustomBundleGUI`
- create a new `getMagnetTrinket` item
- sell Magnet trinket from the leatherworker and map trade to item
- instantiate magnet logic during plugin enable

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6852a93aab848332abb3d31882fc4155