### PR TITLE
Adjust relic growth mechanics

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/meritperks/MasterBotanist.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/meritperks/MasterBotanist.java
@@ -7,7 +7,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 /**
  * Master Botanist merit perk.
  * <p>
- * Reduces the time it takes for Verdant Relics to mature by 50%.
+ * Reduces the time it takes for Verdant Relics to mature by 20%.
  * The adjustment is applied when the relic is planted in
  * {@link goat.minecraft.minecraftnew.subsystems.farming.VerdantRelicsSubsystem}.
  */

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/VerdantRelicsSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/VerdantRelicsSubsystem.java
@@ -204,27 +204,21 @@ public class VerdantRelicsSubsystem implements Listener {
         p.sendMessage(ChatColor.GREEN + "You planted a " + relicName + " relic seed!");
 
         String locKey = toLocKey(target.getLocation());
-        XPManager xpManager = new XPManager(plugin);
-        int farmingLevel = xpManager.getPlayerLevel(p, "Farming");
 
         int growthDuration;
-        if(relicName.equalsIgnoreCase("Sunflare")) {
+        if (relicName.equalsIgnoreCase("Sunflare")) {
             // Sunflare grows quicker than other relics
-            growthDuration = 5 * 1200; // 5 in-game days
+            growthDuration = 5 * 1200 * 3; // 15 in-game days
         } else {
-            // One in-game day is 20 minutes (1,200 seconds)
-            double durationAtLevel1 = 10 * 1200.0;   // 30 days = 36,000 seconds
-            double durationAtLevel100 = 5 * 1200.0;   // 15 days = 18,000 seconds
-            double diff = durationAtLevel1 - durationAtLevel100;
-            double factor = (farmingLevel - 1) / 99.0; // Linear factor from level 1 to 100
-            growthDuration = (int)(durationAtLevel1 - diff * factor);
+            // Base duration for relics
+            growthDuration = 10 * 1200 * 3; // 30 in-game days
         }
 
-        // Apply Master Botanist perk: halve the growth time
+        // Apply Master Botanist perk: reduce growth time by 20%
         PlayerMeritManager meritManager = PlayerMeritManager.getInstance(plugin);
         if (meritManager.hasPerk(p.getUniqueId(), "Master Botanist")) {
-            growthDuration = growthDuration / 2;
-            Bukkit.getLogger().info("Reduced Verdant Relic Growth Time by 50%. Before: " + growthDuration*2 + " after: " +growthDuration);
+            growthDuration = (int) (growthDuration * 0.8);
+            Bukkit.getLogger().info("Reduced Verdant Relic Growth Time by 20%. New duration: " + growthDuration);
         }
 
         RelicSession session = new RelicSession(locKey, relicName, growthDuration, growthDuration);

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/MeritCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/MeritCommand.java
@@ -119,8 +119,8 @@ public class MeritCommand implements CommandExecutor, Listener {
                     )),
             new Perk(ChatColor.DARK_GRAY + "Master Botanist", 3, Material.WHEAT_SEEDS,
                     Arrays.asList(
-                            ChatColor.GRAY + "Verdant relics mature 50% faster.",
-                            ChatColor.BLUE + "On Verdant Relic Growth: " + ChatColor.GRAY + "Time reduced by 50%."
+                            ChatColor.GRAY + "Verdant relics mature 20% faster.",
+                            ChatColor.BLUE + "On Verdant Relic Growth: " + ChatColor.GRAY + "Time reduced by 20%."
                     )),
             new Perk(ChatColor.DARK_GRAY + "Master Brewer", 3, Material.BREWING_STAND,
                     Arrays.asList(


### PR DESCRIPTION
## Summary
- slow down verdant relic growth to triple the previous duration
- remove farming level growth scaling
- nerf Master Botanist perk from 50% to 20%
- update perk descriptions and docs

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable for repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_6854f164d30083329a335552ea1d2033