### PR TITLE
Add monster wave simulation command

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatSubsystemManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatSubsystemManager.java
@@ -11,6 +11,8 @@ import goat.minecraft.minecraftnew.subsystems.combat.damage.strategies.RangedDam
 import goat.minecraft.minecraftnew.subsystems.combat.commands.CombatReloadCommand;
 import goat.minecraft.minecraftnew.subsystems.combat.hostility.HostilityGUIController;
 import goat.minecraft.minecraftnew.subsystems.combat.hostility.HostilityService;
+import goat.minecraft.minecraftnew.subsystems.combat.bloodmoon.BloodmoonSpawnListener;
+import goat.minecraft.minecraftnew.subsystems.combat.bloodmoon.SimulateCommand;
 import goat.minecraft.minecraftnew.subsystems.combat.notification.DamageNotificationService;
 import goat.minecraft.minecraftnew.subsystems.combat.notification.PlayerFeedbackService;
 import goat.minecraft.minecraftnew.subsystems.combat.FireDamageHandler;
@@ -279,6 +281,8 @@ public class CombatSubsystemManager implements CommandExecutor {
         Bukkit.getPluginManager().registerEvents(hostilityGUIController, plugin);
         Bukkit.getPluginManager().registerEvents(fireDamageHandler, plugin);
         Bukkit.getPluginManager().registerEvents(decayDamageHandler, plugin);
+        // Register blood moon spawn overrides
+        Bukkit.getPluginManager().registerEvents(new BloodmoonSpawnListener(), plugin);
 
         logger.fine("Combat event listeners registered");
     }
