### PR TITLE
Add toast sound for beacon tier upgrade

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/BeaconManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/BeaconManager.java
@@ -145,8 +145,9 @@ public class BeaconManager implements Listener {
             return false;
         }
         
-        // Get current beacon power
+        // Get current beacon power and tier
         int currentPower = getCurrentBeaconPower(beacon);
+        int oldTier = getBeaconTierFromPower(currentPower);
         int powerToAdd = powerPerBlock * material.getAmount();
         int newPower = Math.min(currentPower + powerToAdd, 10000);
         
@@ -157,6 +158,12 @@ public class BeaconManager implements Listener {
         
         // Update the beacon's lore with new power
         updateBeaconPower(beacon, newPower);
+
+        // Play a toast sound if we reached a new tier
+        int newTier = getBeaconTierFromPower(newPower);
+        if (newTier > oldTier) {
+            player.playSound(player.getLocation(), Sound.UI_TOAST_CHALLENGE_COMPLETE, 1.0f, 1.0f);
+        }
         
         return true;
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/SetBeaconPowerCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/SetBeaconPowerCommand.java
@@ -2,6 +2,7 @@ package goat.minecraft.minecraftnew.subsystems.beacon;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
+import org.bukkit.Sound;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -58,8 +59,17 @@ public class SetBeaconPowerCommand implements CommandExecutor {
             return true;
         }
 
+        // Determine the old tier before setting power
+        int oldTier = BeaconManager.getBeaconTier(heldItem);
+
         // Set the beacon power
         setBeaconPower(heldItem, power);
+
+        // Check if the tier increased and play a toast sound
+        int newTier = BeaconManager.getBeaconTier(heldItem);
+        if (newTier > oldTier) {
+            player.playSound(player.getLocation(), Sound.UI_TOAST_CHALLENGE_COMPLETE, 1.0f, 1.0f);
+        }
 
         // Send success message
         int tier = BeaconManager.getBeaconTier(heldItem);


### PR DESCRIPTION
## Summary
- play toast sound when a beacon gains a new tier
- include same sound for the `setbeaconpower` admin command

## Testing
- `javac -classpath plugins/Continuity-1.0-SNAPSHOT.jar -d /tmp/out src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/BeaconManager.java src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/SetBeaconPowerCommand.java` *(fails: package org.bukkit does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68576dd89b34833281669502ebe309f9