### PR TITLE
Add generator power depletion handling

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/generator/OreFabricatorGUI.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/generator/OreFabricatorGUI.java
@@ -134,7 +134,11 @@ public class OreFabricatorGUI implements Listener {
                 gems[i - 9] = event.getInventory().getItem(i);
             }
 
-            subsystem.beginFabrication(player, genLoc, ore, gems);
+            if (subsystem.hasSession(genLoc)) {
+                subsystem.addPowerAndResume(player, genLoc, gems);
+            } else {
+                subsystem.beginFabrication(player, genLoc, ore, gems);
+            }
             player.closeInventory();
             selectedOre.remove(player.getUniqueId());
             openGenerators.remove(player.getUniqueId());


### PR DESCRIPTION
## Summary
- consume gem power each second and remove depleted slots
- resume paused generator sessions when power is added or on right-click
- show `Error:` when a generator runs out of power
- fix method boundaries in `GeneratorSubsystem`

## Testing
- `mvn -q package -DskipTests` *(fails: Network is unreachable for repo.maven.apache.org)*
- `mvn -q test` *(fails: Network is unreachable for repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_685799f067e88332803e12569b5ece7d