### PR TITLE
Adjust entropy relic drop chance

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SpawnMonsters.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SpawnMonsters.java
@@ -668,11 +668,9 @@ public class SpawnMonsters implements Listener {
             if (killer != null) {
                 xpManager.addXP(killer, "Combat", 100);
                 event.setDroppedExp(100);
-                if(random.nextBoolean()) {
-                    if(random.nextBoolean()) {
-                        killer.sendMessage(ChatColor.AQUA + "You found a " + ChatColor.GOLD + "Verdant Relic: Entropy!");
-                        Objects.requireNonNull(monster.getLocation().getWorld()).dropItem(monster.getLocation(), ItemRegistry.getVerdantRelicEntropySeed());
-                    }
+                if(random.nextDouble() < 0.125) {
+                    killer.sendMessage(ChatColor.AQUA + "You found a " + ChatColor.GOLD + "Verdant Relic: Entropy!");
+                    Objects.requireNonNull(monster.getLocation().getWorld()).dropItem(monster.getLocation(), ItemRegistry.getVerdantRelicEntropySeed());
                 }
             }
         }


### PR DESCRIPTION
## Summary
- reduce drop chance of the Entropy relic from speed mutants

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e41e09f48332ab173f2dc5cf6310