### PR TITLE
Fix brew time for recurve potion

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
@@ -249,7 +249,7 @@ public class PotionBrewingSubsystem implements Listener {
         List<String> recurveLore = Arrays.asList("Increases arrow damage by 25%", "Base Duration of " + baseDuration);
         Color recurveColor = Color.fromRGB(0, 0, 0); // A sleek violet-tinted archery vibe
         recipeRegistry.add(
-                new PotionRecipe("Potion of Recurve", recurveIngredients, 5, new ItemStack(Material.POTION), recurveColor, recurveLore)
+                new PotionRecipe("Potion of Recurve", recurveIngredients, 60*10, new ItemStack(Material.POTION), recurveColor, recurveLore)
         );
 
         // Potion of Solar Fury


### PR DESCRIPTION
## Summary
- align `Potion of Recurve` brew time with other potions

## Testing
- `mvn -q test` *(fails: Could not resolve maven plugin due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6859dbe936288332857f4062fb955eb2