### PR TITLE
Add warp command

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -256,6 +256,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getCommand("resetend").setExecutor(new ResetEndCommand());
         getCommand("generatecontinuityisland").setExecutor(new GenerateContinuityIslandCommand());
         getCommand("continuitytp").setExecutor(new ContinuityTpCommand());
+        getCommand("warp").setExecutor(new WarpCommand());
         getCommand("setbeaconpower").setExecutor(new SetBeaconPowerCommand());
         getCommand("getnearestcatalysttype").setExecutor(new GetNearestCatalystTypeCommand());
 

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/WarpCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/WarpCommand.java
@@ -1,0 +1,43 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.World;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Teleports a player to the specified world by name.
+ */
+public class WarpCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command!");
+            return true;
+        }
+
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You do not have permission to use this command!");
+            return true;
+        }
+
+        if (args.length != 1) {
+            player.sendMessage(ChatColor.YELLOW + "Usage: /" + label + " <worldName>");
+            return true;
+        }
+
+        String worldName = args[0];
+        World targetWorld = Bukkit.getWorld(worldName);
+        if (targetWorld == null) {
+            player.sendMessage(ChatColor.RED + "World '" + worldName + "' not found!");
+            return true;
+        }
+
+        player.teleport(targetWorld.getSpawnLocation());
+        player.sendMessage(ChatColor.GREEN + "Teleported to world '" + targetWorld.getName() + "'.");
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -148,3 +148,7 @@ commands:
     description: Gets the nearest catalyst type in range of the player
     usage: /getnearestcatalysttype
     permission: continuity.admin
+  warp:
+    description: Teleports the player to the specified world
+    usage: /warp <worldname>
+    permission: continuity.admin


### PR DESCRIPTION
## Summary
- add `WarpCommand` and register it
- expose new `/warp` command in `plugin.yml`

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6857af62262c8332854647ffbb3fff2a