### PR TITLE
Implement Deterioration mechanic

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -523,6 +523,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new Rappel(), this);
         getServer().getPluginManager().registerEvents(new Preservation(), this);
         getServer().getPluginManager().registerEvents(new WaterAspect(), this);
+        getServer().getPluginManager().registerEvents(new Accelerate(), this);
         getServer().getPluginManager().registerEvents(new FortuneRemover(), this);
 
         CustomEnchantmentManager.registerEnchantment("Feed", 3, true);
@@ -544,6 +545,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         CustomEnchantmentManager.registerEnchantment("Rappel", 1, true);
         CustomEnchantmentManager.registerEnchantment("Preservation", 1, true);
         CustomEnchantmentManager.registerEnchantment("Water Aspect", 4, true);
+        CustomEnchantmentManager.registerEnchantment("Accelerate", 4, true);
 
 
         getServer().getPluginManager().registerEvents(new KnightMob(this), this);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatSubsystemManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatSubsystemManager.java
@@ -14,6 +14,7 @@ import goat.minecraft.minecraftnew.subsystems.combat.hostility.HostilityService;
 import goat.minecraft.minecraftnew.subsystems.combat.notification.DamageNotificationService;
 import goat.minecraft.minecraftnew.subsystems.combat.notification.PlayerFeedbackService;
 import goat.minecraft.minecraftnew.subsystems.combat.FireDamageHandler;
+import goat.minecraft.minecraftnew.subsystems.combat.DeteriorationDamageHandler;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
@@ -44,6 +45,7 @@ public class CombatSubsystemManager implements CommandExecutor {
     private HostilityService hostilityService;
 
     private FireDamageHandler fireDamageHandler;
+    private DeteriorationDamageHandler decayDamageHandler;
     
     // Controllers and handlers
     private CombatEventHandler eventHandler;
@@ -264,6 +266,7 @@ public class CombatSubsystemManager implements CommandExecutor {
         );
 
         fireDamageHandler = new FireDamageHandler(plugin, notificationService);
+        decayDamageHandler = DeteriorationDamageHandler.getInstance(plugin, notificationService);
         
         logger.fine("Combat controllers and handlers initialized");
     }
