### PR TITLE
Prevent interacting with lottery GUI

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/InventoryClickListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/InventoryClickListener.java
@@ -13,8 +13,8 @@ public class InventoryClickListener implements Listener {
         InventoryView view = event.getView();
         String title = ChatColor.stripColor(view.getTitle());
 
-        // Check if the clicked inventory is the Skills GUI
-        if (title.equals("Your Skills")) {
+        // Cancel interaction with certain custom GUIs
+        if (title.equals("Your Skills") || title.equals("Lottery Wheel")) {
             event.setCancelled(true); // Prevent any interaction
         }
     }


### PR DESCRIPTION
## Summary
- disallow clicks in the Lottery Wheel inventory

## Testing
- `mvn -q -DskipTests package` *(fails: could not download Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6857ac4d67e48332b1f42f698faba167