### PR TITLE
Add basic Beacon Catalyst GUI

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -67,6 +67,8 @@ import org.bukkit.*;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
+import goat.minecraft.minecraftnew.subsystems.beacon.BeaconCharmGUI;
+import goat.minecraft.minecraftnew.utils.commands.BeaconCharmCommand;
 
 import java.util.Objects;
 
@@ -95,6 +97,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
 
 
     private PotionBrewingSubsystem potionBrewingSubsystem;
+    private BeaconCharmGUI beaconCharmGUI;
     private VerdantRelicsSubsystem verdantRelicsSubsystem;
     private CombatSubsystemManager combatSubsystemManager;
 
@@ -147,6 +150,8 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         PlayerOxygenManager oxygenManager = new PlayerOxygenManager(this);
         this.getCommand("setplayeroxygen").setExecutor(new SetPlayerOxygenCommand());
 
+        beaconCharmGUI = new BeaconCharmGUI(this);
+        new BeaconCharmCommand(this, beaconCharmGUI);
 
 
         new SetDurabilityCommand(this);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/BeaconCharmGUI.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/BeaconCharmGUI.java
@@ -1,0 +1,62 @@
+package goat.minecraft.minecraftnew.subsystems.beacon;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Simple GUI allowing players to select a beacon catalyst.
+ */
+public class BeaconCharmGUI implements Listener {
+    private static final String TITLE = ChatColor.AQUA + "Beacon Catalyst Selection";
+    private final MinecraftNew plugin;
+    private final Map<Integer, CatalystType> slotMap = new HashMap<>();
+
+    public BeaconCharmGUI(MinecraftNew plugin) {
+        this.plugin = plugin;
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    /**
+     * Opens the catalyst selection GUI for the given beacon tier.
+     */
+    public void open(Player player, int tier) {
+        Inventory gui = Bukkit.createInventory(new Holder(), 27, TITLE);
+        slotMap.clear();
+        int slot = 10; // start near center
+        for (CatalystType type : CatalystType.values()) {
+            gui.setItem(slot, type.createItem(tier));
+            slotMap.put(slot, type);
+            slot += 1;
+        }
+        player.openInventory(gui);
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player)) return;
+        if (!event.getView().getTitle().equals(TITLE)) return;
+        event.setCancelled(true);
+        Player player = (Player) event.getWhoClicked();
+        CatalystType type = slotMap.get(event.getSlot());
+        if (type != null) {
+            player.sendMessage(ChatColor.GREEN + "Selected " + type.name());
+            player.closeInventory();
+        }
+    }
+
+    private static class Holder implements InventoryHolder {
+        @Override
+        public Inventory getInventory() { return null; }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/CatalystType.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/CatalystType.java
@@ -1,0 +1,77 @@
+package goat.minecraft.minecraftnew.subsystems.beacon;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Types of Beacon Catalysts with scaling buffs based on beacon tier.
+ */
+public enum CatalystType {
+    POWER("Catalyst of Power", Material.NETHERITE_SWORD),
+    FLIGHT("Catalyst of Flight", Material.ELYTRA),
+    FORTITUDE("Catalyst of Fortitude", Material.SHIELD),
+    DEPTH("Catalyst of Depth", Material.NAUTILUS_SHELL),
+    INSANITY("Catalyst of Insanity", Material.TOTEM_OF_UNDYING),
+    OXYGEN("Catalyst of Oxygen", Material.POTION);
+
+    private final String displayName;
+    private final Material icon;
+
+    CatalystType(String displayName, Material icon) {
+        this.displayName = displayName;
+        this.icon = icon;
+    }
+
+    public ItemStack createItem(int tier) {
+        ItemStack item = new ItemStack(icon);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.GOLD + displayName);
+            meta.setLore(getLore(tier));
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    /**
+     * Generates lore describing the catalyst effects at the given beacon tier.
+     */
+    public List<String> getLore(int tier) {
+        List<String> lore = new ArrayList<>();
+        switch (this) {
+            case POWER -> {
+                double dmg = 0.25 + 0.05 * tier;
+                lore.add(ChatColor.GRAY + String.format("Increase damage by +%.0f%%", dmg * 100));
+            }
+            case FLIGHT -> lore.add(ChatColor.GRAY + "Grants flight while active");
+            case FORTITUDE -> {
+                double red = 0.40 + 0.05 * tier;
+                lore.add(ChatColor.GRAY + String.format("Damage reduction: +%.0f%%", red * 100));
+                lore.add(ChatColor.GRAY + "Knockback immunity");
+            }
+            case DEPTH -> {
+                double chance = 0.05 + 0.01 * tier;
+                lore.add(ChatColor.GRAY + String.format("Treasure Chance: +%.0f%%", chance * 100));
+                lore.add(ChatColor.GRAY + String.format("Sea Creature Chance: +%.0f%%", chance * 100));
+            }
+            case INSANITY -> {
+                double spirit = 0.05 + 0.01 * tier;
+                double red = 0.50 + 0.05 * tier;
+                lore.add(ChatColor.GRAY + String.format("Spirit chance: +%.0f%%", spirit * 100));
+                lore.add(ChatColor.GRAY + String.format("Spirit damage reduction: +%.0f%%", red * 100));
+            }
+            case OXYGEN -> {
+                double interval = 3 - 0.2 * tier;
+                lore.add(ChatColor.GRAY + String.format("+1 Oxygen every %.1fs", interval));
+            }
+        }
+        lore.add("");
+        lore.add(ChatColor.DARK_GRAY + "Tier " + tier);
+        return lore;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/BeaconCharmCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/BeaconCharmCommand.java
@@ -1,0 +1,35 @@
+package goat.minecraft.minecraftnew.utils.commands;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.beacon.BeaconCharmGUI;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Command to open the Beacon Catalyst GUI.
+ */
+public class BeaconCharmCommand implements CommandExecutor {
+    private final BeaconCharmGUI gui;
+
+    public BeaconCharmCommand(MinecraftNew plugin, BeaconCharmGUI gui) {
+        this.gui = gui;
+        plugin.getCommand("beaconcharm").setExecutor(this);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players may use this command.");
+            return true;
+        }
+        int tier = 1;
+        if (args.length > 0) {
+            try { tier = Integer.parseInt(args[0]); } catch (NumberFormatException ignored) {}
+        }
+        if (tier < 0) tier = 0; if (tier > 6) tier = 6;
+        gui.open(player, tier);
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -134,3 +134,7 @@ commands:
     description: Sets a player's skill level
     usage: /setskilllevel <player> <skill> <level>
     permission: continuity.admin
+  beaconcharm:
+    description: Opens the Beacon Catalyst GUI
+    usage: /beaconcharm [tier]
+    permission: continuity.use


### PR DESCRIPTION
## Summary
- implement `CatalystType` enum for beacon catalysts
- add `BeaconCharmGUI` and command to open it
- register new `beaconcharm` command

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68552b9d57308332b8d78acc712fb7af