@@ -275,6 +278,7 @@ public class CombatSubsystemManager implements CommandExecutor {
         Bukkit.getPluginManager().registerEvents(eventHandler, plugin);
         Bukkit.getPluginManager().registerEvents(hostilityGUIController, plugin);
         Bukkit.getPluginManager().registerEvents(fireDamageHandler, plugin);
+        Bukkit.getPluginManager().registerEvents(decayDamageHandler, plugin);
 
         logger.fine("Combat event listeners registered");
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SoulUpgradeSystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SoulUpgradeSystem.java
@@ -35,6 +35,7 @@ public class SoulUpgradeSystem implements Listener {
         LIFESTEAL_POTENCY("Potency", "+1 regen potency per level", Material.BLAZE_POWDER, 2, 12),
         LIFESTEAL_DURATION("Duration", "+5 seconds of regeneration per level", Material.CLOCK, 3, 13),
         FEED("Feed", "15% chance to gain +1 hunger and +2 saturation when hitting a monster", Material.COOKED_BEEF, 1, 14),
+        ASPECT_OF_DECAY("Aspect of Decay", "+5 Deterioration stacks per level", Material.WITHER_ROSE, 4, 6),
         LOYAL_AUGMENT("Loyal Augment", "-1s cooldown per level", Material.NETHER_STAR, 4, 20),
         SHRED_AUGMENT("Shred Augment", "+3 stacks of shredders per level", Material.IRON_SWORD, 6, 21),
         WARP_AUGMENT("Warp Augment", "+5 warp charges per level", Material.ENDER_PEARL, 6, 22),
@@ -95,6 +96,7 @@ public class SoulUpgradeSystem implements Listener {
         gui.setItem(SwordUpgrade.FURY.getSlot(), createUpgradeItem(weapon, SwordUpgrade.FURY, available));
         gui.setItem(SwordUpgrade.BETRAYAL.getSlot(), createUpgradeItem(weapon, SwordUpgrade.BETRAYAL, available));
         gui.setItem(SwordUpgrade.LETHALITY.getSlot(), createUpgradeItem(weapon, SwordUpgrade.LETHALITY, available));
+        gui.setItem(SwordUpgrade.ASPECT_OF_DECAY.getSlot(), createUpgradeItem(weapon, SwordUpgrade.ASPECT_OF_DECAY, available));
 
         // ----- Regeneration Row -----
         gui.setItem(9, createHeader(Material.GHAST_TEAR, ChatColor.LIGHT_PURPLE + "❤ Regeneration"));
@@ -371,6 +373,7 @@ public class SoulUpgradeSystem implements Listener {
             case "BETRAYAL": return "♬";
             case "LETHALITY": return "✖";
             case "FEED": return "☕";
+            case "ASPECT_OF_DECAY": return "☣";
             case "STARLESS_NIGHT": return "☾";
             case "CHALLENGE": return "⚑";
             case "BLOOD_MOON": return "☽";
@@ -489,6 +492,7 @@ public class SoulUpgradeSystem implements Listener {
             case "BETRAYAL" -> "♬";
             case "LETHALITY" -> "✖";
             case "FEED" -> "☕";
+            case "ASPECT_OF_DECAY" -> "☣";
             case "STARLESS_NIGHT" -> "☾";
             case "CHALLENGE" -> "⚑";
             case "BLOOD_MOON" -> "☽";

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SwordUpgradeListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SwordUpgradeListener.java
@@ -2,6 +2,8 @@ package goat.minecraft.minecraftnew.subsystems.combat;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import goat.minecraft.minecraftnew.subsystems.combat.DeteriorationDamageHandler;
+import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
 import org.bukkit.*;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
@@ -40,6 +42,15 @@ public class SwordUpgradeListener implements Listener {
         int lethality = SoulUpgradeSystem.getUpgradeLevel(weapon, SoulUpgradeSystem.SwordUpgrade.LETHALITY);
         if (lethality > 0) {
             event.setDamage(event.getDamage() * (1 + lethality * 0.02));
+        }
+        int decayLvl = SoulUpgradeSystem.getUpgradeLevel(weapon, SoulUpgradeSystem.SwordUpgrade.ASPECT_OF_DECAY);
+        if (decayLvl > 0) {
+            int stacks = decayLvl * 5;
+            PlayerMeritManager merit = PlayerMeritManager.getInstance(MinecraftNew.getInstance());
+            if (merit.hasPerk(player.getUniqueId(), "Decay Mastery")) {
+                stacks *= 2;
+            }
+            DeteriorationDamageHandler.getInstance().addDeterioration(target, stacks);
         }
         if (target instanceof Creeper) {
             int diamond = SoulUpgradeSystem.getUpgradeLevel(weapon, SoulUpgradeSystem.SwordUpgrade.DIAMOND_ESSENCE);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/enchantingeffects/Accelerate.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/enchantingeffects/Accelerate.java
@@ -1,0 +1,36 @@
+package goat.minecraft.minecraftnew.subsystems.enchanting.enchantingeffects;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.combat.DeteriorationDamageHandler;
+import goat.minecraft.minecraftnew.subsystems.enchanting.CustomEnchantmentManager;
+import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Accelerate custom enchantment - applies Deterioration stacks on hit.
+ */
+public class Accelerate implements Listener {
+
+    private final PlayerMeritManager meritManager = PlayerMeritManager.getInstance(MinecraftNew.getInstance());
+
+    @EventHandler
+    public void onHit(EntityDamageByEntityEvent event) {
+        if (!(event.getDamager() instanceof Player player)) return;
+        if (!(event.getEntity() instanceof LivingEntity target)) return;
+
+        ItemStack weapon = player.getInventory().getItemInMainHand();
+        if (!CustomEnchantmentManager.hasEnchantment(weapon, "Accelerate")) return;
+
+        int level = CustomEnchantmentManager.getEnchantmentLevel(weapon, "Accelerate");
+        int stacks = level * 5;
+        if (meritManager.hasPerk(player.getUniqueId(), "Decay Mastery")) {
+            stacks *= 2;
+        }
+        DeteriorationDamageHandler.getInstance().addDeterioration(target, stacks);
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/Decay.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/Decay.java
@@ -1,83 +1,40 @@
 package goat.minecraft.minecraftnew.subsystems.pets.perks;
 
+import goat.minecraft.minecraftnew.subsystems.combat.DeteriorationDamageHandler;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.Sound;
+import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitRunnable;
 
-import java.util.HashMap;
-import java.util.Map;
 
 public class Decay implements Listener {
 
     private final PetManager petManager;
     private final JavaPlugin plugin;
-    private final Map<LivingEntity, String> originalNames = new HashMap<>();
+    private final PlayerMeritManager meritManager;
 
     public Decay(JavaPlugin plugin) {
         this.plugin = plugin;
         this.petManager = PetManager.getInstance(plugin);
+        this.meritManager = PlayerMeritManager.getInstance(plugin);
     }
 
     @EventHandler
     public void onPlayerHitMob(EntityDamageByEntityEvent event) {
-        // Check if the damager is a player
         if (!(event.getDamager() instanceof Player player)) return;
-
-        // Check if the entity being damaged is a LivingEntity
         if (!(event.getEntity() instanceof LivingEntity target)) return;
 
-        // Get the player's active pet
         PetManager.Pet activePet = petManager.getActivePet(player);
+        if (activePet == null || !activePet.hasPerk(PetManager.PetPerk.DECAY)) return;
 
-        // Check if the player has the Decay perk
-        if (activePet != null && activePet.hasPerk(PetManager.PetPerk.DECAY)) {
-            // Save the target's original name if not already saved
-            originalNames.putIfAbsent(target, target.getCustomName() != null ? target.getCustomName() : target.getName());
-
-            // Apply rapid decay via a repeating task
-            new BukkitRunnable() {
-                int ticks = 0;
-
-                @Override
-                public void run() {
-                    if (target.isDead() || ticks >= 40) { // Stop after 5 seconds (100 ticks)
-                        resetName(target);
-                        this.cancel();
-                        return;
-                    }
-
-                    // Calculate and apply 10% current health as damage
-                    double currentHealth = target.getHealth();
-                    double damage = currentHealth * 0.1; // 10% of current health
-                    target.damage(damage);
-
-                    // Update the target's name to display current damage
-                    target.setCustomName(ChatColor.BLACK + String.format("Damage: %.2f", damage));
-                    target.setCustomNameVisible(true);
-
-                    // Play a sound to indicate decay
-                    target.getWorld().playSound(target.getLocation(), Sound.ENTITY_WITHER_HURT, 1.0f, 1.0f);
-
-                    ticks += 5; // Increment ticks (5 ticks per execution)
-                }
-            }.runTaskTimer(plugin, 0L, 5L); // Runs every 5 ticks (0.25 seconds)
+        int stacks = 40;
+        if (meritManager.hasPerk(player.getUniqueId(), "Decay Mastery")) {
+            stacks *= 2;
         }
-    }
-
-    private void resetName(LivingEntity target) {
-        // Restore the entity's original name
-        if (originalNames.containsKey(target)) {
-            String originalName = originalNames.remove(target);
-            target.setCustomName(originalName);
-            target.setCustomNameVisible(originalName != null);
-        }
+        DeteriorationDamageHandler.getInstance().addDeterioration(target, stacks);
     }
 }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -223,6 +223,7 @@ public class VillagerTradeManager implements Listener {
         weaponsmithPurchases.add(createTradeMap("WEAPONSMITH_LOOTING", 1, 64, 4)); // ItemRegistry.getWeaponsmithLooting()
         weaponsmithPurchases.add(createTradeMap("WEAPONSMITH_KNOCKBACK", 1, 64, 4)); // ItemRegistry.getWeaponsmithKnockback()
         weaponsmithPurchases.add(createTradeMap("WEAPONSMITH_FIRE_ASPECT", 1, 64, 4)); // ItemRegistry.getWeaponsmithFireAspect()
+        weaponsmithPurchases.add(createTradeMap("CURSED_CLOCK", 1, 64, 4)); // ItemRegistry.getCursedClock()
         weaponsmithPurchases.add(createTradeMap("WEAPONSMITH_SMITE", 1, 64, 4)); // ItemRegistry.getWeaponsmithSmite()
         weaponsmithPurchases.add(createTradeMap("WEAPONSMITH_BANE_OF_ARTHROPODS", 1, 64, 4)); // ItemRegistry.getWeaponsmithBaneofAnthropods()
 
@@ -964,6 +965,8 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getWeaponsmithKnockback();
             case "WEAPONSMITH_FIRE_ASPECT":
                 return ItemRegistry.getWeaponsmithFireAspect();
+            case "CURSED_CLOCK":
+                return ItemRegistry.getCursedClock();
             case "WEAPONSMITH_SMITE":
                 return ItemRegistry.getWeaponsmithSmite();
             case "WEAPONSMITH_BANE_OF_ARTHROPODS":

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/MeritCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/MeritCommand.java
@@ -226,6 +226,11 @@ public class MeritCommand implements CommandExecutor, Listener {
                     Arrays.asList(
                             ChatColor.GRAY + "Displays two extra auction items.",
                             ChatColor.BLUE + "On Auction: " + ChatColor.GRAY + "2 bonus items with rare chance"
+                    )),
+            new Perk(ChatColor.DARK_GRAY + "Decay Mastery", 3, Material.WITHER_ROSE,
+                    Arrays.asList(
+                            ChatColor.GRAY + "Doubles Deterioration stacks.",
+                            ChatColor.BLUE + "On Hit: " + ChatColor.GRAY + "Decay stacks doubled."
                     ))
             );
 

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -1657,6 +1657,21 @@ public class ItemRegistry {
         );
     }
 
+    public static ItemStack getCursedClock() {
+        return createCustomItem(
+                Material.CLOCK,
+                ChatColor.YELLOW + "Cursed Clock",
+                Arrays.asList(
+                        ChatColor.GRAY + "A clock that ticks with decay.",
+                        ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Applies the Accelerate enchantment.",
+                        ChatColor.DARK_PURPLE + "Smithing Item"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
     public static ItemStack getBait() {
         return createCustomItem(
                 Material.OAK_BUTTON,


### PR DESCRIPTION
## Summary
- add `DeteriorationDamageHandler` to manage stacks and ticking damage
- support new damage indicator animations
- create `Accelerate` enchantment and register it
- add `Aspect of Decay` sword upgrade and GUI slot
- modify Decay pet perk to add stacks instead of periodic damage
- integrate merit perk `Decay Mastery` that doubles decay stacks
- sell `Cursed Clock` item and handle new villager trade
- apply stacks via upgrade, enchant, or perk

## Testing
- `mvn -q -DskipTests install` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858d47eee38833287f0ae9a8d1459b1