### PR TITLE
Add persistence for beacon passives

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -232,11 +232,13 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new ShulkerBox(), this);
         getServer().getPluginManager().registerEvents(new BeaconManager(this), this);
         getServer().getPluginManager().registerEvents(new BeaconCharmGUI(this, null), this);
+        BeaconPassivesGUI.init(this);
         getServer().getPluginManager().registerEvents(new BeaconPassivesGUI(this, null), this);
         getServer().getPluginManager().registerEvents(new BeaconCatalystsGUI(this, null), this);
         getServer().getPluginManager().registerEvents(new BeaconUpgradesGUI(this, null), this);
         beaconPassiveEffects = new BeaconPassiveEffects(this);
         getServer().getPluginManager().registerEvents(beaconPassiveEffects, this);
+        beaconPassiveEffects.reapplyAllPassiveEffects();
         // Initialize catalyst manager for beacon charm catalysts
         CatalystManager.initialize(this);
 
@@ -628,6 +630,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         if (beaconPassiveEffects != null) {
             beaconPassiveEffects.removeAllPassiveEffects();
         }
+        BeaconPassivesGUI.saveAllPassives();
         if (CatalystManager.getInstance() != null) {
             CatalystManager.getInstance().shutdown();
         }


### PR DESCRIPTION
## Summary
- persist beacon passive selections to `beacon_passives.yml`
- load player selections on join and save on quit
- initialise and save passives from the main plugin
- reapply beacon passive effects on startup

## Testing
- `mvn -q -DskipTests=false test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68576ab8d0dc8332bd7ef8e234657926