### PR TITLE
Remove unwanted items from fishing drops and trades

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureRegistry.java
@@ -113,9 +113,8 @@ public class SeaCreatureRegistry implements Listener {
         ));
         List<SeaCreature.DropItem> luminescentDrownedDrops = new ArrayList<>();
         luminescentDrownedDrops.add(new SeaCreature.DropItem(ItemRegistry.getFishBone(), 1, 1, 2)); // Common drop for a luminescent drowned
-        luminescentDrownedDrops.add(new SeaCreature.DropItem(ItemRegistry.getLuminescentInk(), 1, 1, 3)); // Luminescent Ink drop
-        luminescentDrownedDrops.add(new SeaCreature.DropItem(ItemRegistry.getSeaSalt(), 1, 1, 1)); // Luminescent Ink drop
-        luminescentDrownedDrops.add(new SeaCreature.DropItem(ItemRegistry.getAquaAffinity(), 1, 1, 12)); // Luminescent Ink drop
+        luminescentDrownedDrops.add(new SeaCreature.DropItem(ItemRegistry.getSeaSalt(), 1, 1, 1));
+        luminescentDrownedDrops.add(new SeaCreature.DropItem(ItemRegistry.getAquaAffinity(), 1, 1, 12));
         SEA_CREATURES.add(new SeaCreature(
                 "Luminescent Drowned", // Name of the sea creature
                 Rarity.UNCOMMON, // Rarity of the sea creature
@@ -216,7 +215,6 @@ public class SeaCreatureRegistry implements Listener {
         List<SeaCreature.DropItem> waterSpiderDrops = new ArrayList<>();
         waterSpiderDrops.add(new SeaCreature.DropItem(ItemRegistry.getFishBone(), 14, 1, 5));
         waterSpiderDrops.add(new SeaCreature.DropItem(ItemRegistry.getTooth(), 14, 1, 4));
-        waterSpiderDrops.add(new SeaCreature.DropItem(ItemRegistry.getAbyssalVenom(), 1, 1, 2));
         SEA_CREATURES.add(new SeaCreature(
                 "Water Spider",
                 Rarity.EPIC,
@@ -277,7 +275,6 @@ public class SeaCreatureRegistry implements Listener {
         //LEGENDARY
         List<SeaCreature.DropItem> bioluminescentGuardianDrops = new ArrayList<>();
         bioluminescentGuardianDrops.add(new SeaCreature.DropItem(ItemRegistry.getAbyssalInk(), 2, 1, 2));
-        bioluminescentGuardianDrops.add(new SeaCreature.DropItem(ItemRegistry.getLuminescentInk(), 8, 1, 2));
         SEA_CREATURES.add(new SeaCreature(
                 "Bioluminescent Guardian",
                 Rarity.LEGENDARY,

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -545,9 +545,6 @@ public class VillagerTradeManager implements Listener {
         fishermanPurchases.add(createTradeMap("FISHERMAN_LUCK_OF_THE_SEA", 1, 64, 4)); // Custom Item
         fishermanPurchases.add(createTradeMap("ABYSSAL_SHELL", 1, 32, 5)); // Custom Item
         fishermanPurchases.add(createTradeMap("ABYSSAL_INK", 1, 64, 5)); // Custom Item
-        fishermanPurchases.add(createTradeMap("ABYSSAL_VENOM", 1, 64, 5)); // Custom Item
-
-
         defaultConfig.set("FISHERMAN.purchases", fishermanPurchases);
 
 // Fisherman Sells
@@ -560,7 +557,6 @@ public class VillagerTradeManager implements Listener {
         fishermanSells.add(createTradeMap("TROPICAL_FISH", 1, 1, 2)); // Material
         fishermanSells.add(createTradeMap("GLOW_INK_SAC", 4, 1, 2)); // Material
         fishermanSells.add(createTradeMap("TOOTH", 1, 2, 2)); // Custom Item
-        fishermanSells.add(createTradeMap("LUMINESCENT_INK", 1, 2, 2)); // Custom Item
         fishermanSells.add(createTradeMap("NAUTILUS_SHELL", 1, 4, 2)); // Material
         fishermanSells.add(createTradeMap("HEART_OF_THE_SEA", 1, 16, 2)); // Material
         fishermanSells.add(createTradeMap("FISH_BONE", 1, 1, 2)); // Custom Item


### PR DESCRIPTION
## Summary
- remove luminescent ink and abyssal venom drops from sea creatures
- remove luminescent ink from fisherman sells
- remove abyssal venom from fisherman purchases

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6859f533c59483328dc5323efd40ac5a