### PR TITLE
Fix beacon passive stacking and mending bonus

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/BeaconPassiveEffects.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/BeaconPassiveEffects.java
@@ -60,11 +60,11 @@ public class BeaconPassiveEffects implements Listener {
     private void applyMendingEffect(Player player) {
         UUID playerId = player.getUniqueId();
         if (!mendingApplied.getOrDefault(playerId, false)) {
-            // Increase max health by 1 row of hearts (10 health points)
+            // Increase max health by 20 (10 hearts)
             AttributeInstance maxHealth = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
             if (maxHealth != null) {
                 double currentMax = maxHealth.getBaseValue();
-                double newMax = currentMax + 20.0; // Add 10 health (1 row of hearts)
+                double newMax = currentMax + 20.0; // +20 health
                 maxHealth.setBaseValue(newMax);
                 player.setHealth(Math.min(player.getHealth() + 20.0, newMax));
             }
@@ -75,12 +75,12 @@ public class BeaconPassiveEffects implements Listener {
     private void removeMendingEffect(Player player) {
         UUID playerId = player.getUniqueId();
         if (mendingApplied.getOrDefault(playerId, false)) {
-            // Remove the 10 health bonus
+            // Remove the 20 health bonus
             AttributeInstance maxHealth = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
             if (maxHealth != null) {
                 double currentHealth = player.getHealth();
                 double currentMax = maxHealth.getBaseValue();
-                double newMax = currentMax - 20.0; // Remove 10 health
+                double newMax = currentMax - 20.0; // Remove 20 health
                 maxHealth.setBaseValue(newMax);
                 player.setHealth(Math.min(currentHealth, newMax));
             }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/BeaconPassivesGUI.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/BeaconPassivesGUI.java
@@ -264,6 +264,10 @@ public class BeaconPassivesGUI implements Listener {
         if (passivesConfig == null) return;
         Map<String, Boolean> passives = playerPassives.get(uuid);
         if (passives == null) return;
+
+        // Clear existing entries to prevent multiple passives being stored
+        passivesConfig.set(uuid.toString(), null);
+
         for (Map.Entry<String, Boolean> entry : passives.entrySet()) {
             passivesConfig.set(uuid.toString() + "." + entry.getKey(), entry.getValue());
         }
@@ -282,6 +286,17 @@ public class BeaconPassivesGUI implements Listener {
             for (String key : section.getKeys(false)) {
                 map.put(key, section.getBoolean(key, false));
             }
+            // Ensure only one passive is active
+            String active = null;
+            for (Map.Entry<String, Boolean> entry : map.entrySet()) {
+                if (entry.getValue()) {
+                    if (active == null) {
+                        active = entry.getKey();
+                    } else {
+                        entry.setValue(false);
+                    }
+                }
+            }
             playerPassives.put(uuid, map);
         }
     }
@@ -290,6 +305,8 @@ public class BeaconPassivesGUI implements Listener {
         if (passivesConfig == null) return;
         for (UUID uuid : playerPassives.keySet()) {
             Map<String, Boolean> passives = playerPassives.get(uuid);
+            // Remove old entries
+            passivesConfig.set(uuid.toString(), null);
             for (Map.Entry<String, Boolean> entry : passives.entrySet()) {
                 passivesConfig.set(uuid.toString() + "." + entry.getKey(), entry.getValue());
             }


### PR DESCRIPTION
## Summary
- ensure beacon passive YAML only stores one active entry
- normalise saved passives on load so only one is enabled
- clarify mending bonus and fix removal comment

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6859e1b8f65483328d676e1cab5a0ffc