### PR TITLE
Fix deterioration stack damage and indicator duration

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/DeteriorationDamageHandler.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/DeteriorationDamageHandler.java
@@ -1,7 +1,6 @@
 package goat.minecraft.minecraftnew.subsystems.combat;
 
 import goat.minecraft.minecraftnew.subsystems.combat.notification.DamageNotificationService;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Monster;
@@ -17,6 +16,9 @@ import java.util.concurrent.ConcurrentHashMap;
  * Handles the Deterioration stacking damage over time.
  */
 public class DeteriorationDamageHandler implements Listener {
+
+    /** Damage applied per deterioration stack each tick. */
+    private static final double DAMAGE_PER_STACK = 0.5;
 
     private static DeteriorationDamageHandler instance;
 
@@ -70,9 +72,8 @@ public class DeteriorationDamageHandler implements Listener {
                     return;
                 }
 
-                double damage = level;
-                double newHealth = Math.max(0.0, entity.getHealth() - damage);
-                entity.setHealth(newHealth);
+                double damage = level * DAMAGE_PER_STACK;
+                entity.damage(damage);
                 notificationService.createDecayDamageIndicator(entity.getLocation(), damage);
                 stacks.put(id, level - 1);
             }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/notification/DamageNotificationService.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/notification/DamageNotificationService.java
@@ -335,7 +335,7 @@ public class DamageNotificationService {
                 cleanup();
                 return;
             }
-            if (ticks >= 5) {
+            if (ticks >= 20) {
                 cleanup();
                 return;
             }


### PR DESCRIPTION
## Summary
- apply a scaling factor for deterioration damage
- use damage API instead of directly setting health
- extend decay damage indicator animation from 5 to 20 ticks

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6859db11b8688332a6e250887a39cdab