### PR TITLE
Add assault wave system

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatSubsystemManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatSubsystemManager.java
@@ -11,6 +11,10 @@ import goat.minecraft.minecraftnew.subsystems.combat.damage.strategies.RangedDam
 import goat.minecraft.minecraftnew.subsystems.combat.commands.CombatReloadCommand;
 import goat.minecraft.minecraftnew.subsystems.combat.hostility.HostilityGUIController;
 import goat.minecraft.minecraftnew.subsystems.combat.hostility.HostilityService;
+import goat.minecraft.minecraftnew.subsystems.combat.bloodmoon.BloodmoonSpawnListener;
+import goat.minecraft.minecraftnew.subsystems.combat.bloodmoon.SimulateCommand;
+import goat.minecraft.minecraftnew.subsystems.combat.bloodmoon.SkipCommand;
+import goat.minecraft.minecraftnew.subsystems.combat.bloodmoon.AssaultWaveListener;
 import goat.minecraft.minecraftnew.subsystems.combat.notification.DamageNotificationService;
 import goat.minecraft.minecraftnew.subsystems.combat.notification.PlayerFeedbackService;
 import goat.minecraft.minecraftnew.subsystems.combat.FireDamageHandler;
@@ -279,6 +283,9 @@ public class CombatSubsystemManager implements CommandExecutor {
         Bukkit.getPluginManager().registerEvents(hostilityGUIController, plugin);
         Bukkit.getPluginManager().registerEvents(fireDamageHandler, plugin);
         Bukkit.getPluginManager().registerEvents(decayDamageHandler, plugin);
+        // Register blood moon spawn overrides
+        Bukkit.getPluginManager().registerEvents(new BloodmoonSpawnListener(), plugin);
+        Bukkit.getPluginManager().registerEvents(new AssaultWaveListener(), plugin);
 
         logger.fine("Combat event listeners registered");
     }
