### PR TITLE
Remove Pigstep disc functionality

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/RightClickArtifacts.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/RightClickArtifacts.java
@@ -238,7 +238,6 @@ public class RightClickArtifacts implements Listener {
             Material.MUSIC_DISC_FAR,
             Material.MUSIC_DISC_MALL,
             Material.MUSIC_DISC_MELLOHI,
-            Material.MUSIC_DISC_PIGSTEP,
             Material.MUSIC_DISC_STAL,
             Material.MUSIC_DISC_STRAD,
             Material.MUSIC_DISC_WAIT,
@@ -1052,14 +1051,6 @@ public class RightClickArtifacts implements Listener {
                 )
         ));
 
-        map.put(Material.MUSIC_DISC_PIGSTEP, new DiscData(
-                ChatColor.RED + "Music Disc Pigstep",
-                ChatColor.RED,
-                List.of(
-                        ChatColor.GRAY + "Summons an Angry Pigman boss",
-                        ChatColor.GRAY + "Defeat it for gold, enchanted apples, or pet rewards"
-                )
-        ));
 
         map.put(Material.MUSIC_DISC_5, new DiscData(
                 ChatColor.GRAY + "Music Disc 5",

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/FishingEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/FishingEvent.java
@@ -520,7 +520,6 @@ public class FishingEvent implements Listener {
                 new LootItem(new ItemStack(Material.MUSIC_DISC_WARD), 2),
                 new LootItem(new ItemStack(Material.MUSIC_DISC_11), 2),
                 new LootItem(new ItemStack(Material.MUSIC_DISC_WAIT), 2),
-                new LootItem(new ItemStack(Material.MUSIC_DISC_PIGSTEP), 2),
                 new LootItem(new ItemStack(Material.MUSIC_DISC_OTHERSIDE), 2),
                 new LootItem(new ItemStack(Material.MUSIC_DISC_RELIC), 2),
                 new LootItem(new ItemStack(Material.MUSIC_DISC_5), 2),

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerWorkCycleManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerWorkCycleManager.java
@@ -457,7 +457,6 @@ public class VillagerWorkCycleManager implements Listener, CommandExecutor {
                 Material.MUSIC_DISC_WARD,
                 Material.MUSIC_DISC_11,
                 Material.MUSIC_DISC_WAIT,
-                Material.MUSIC_DISC_PIGSTEP,
                 Material.MUSIC_DISC_OTHERSIDE,
                 Material.MUSIC_DISC_RELIC,
                 Material.MUSIC_DISC_5

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/DiscsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/DiscsCommand.java
@@ -125,14 +125,6 @@ public class DiscsCommand implements CommandExecutor, Listener {
                         "Spawns XP orbs with accompanying visual effects"
                 )
         ));
-        discDataMap.put(Material.MUSIC_DISC_PIGSTEP, new DiscData(
-                ChatColor.RED + "Music Disc Pigstep",
-                ChatColor.RED,
-                Arrays.asList(
-                        "Summons an Angry Pigman boss",
-                        "Defeat it for gold, enchanted apples, or pet rewards"
-                )
-        ));
         discDataMap.put(Material.MUSIC_DISC_5, new DiscData(
                 ChatColor.GRAY + "Music Disc 5",
                 ChatColor.GRAY,

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -3242,7 +3242,6 @@ public class ItemRegistry {
                 new ItemStack(Material.MUSIC_DISC_WARD),
                 new ItemStack(Material.MUSIC_DISC_11),
                 new ItemStack(Material.MUSIC_DISC_WAIT),
-                new ItemStack(Material.MUSIC_DISC_PIGSTEP),
                 new ItemStack(Material.MUSIC_DISC_OTHERSIDE),
                 new ItemStack(Material.MUSIC_DISC_RELIC),
                 new ItemStack(Material.MUSIC_DISC_5)


### PR DESCRIPTION
## Summary
- strip Pigstep references from disc command descriptions
- remove Pigstep disc entry from random disc lists and loot tables
- delete Pigstep disc boss event logic

## Testing
- `mvn -q package -DskipTests` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854f2030dcc8332ac24a8bd4fb5ac92