### PR TITLE
Fix seed pouch inventory check

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/SeedPouchManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/SeedPouchManager.java
@@ -133,6 +133,9 @@ public class SeedPouchManager implements Listener {
     @EventHandler
     public void onClick(InventoryClickEvent event) {
         if (!event.getView().getTitle().equals("Seed Pouch")) return;
+        if (event.getClickedInventory() == null || event.getClickedInventory() != event.getInventory()) {
+            return;
+        }
         event.setCancelled(true);
         ItemStack clicked = event.getCurrentItem();
         if (clicked == null || clicked.getType() == Material.AIR || clicked.getType() == Material.GRAY_STAINED_GLASS_PANE) return;


### PR DESCRIPTION
## Summary
- avoid item dupe when clicking personal inventory while pouch GUI open

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact maven-resources-plugin due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6859f23ed4a483328a0f4d800dcc8e37