@@ -288,10 +292,14 @@ public class CombatSubsystemManager implements CommandExecutor {
      */
     private void registerCommands() {
         plugin.getCommand("hostility").setExecutor(this);
-        
+
         // Register reload command if it exists in plugin.yml
         if (plugin.getCommand("combatreload") != null) {
             plugin.getCommand("combatreload").setExecutor(new CombatReloadCommand(this));
+        }
+
+        if (plugin.getCommand("simulate") != null) {
+            plugin.getCommand("simulate").setExecutor(new SimulateCommand(plugin));
         }
         
         logger.fine("Combat commands registered");

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/BloodmoonSpawnListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/BloodmoonSpawnListener.java
@@ -1,0 +1,32 @@
+package goat.minecraft.minecraftnew.subsystems.combat.bloodmoon;
+
+import org.bukkit.World;
+import org.bukkit.entity.EntityType;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.event.entity.PhantomPreSpawnEvent;
+
+public class BloodmoonSpawnListener implements Listener {
+
+    @EventHandler
+    public void onPhantomSpawn(PhantomPreSpawnEvent event) {
+        event.setCancelled(true);
+    }
+
+    @EventHandler
+    public void onCreatureSpawn(CreatureSpawnEvent event) {
+        if (event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.NATURAL) return;
+        EntityType type = event.getEntityType();
+        if (type == EntityType.ZOMBIE || type == EntityType.SKELETON ||
+            type == EntityType.SPIDER || type == EntityType.CREEPER) {
+            World world = event.getLocation().getWorld();
+            if (world != null) {
+                long time = world.getTime() % 24000;
+                if (time >= 13000 && time <= 23000) {
+                    event.setCancelled(true);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/Range.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/Range.java
@@ -1,0 +1,25 @@
+package goat.minecraft.minecraftnew.subsystems.combat.bloodmoon;
+
+import java.util.Random;
+
+public class Range {
+    private final int min;
+    private final int max;
+
+    public Range(int min, int max) {
+        this.min = min;
+        this.max = max;
+    }
+
+    public int getMin() {
+        return min;
+    }
+
+    public int getMax() {
+        return max;
+    }
+
+    public int random(Random random) {
+        return min + random.nextInt(max - min + 1);
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/SimulateCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/SimulateCommand.java
@@ -1,0 +1,39 @@
+package goat.minecraft.minecraftnew.subsystems.combat.bloodmoon;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class SimulateCommand implements CommandExecutor {
+
+    private final WaveManager waveManager;
+
+    public SimulateCommand(JavaPlugin plugin) {
+        this.waveManager = new WaveManager(plugin);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("This command can only be used by players.");
+            return true;
+        }
+        if (args.length < 1) {
+            player.sendMessage(ChatColor.RED + "Usage: /simulate <skirmish|clash|assault|onslaught|carnage>");
+            return true;
+        }
+        WaveDifficulty diff;
+        try {
+            diff = WaveDifficulty.valueOf(args[0].toUpperCase());
+        } catch (IllegalArgumentException e) {
+            player.sendMessage(ChatColor.RED + "Unknown difficulty type.");
+            return true;
+        }
+        waveManager.startSimulation(player, diff);
+        player.sendMessage(ChatColor.GREEN + "Starting simulation: " + diff.name().toLowerCase());
+        return true;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/WaveDifficulty.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/WaveDifficulty.java
@@ -1,0 +1,9 @@
+package goat.minecraft.minecraftnew.subsystems.combat.bloodmoon;
+
+public enum WaveDifficulty {
+    SKIRMISH,
+    CLASH,
+    ASSAULT,
+    ONSLAUGHT,
+    CARNAGE
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/WaveManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/WaveManager.java
@@ -1,0 +1,149 @@
+package goat.minecraft.minecraftnew.subsystems.combat.bloodmoon;
+
+import org.bukkit.*;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.*;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+public class WaveManager {
+    private static final Range FAR_RANGE = new Range(60,80);
+    private static final Range MID_RANGE = new Range(40,60);
+
+    private final JavaPlugin plugin;
+    private final Random random = new Random();
+
+    public WaveManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void startSimulation(Player player, WaveDifficulty difficulty) {
+        player.getWorld().setTime(18000L);
+        new BukkitRunnable() {
+            int count = 0;
+            @Override
+            public void run() {
+                if (!player.isOnline()) { cancel(); return; }
+                if (difficulty == WaveDifficulty.CARNAGE && count >= 15) { cancel(); return; }
+                launchWave(player, difficulty);
+                count++;
+            }
+        }.runTaskTimer(plugin, 0L, 20L * 60L);
+    }
+
+    private void launchWave(Player player, WaveDifficulty difficulty) {
+        switch (difficulty) {
+            case SKIRMISH -> {
+                for (int i=0;i<3;i++) spawnGroup(player,4,8,FAR_RANGE,false);
+            }
+            case CLASH -> {
+                for (int i=0;i<3;i++) spawnGroup(player,8,12,MID_RANGE,false);
+            }
+            case ASSAULT -> spawnGroup(player,20,40,FAR_RANGE,true);
+            case ONSLAUGHT -> {
+                for (int i=0;i<2;i++) spawnGroup(player,20,40,MID_RANGE,true);
+            }
+            case CARNAGE -> {
+                for (int i=0;i<5;i++) spawnGroup(player,20,20,MID_RANGE,true);
+            }
+        }
+    }
+
+    private void spawnGroup(Player player, int min, int max, Range range, boolean pathfind) {
+        Location base = findOptimalMonsterNode(player, range);
+        if (base == null) return;
+        int amount = random.nextInt(max - min + 1) + min;
+        for (int i=0;i<amount;i++) {
+            EntityType type = pickMonsterType();
+            Monster mob = (Monster) player.getWorld().spawnEntity(base, type);
+            if (pathfind) mob.setTarget(player);
+        }
+        spawnCaptain(player, base, pathfind);
+    }
+
+    private EntityType pickMonsterType() {
+        if (random.nextDouble() < 0.2) return EntityType.CREEPER;
+        List<EntityType> list = Arrays.asList(EntityType.ZOMBIE, EntityType.SKELETON, EntityType.SPIDER);
+        return list.get(random.nextInt(list.size()));
+    }
+
+    private void spawnCaptain(Player player, Location base, boolean pathfind) {
+        WitherSkeleton captain = (WitherSkeleton) player.getWorld().spawnEntity(base, EntityType.WITHER_SKELETON);
+        captain.setCustomName(ChatColor.DARK_RED + "Captain");
+        captain.setCustomNameVisible(true);
+        ItemStack helm = enchanted(Material.NETHERITE_HELMET);
+        ItemStack chest = enchanted(Material.NETHERITE_CHESTPLATE);
+        ItemStack legs = enchanted(Material.NETHERITE_LEGGINGS);
+        ItemStack boots = enchanted(Material.NETHERITE_BOOTS);
+        captain.getEquipment().setHelmet(helm);
+        captain.getEquipment().setChestplate(chest);
+        captain.getEquipment().setLeggings(legs);
+        captain.getEquipment().setBoots(boots);
+        captain.getEquipment().setHelmetDropChance(0f);
+        captain.getEquipment().setChestplateDropChance(0f);
+        captain.getEquipment().setLeggingsDropChance(0f);
+        captain.getEquipment().setBootsDropChance(0f);
+        if (pathfind) captain.setTarget(player);
+    }
+
+    private ItemStack enchanted(Material mat) {
+        ItemStack stack = new ItemStack(mat);
+        ItemMeta meta = stack.getItemMeta();
+        if (meta != null) {
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 4, true);
+            stack.setItemMeta(meta);
+        }
+        return stack;
+    }
+
+    public Location findOptimalMonsterNode(Player player, Range range) {
+        World world = player.getWorld();
+        Location best = null;
+        double bestScore = Double.MAX_VALUE;
+        for (int i=0;i<40;i++) {
+            double angle = random.nextDouble()*Math.PI*2;
+            double radius = range.random(random);
+            int x = player.getLocation().getBlockX() + (int)(Math.cos(angle)*radius);
+            int z = player.getLocation().getBlockZ() + (int)(Math.sin(angle)*radius);
+            int y = world.getHighestBlockYAt(x, z);
+            Location loc = new Location(world, x + 0.5, y, z + 0.5);
+            if (!isValidSpawnLocation(loc)) continue;
+            double var = terrainVariance(world, x, z);
+            if (var < bestScore) {
+                bestScore = var;
+                best = loc;
+            }
+        }
+        return best;
+    }
+
+    private boolean isValidSpawnLocation(Location loc) {
+        if (loc.getBlock().isLiquid()) return false;
+        if (loc.getBlock().getLightLevel() > 7) return false;
+        for (int dx=-1;dx<=1;dx++) {
+            for (int dz=-1;dz<=1;dz++) {
+                if (loc.clone().add(dx,0,dz).getBlock().isLiquid()) return false;
+            }
+        }
+        return true;
+    }
+
+    private double terrainVariance(World world, int baseX, int baseZ) {
+        int minY = Integer.MAX_VALUE;
+        int maxY = Integer.MIN_VALUE;
+        for (int dx=-1;dx<=1;dx++) {
+            for (int dz=-1;dz<=1;dz++) {
+                int y = world.getHighestBlockYAt(baseX+dx, baseZ+dz);
+                minY = Math.min(minY, y);
+                maxY = Math.max(maxY, y);
+            }
+        }
+        return maxY - minY;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -152,3 +152,7 @@ commands:
     description: Teleports the player to the specified world
     usage: /warp <worldname>
     permission: continuity.admin
+  simulate:
+    description: Spawns waves of monsters for testing
+    usage: /simulate <skirmish|clash|assault|onslaught|carnage>
+    permission: continuity.admin


### PR DESCRIPTION
## Summary
- add bloodmoon package with range and wave logic
- spawn override listener to cancel normal night mobs
- add `/simulate` command with several wave difficulties
- register new listener and command via CombatSubsystemManager
- document command in plugin.yml

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858e66d6ef083328242dafafa759598