### PR TITLE
Implement Enchanted Lava Bucket trinket

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -60,6 +60,7 @@ import goat.minecraft.minecraftnew.utils.dimensions.end.BetterEnd;
 import goat.minecraft.minecraftnew.other.trinkets.BankAccountManager;
 import goat.minecraft.minecraftnew.other.trinkets.SatchelManager;
 import goat.minecraft.minecraftnew.other.trinkets.SeedPouchManager;
+import goat.minecraft.minecraftnew.other.trinkets.LavaBucketManager;
 import goat.minecraft.minecraftnew.other.trinkets.TrinketManager;
 
 import goat.minecraft.minecraftnew.subsystems.music.PigStepArena;
@@ -278,6 +279,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         BankAccountManager.init(this);
         SatchelManager.init(this);
         SeedPouchManager.init(this);
+        LavaBucketManager.init(this);
         TrinketManager.init(this);
         //getServer().getPluginManager().registerEvents(new GamblingTable(this), this);
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/LavaBucketManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/LavaBucketManager.java
@@ -1,0 +1,41 @@
+package goat.minecraft.minecraftnew.other.trinkets;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class LavaBucketManager implements Listener {
+    private static LavaBucketManager instance;
+    private final JavaPlugin plugin;
+
+    private LavaBucketManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    public static void init(JavaPlugin plugin) {
+        if (instance == null) {
+            instance = new LavaBucketManager(plugin);
+        }
+    }
+
+    public static LavaBucketManager getInstance() {
+        return instance;
+    }
+
+    public void openTrash(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 54, "Lava Bucket");
+        player.openInventory(inv);
+    }
+
+    @EventHandler
+    public void onClose(InventoryCloseEvent event) {
+        if (event.getView().getTitle().equals("Lava Bucket")) {
+            event.getInventory().clear();
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TrinketManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TrinketManager.java
@@ -101,6 +101,15 @@ public class TrinketManager implements Listener {
                     event.setCancelled(true);
                 }
             }
+            case "Enchanted Lava Bucket" -> {
+                if (event.getClick() == ClickType.LEFT && event.getCursor() != null && event.getCursor().getType() != Material.AIR) {
+                    event.getWhoClicked().setItemOnCursor(null);
+                    event.setCancelled(true);
+                } else if (event.getClick() == ClickType.SHIFT_RIGHT) {
+                    LavaBucketManager.getInstance().openTrash(player);
+                    event.setCancelled(true);
+                }
+            }
         }
     }
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -365,6 +365,7 @@ public class VillagerTradeManager implements Listener {
         leatherworkerPurchases.add(createTradeMap("BLACK_SATCHEL", 1, 90, 3));
         leatherworkerPurchases.add(createTradeMap("GREEN_SATCHEL", 1, 90, 3));
         leatherworkerPurchases.add(createTradeMap("POUCH_OF_SEEDS", 1, 90, 3));
+        leatherworkerPurchases.add(createTradeMap("ENCHANTED_LAVA_BUCKET_TRINKET", 1, 90, 3));
         leatherworkerPurchases.add(createTradeMap("SHULKER_SHELL", 1, 64, 3)); // Material
         leatherworkerPurchases.add(createTradeMap("ANVIL_TRINKET", 1, 90, 4));
 
@@ -865,6 +866,8 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getGreenSatchelTrinket();
             case "POUCH_OF_SEEDS":
                 return ItemRegistry.getSeedPouchTrinket();
+            case "ENCHANTED_LAVA_BUCKET_TRINKET":
+                return ItemRegistry.getEnchantedLavaBucketTrinket();
             case "CLERIC_ENCHANT":
                 return ItemRegistry.getClericEnchant();
             case "SUNFLARE":

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -1105,6 +1105,20 @@ public class ItemRegistry {
         );
     }
 
+    public static ItemStack getEnchantedLavaBucketTrinket() {
+        return createCustomItem(
+                Material.LAVA_BUCKET,
+                ChatColor.YELLOW + "Enchanted Lava Bucket",
+                List.of(
+                        ChatColor.BLUE + "Left-click" + ChatColor.GRAY + ": Trash cursor item",
+                        ChatColor.BLUE + "Shift-Right-click" + ChatColor.GRAY + ": Open trash"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
     public static ItemStack getClericEnchant() {
         return createCustomItem(Material.SUGAR_CANE, ChatColor.YELLOW +
                 "Alchemical Bundle", Arrays.asList(


### PR DESCRIPTION
## Summary
- add `getEnchantedLavaBucketTrinket` to `ItemRegistry`
- create `LavaBucketManager` for trash inventory
- handle new trinket in `TrinketManager`
- register manager in `MinecraftNew`
- expose trinket through villager trades

## Testing
- `mvn -q -DskipTests=false test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ee378f8c8332a0c20419b64d3c30