### PR TITLE
Fix zombie drops clearing held items

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/KillMonster.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/KillMonster.java
@@ -15,6 +15,8 @@ import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.Material;
 
 import java.util.Random;
 
@@ -104,7 +106,18 @@ public class KillMonster implements Listener {
                         }
                     }
                 }
-                if (random.nextInt(100) < 20) {
+                boolean allowNormalDrops = random.nextInt(100) < 20;
+                if (!allowNormalDrops && entity instanceof Zombie zombie) {
+                    ItemStack main = zombie.getEquipment().getItemInMainHand();
+                    if (main != null && main.getType() != Material.AIR) {
+                        zombie.getWorld().dropItemNaturally(zombie.getLocation(), main.clone());
+                    }
+                    ItemStack off = zombie.getEquipment().getItemInOffHand();
+                    if (off != null && off.getType() != Material.AIR) {
+                        zombie.getWorld().dropItemNaturally(zombie.getLocation(), off.clone());
+                    }
+                }
+                if (allowNormalDrops) {
                     return; // Allow normal drops
                 } else {
                     e.getDrops().clear();


### PR DESCRIPTION
## Summary
- ensure zombies always drop their held items when drops are cleared

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6859f54a74a48332bcfd088dbe10b761