@@ -288,12 +295,20 @@ public class CombatSubsystemManager implements CommandExecutor {
      */
     private void registerCommands() {
         plugin.getCommand("hostility").setExecutor(this);
-        
+
         // Register reload command if it exists in plugin.yml
         if (plugin.getCommand("combatreload") != null) {
             plugin.getCommand("combatreload").setExecutor(new CombatReloadCommand(this));
         }
-        
+
+        if (plugin.getCommand("simulate") != null) {
+            plugin.getCommand("simulate").setExecutor(new SimulateCommand(plugin));
+        }
+
+        if (plugin.getCommand("skip") != null) {
+            plugin.getCommand("skip").setExecutor(new SkipCommand(plugin));
+        }
+
         logger.fine("Combat commands registered");
     }
     

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/AssaultWaveListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/AssaultWaveListener.java
@@ -1,0 +1,25 @@
+package goat.minecraft.minecraftnew.subsystems.combat.bloodmoon;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
+
+/**
+ * Forwards combat events to the AssaultWaveManager.
+ */
+public class AssaultWaveListener implements Listener {
+
+    @EventHandler
+    public void onEntityDamage(EntityDamageByEntityEvent event) {
+        AssaultWaveManager manager = AssaultWaveManager.getInstance(MinecraftNew.getInstance());
+        manager.onWaveEntityDamaged(event.getEntity());
+    }
+
+    @EventHandler
+    public void onEntityDeath(EntityDeathEvent event) {
+        AssaultWaveManager manager = AssaultWaveManager.getInstance(MinecraftNew.getInstance());
+        manager.onWaveEntityDamaged(event.getEntity());
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/AssaultWaveManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/AssaultWaveManager.java
@@ -1,0 +1,259 @@
+package goat.minecraft.minecraftnew.subsystems.combat.bloodmoon;
+
+import me.gamercoder215.mobchip.EntityBrain;
+import me.gamercoder215.mobchip.bukkit.BukkitBrain;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.entity.*;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.*;
+import java.util.logging.Logger;
+
+/**
+ * Spawns and manages repeating assault waves for a single player.
+ */
+public class AssaultWaveManager {
+
+    private static AssaultWaveManager instance;
+
+    public static AssaultWaveManager getInstance(JavaPlugin plugin) {
+        if (instance == null) {
+            instance = new AssaultWaveManager(plugin);
+        }
+        return instance;
+    }
+
+    private final JavaPlugin plugin;
+    private final Logger logger;
+    private final Random random = new Random();
+    private final Range spawnRange = new Range(60, 80);
+
+    private Player player;
+    private int waveNumber = 0;
+    private List<Monster> currentWave = new ArrayList<>();
+    private Location waveOrigin;
+    private long lastCombatTime;
+    private boolean resting = false;
+    private boolean highlighted = false;
+
+    private BukkitRunnable monitorTask;
+
+    private AssaultWaveManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.logger = plugin.getLogger();
+    }
+
+    public void start(Player player) {
+        if (monitorTask != null) {
+            monitorTask.cancel();
+        }
+        this.player = player;
+        this.waveNumber = 0;
+        this.resting = false;
+        this.highlighted = false;
+        this.currentWave.clear();
+        player.getWorld().setTime(18000L);
+        spawnNextWave();
+        monitorTask = new MonitorTask();
+        monitorTask.runTaskTimer(plugin, 20L, 20L);
+    }
+
+    public void skipRest() {
+        if (resting) {
+            resting = false;
+            spawnNextWave();
+        }
+    }
+
+    private void spawnNextWave() {
+        highlighted = false;
+        waveNumber++;
+        int extra = (waveNumber - 1) * 2;
+        waveOrigin = findOptimalMonsterNode(player, spawnRange);
+        if (waveOrigin == null) {
+            logger.warning("[Bloodmoon] Could not find spawn location for wave");
+            return;
+        }
+        logger.info("[Bloodmoon] Spawning assault wave #" + waveNumber + " for " + player.getName());
+        List<SpawnRequest> mobs = buildDistribution(extra);
+        for (SpawnRequest req : mobs) {
+            for (int i = 0; i < req.count; i++) {
+                Location loc = offset(waveOrigin, req.radius).add(0, 1, 0);
+                Monster m = (Monster) player.getWorld().spawnEntity(loc, req.type);
+                if (m instanceof Zombie zombie) {
+                    zombie.setCanPickupItems(false);
+                }
+                if (m instanceof Skeleton skeleton) {
+                    pathfind(skeleton, player.getLocation());
+                } else {
+                    m.setTarget(player);
+                }
+                currentWave.add(m);
+            }
+        }
+        lastCombatTime = System.currentTimeMillis();
+    }
+
+    private List<SpawnRequest> buildDistribution(int extra) {
+        int zombies = 6;
+        int skeletons = 4;
+        int spiders = 4;
+        int creepers = 1;
+        if (random.nextDouble() < 0.1) {
+            int total = zombies + skeletons + spiders + creepers;
+            zombies = skeletons = spiders = creepers = 0;
+            for (int i = 0; i < total; i++) {
+                switch (pickMonsterType()) {
+                    case ZOMBIE -> zombies++;
+                    case SKELETON -> skeletons++;
+                    case SPIDER -> spiders++;
+                    case CREEPER -> creepers++;
+                }
+            }
+        }
+        for (int i = 0; i < extra; i++) {
+            switch (pickMonsterType()) {
+                case ZOMBIE -> zombies++;
+                case SKELETON -> skeletons++;
+                case SPIDER -> spiders++;
+                case CREEPER -> creepers++;
+            }
+        }
+        return Arrays.asList(
+            new SpawnRequest(EntityType.SPIDER, spiders, 2),
+            new SpawnRequest(EntityType.ZOMBIE, zombies, 5),
+            new SpawnRequest(EntityType.CREEPER, creepers, 5),
+            new SpawnRequest(EntityType.SKELETON, skeletons, 8)
+        );
+    }
+
+    private EntityType pickMonsterType() {
+        double d = random.nextDouble();
+        if (d < 0.25) return EntityType.CREEPER;
+        if (d < 0.5) return EntityType.SPIDER;
+        if (d < 0.75) return EntityType.SKELETON;
+        return EntityType.ZOMBIE;
+    }
+
+    private Location offset(Location base, double radius) {
+        double angle = random.nextDouble() * Math.PI * 2;
+        return base.clone().add(Math.cos(angle) * radius, 0, Math.sin(angle) * radius);
+    }
+
+    private void pathfind(Monster mob, Location to) {
+        EntityBrain brain = BukkitBrain.getBrain(mob);
+        if (brain != null) {
+            brain.getController().moveTo(to);
+        }
+    }
+
+    private class MonitorTask extends BukkitRunnable {
+        @Override
+        public void run() {
+            if (player == null || !player.isOnline()) {
+                cancel();
+                return;
+            }
+            if (player.isDead() || player.isSleeping()) {
+                clearCurrentWave();
+                cancel();
+                return;
+            }
+            if (waveOrigin != null && player.getLocation().distanceSquared(waveOrigin) > 2500) {
+                clearCurrentWave();
+                cancel();
+                return;
+            }
+            currentWave.removeIf(m -> m.isDead() || !m.isValid());
+            if (currentWave.isEmpty()) {
+                if (!resting) {
+                    resting = true;
+                    player.sendMessage(ChatColor.GREEN + "Wave cleared! Next wave in 30 seconds. Click to skip: "
+                            + ChatColor.AQUA + ChatColor.UNDERLINE + "/skip");
+                    Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                        if (resting) {
+                            resting = false;
+                            spawnNextWave();
+                        }
+                    }, 20L * 30);
+                }
+                return;
+            }
+            long now = System.currentTimeMillis();
+            if (now - lastCombatTime > 30000 && !highlighted) {
+                highlighted = true;
+                for (Monster m : currentWave) {
+                    m.setGlowing(true);
+                }
+            }
+            if (highlighted && now - lastCombatTime > 60000) {
+                clearCurrentWave();
+                spawnNextWave();
+            }
+        }
+    }
+
+    private void clearCurrentWave() {
+        for (Monster m : currentWave) {
+            if (m.isValid()) m.remove();
+        }
+        currentWave.clear();
+    }
+
+    public void onWaveEntityDamaged(Entity entity) {
+        if (entity instanceof Monster mob && currentWave.contains(mob)) {
+            lastCombatTime = System.currentTimeMillis();
+            if (highlighted) mob.setGlowing(false);
+            highlighted = false;
+        }
+    }
+
+    public Location findOptimalMonsterNode(Player player, Range range) {
+        Location best = null;
+        double bestScore = Double.MAX_VALUE;
+        for (int i = 0; i < 40; i++) {
+            double angle = random.nextDouble() * Math.PI * 2;
+            double radius = range.random(random);
+            int x = player.getLocation().getBlockX() + (int) (Math.cos(angle) * radius);
+            int z = player.getLocation().getBlockZ() + (int) (Math.sin(angle) * radius);
+            int y = player.getWorld().getHighestBlockYAt(x, z);
+            Location loc = new Location(player.getWorld(), x + 0.5, y, z + 0.5);
+            if (!isValidSpawnLocation(loc)) continue;
+            double var = terrainVariance(player.getWorld(), x, z);
+            if (var < bestScore) {
+                bestScore = var;
+                best = loc;
+            }
+        }
+        return best;
+    }
+
+    private boolean isValidSpawnLocation(Location loc) {
+        if (loc.getBlock().isLiquid()) return false;
+        if (loc.getBlock().getLightLevel() > 7) return false;
+        for (int dx = -1; dx <= 1; dx++) {
+            for (int dz = -1; dz <= 1; dz++) {
+                if (loc.clone().add(dx, 0, dz).getBlock().isLiquid()) return false;
+            }
+        }
+        return true;
+    }
+
+    private double terrainVariance(World world, int baseX, int baseZ) {
+        int minY = Integer.MAX_VALUE;
+        int maxY = Integer.MIN_VALUE;
+        for (int dx = -1; dx <= 1; dx++) {
+            for (int dz = -1; dz <= 1; dz++) {
+                int y = world.getHighestBlockYAt(baseX + dx, baseZ + dz);
+                minY = Math.min(minY, y);
+                maxY = Math.max(maxY, y);
+            }
+        }
+        return maxY - minY;
+    }
+
+    private record SpawnRequest(EntityType type, int count, double radius) {}
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/BloodmoonSpawnListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/BloodmoonSpawnListener.java
@@ -1,0 +1,32 @@
+package goat.minecraft.minecraftnew.subsystems.combat.bloodmoon;
+
+import org.bukkit.World;
+import org.bukkit.entity.EntityType;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.event.entity.PhantomPreSpawnEvent;
+
+public class BloodmoonSpawnListener implements Listener {
+
+    @EventHandler
+    public void onPhantomSpawn(PhantomPreSpawnEvent event) {
+        event.setCancelled(true);
+    }
+
+    @EventHandler
+    public void onCreatureSpawn(CreatureSpawnEvent event) {
+        if (event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.NATURAL) return;
+        EntityType type = event.getEntityType();
+        if (type == EntityType.ZOMBIE || type == EntityType.SKELETON ||
+            type == EntityType.SPIDER || type == EntityType.CREEPER) {
+            World world = event.getLocation().getWorld();
+            if (world != null) {
+                long time = world.getTime() % 24000;
+                if (time >= 13000 && time <= 23000) {
+                    event.setCancelled(true);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/Range.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/Range.java
@@ -1,0 +1,25 @@
+package goat.minecraft.minecraftnew.subsystems.combat.bloodmoon;
+
+import java.util.Random;
+
+public class Range {
+    private final int min;
+    private final int max;
+
+    public Range(int min, int max) {
+        this.min = min;
+        this.max = max;
+    }
+
+    public int getMin() {
+        return min;
+    }
+
+    public int getMax() {
+        return max;
+    }
+
+    public int random(Random random) {
+        return min + random.nextInt(max - min + 1);
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/SimulateCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/SimulateCommand.java
@@ -1,0 +1,29 @@
+package goat.minecraft.minecraftnew.subsystems.combat.bloodmoon;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class SimulateCommand implements CommandExecutor {
+
+    private final JavaPlugin plugin;
+
+    public SimulateCommand(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("This command can only be used by players.");
+            return true;
+        }
+        AssaultWaveManager.getInstance(plugin).start(player);
+        player.sendMessage(ChatColor.GREEN + "Starting assault simulation");
+        return true;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/SkipCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodmoon/SkipCommand.java
@@ -1,0 +1,29 @@
+package goat.minecraft.minecraftnew.subsystems.combat.bloodmoon;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class SkipCommand implements CommandExecutor {
+
+    private final JavaPlugin plugin;
+
+    public SkipCommand(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("This command can only be used by players.");
+            return true;
+        }
+        AssaultWaveManager.getInstance(plugin).skipRest();
+        player.sendMessage(ChatColor.YELLOW + "Skipping rest phase.");
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -152,3 +152,10 @@ commands:
     description: Teleports the player to the specified world
     usage: /warp <worldname>
     permission: continuity.admin
+  simulate:
+    description: Spawns assault waves for testing
+    usage: /simulate
+    permission: continuity.admin
+  skip:
+    description: Skip the wave rest period
+    usage: /skip


### PR DESCRIPTION
## Summary
- remove old wave behavior classes
- add `AssaultWaveManager` to spawn repeating assault waves
- integrate new `AssaultWaveListener` and `/skip` command
- update `/simulate` command to start assault simulation only
- register new commands and event listener

## Testing
- ❌ `mvn -q -DskipTests package` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858e66d6ef083328242dafafa759598