### PR TITLE
Add Pigstep Lottery Wheel

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/BeaconManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/BeaconManager.java
@@ -112,8 +112,11 @@ public class BeaconManager implements Listener {
             
             // Success message
             String materialName = formatMaterialName(cursor.getType());
-            int powerGained = MATERIAL_POWER_VALUES.get(cursor.getType()) * cursor.getAmount();
-            player.sendMessage(ChatColor.GOLD + "Applied " + ChatColor.YELLOW + cursor.getAmount() + "x " + materialName + 
+            int powerGained = MATERIAL_POWER_VALUES.getOrDefault(cursor.getType(), isNetherStardust(cursor) ? 1000 : 0) * cursor.getAmount();
+            if (isNetherStardust(cursor)) {
+                materialName = "Nether Stardust";
+            }
+            player.sendMessage(ChatColor.GOLD + "Applied " + ChatColor.YELLOW + cursor.getAmount() + "x " + materialName +
                              ChatColor.GOLD + " (+" + powerGained + " Beacon Power) to your beacon!");
         }
     }
@@ -125,7 +128,14 @@ public class BeaconManager implements Listener {
 
     private boolean isMaterialBlock(ItemStack item) {
         if (item == null) return false;
-        return MATERIAL_POWER_VALUES.containsKey(item.getType());
+        return MATERIAL_POWER_VALUES.containsKey(item.getType()) || isNetherStardust(item);
+    }
+
+    private boolean isNetherStardust(ItemStack item) {
+        if (item == null || item.getType() != Material.NETHER_STAR) return false;
+        if (!item.hasItemMeta() || !item.getItemMeta().hasDisplayName()) return false;
+        String name = ChatColor.stripColor(item.getItemMeta().getDisplayName());
+        return name.equalsIgnoreCase("Nether Stardust");
     }
 
     private boolean isCustomBeacon(ItemStack item) {
@@ -138,7 +148,13 @@ public class BeaconManager implements Listener {
 
     private boolean applyMaterialToBeacon(ItemStack material, ItemStack beacon, Player player) {
         Material materialType = material.getType();
-        Integer powerPerBlock = MATERIAL_POWER_VALUES.get(materialType);
+        Integer powerPerBlock;
+
+        if (isNetherStardust(material)) {
+            powerPerBlock = 1000;
+        } else {
+            powerPerBlock = MATERIAL_POWER_VALUES.get(materialType);
+        }
         
         if (powerPerBlock == null) {
             player.sendMessage(ChatColor.RED + "Unknown material type!");

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -3982,7 +3982,7 @@ public class ItemRegistry {
         return new ItemStack[]{
             // Common
             getQuartz(), getHematite(), getObsidian(), getAgate(),
-            // Uncommon  
+            // Uncommon
             getTurquoise(), getAmethyst(), getCitrine(), getGarnet(),
             // Rare
             getTopaz(), getPeridot(), getAquamarine(), getTanzanite(),
@@ -3991,5 +3991,85 @@ public class ItemRegistry {
             // Legendary
             getEmerald(), getDiamond()
         };
+    }
+
+    /** Creates the Nether Stardust item used to empower beacons. */
+    public static ItemStack getNetherStardust() {
+        return createCustomItem(
+                Material.NETHER_STAR,
+                ChatColor.LIGHT_PURPLE + "Nether Stardust",
+                Arrays.asList(
+                        ChatColor.GRAY + "A rare residue of Piglin festivities.",
+                        ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Click onto a Beacon Charm to add 1,000 Beacon Power.",
+                        ChatColor.DARK_PURPLE + "Special Item"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
+    /** Smithing item unlocking Unbreaking VI. */
+    public static ItemStack getUnbreakingVI() {
+        return createCustomItem(
+                Material.NETHERITE_INGOT,
+                ChatColor.GOLD + "Unbreaking VI",
+                Arrays.asList(
+                        ChatColor.GRAY + "A masterwork manual on durability.",
+                        ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Apply to equipment to unlock Unbreaking VI.",
+                        ChatColor.DARK_PURPLE + "Smithing Item"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
+    /** Smithing item unlocking Sharpness VIII. */
+    public static ItemStack getSharpnessVIII() {
+        return createCustomItem(
+                Material.NETHERITE_SWORD,
+                ChatColor.GOLD + "Sharpness VIII",
+                Arrays.asList(
+                        ChatColor.GRAY + "A masterwork manual on lethality.",
+                        ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Apply to equipment to unlock Sharpness VIII.",
+                        ChatColor.DARK_PURPLE + "Smithing Item"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
+    /** Smithing item unlocking Smite VIII. */
+    public static ItemStack getSmiteVIII() {
+        return createCustomItem(
+                Material.BONE,
+                ChatColor.GOLD + "Smite VIII",
+                Arrays.asList(
+                        ChatColor.GRAY + "A masterwork manual on undead slaying.",
+                        ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Apply to equipment to unlock Smite VIII.",
+                        ChatColor.DARK_PURPLE + "Smithing Item"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
+    /** Smithing item unlocking Bane of Arthropods VIII. */
+    public static ItemStack getBaneOfArthropodsVIII() {
+        return createCustomItem(
+                Material.FERMENTED_SPIDER_EYE,
+                ChatColor.GOLD + "Bane of Arthropods VIII",
+                Arrays.asList(
+                        ChatColor.GRAY + "A masterwork manual on insect eradication.",
+                        ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Apply to equipment to unlock Bane of Arthropods VIII.",
+                        ChatColor.DARK_PURPLE + "Smithing Item"
+                ),
+                1,
+                false,
+                true
+        );
     }
 }


### PR DESCRIPTION
## Summary
- create new beacon power item `Nether Stardust` and several new smithing items
- allow beacon charms to accept Nether Stardust for 1000 power
- make pigstep disc open an animated Lottery Wheel that rewards one random prize

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6857a6f595e0833284aa8861d13dda58