### PR TITLE
Add generator item and drop on pickup

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/cut_content/ResourceGeneratorSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/cut_content/ResourceGeneratorSubsystem.java
@@ -1,6 +1,7 @@
 package goat.minecraft.minecraftnew.cut_content;
 
 import org.bukkit.*;
+import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.*;
@@ -123,8 +124,7 @@ public class ResourceGeneratorSubsystem implements Listener {
             saveGenerators();
 
             // Drop the generator item instead of the block
-            ItemStack generatorItem = createGenerator(generator.getResourceType(), generator.getAmount(), generator.getCooldown());
-            loc.getWorld().dropItemNaturally(loc, generatorItem);
+            loc.getWorld().dropItemNaturally(loc, ItemRegistry.getGeneratorItem());
 
             // Play break effects
             loc.getWorld().playSound(loc, Sound.BLOCK_STONE_BREAK, 1.0f, 1.0f);

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -2525,6 +2525,20 @@ public class ItemRegistry {
         );
     }
 
+    public static ItemStack getGeneratorItem() {
+        return createCustomItem(
+                Material.SKULK_SHRIEKER,
+                ChatColor.YELLOW + "Generator",
+                Arrays.asList(
+                        ChatColor.BLUE + "Right-click" + ChatColor.GRAY + ": Place",
+                        ChatColor.BLUE + "Shift-Right-click" + ChatColor.GRAY + ": Pick up"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
 
     public static ItemStack getEngineeringDegree() {
         return createCustomItem(


### PR DESCRIPTION
## Summary
- drop new generator item when breaking a generator
- provide `ItemRegistry.getGeneratorItem()` for a custom skulk shrieker icon

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857913276048332bf3fa6ccc609b434