### PR TITLE
Add unbreakable shears trade

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/VerdantRelicsSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/VerdantRelicsSubsystem.java
@@ -543,24 +543,28 @@ public class VerdantRelicsSubsystem implements Listener {
                         org.bukkit.inventory.meta.Damageable dmgMeta =
                                 (org.bukkit.inventory.meta.Damageable) hand.getItemMeta();
 
-                        int cost = 10;
-                        int unbreakingLevel = hand.getEnchantmentLevel(org.bukkit.enchantments.Enchantment.DURABILITY);
-                        if (unbreakingLevel > 5) unbreakingLevel = 5;
+                        if (!dmgMeta.isUnbreakable()) {
+                            int cost = 10;
+                            int unbreakingLevel = hand.getEnchantmentLevel(org.bukkit.enchantments.Enchantment.DURABILITY);
+                            if (unbreakingLevel > 5) unbreakingLevel = 5;
 
-                        PlayerMeritManager meritManager = PlayerMeritManager.getInstance(plugin);
-                        int perkReduction = 0;
-                        if (meritManager.hasPerk(player.getUniqueId(), "Unbreaking")) perkReduction++;
+                            PlayerMeritManager meritManager = PlayerMeritManager.getInstance(plugin);
+                            int perkReduction = 0;
+                            if (meritManager.hasPerk(player.getUniqueId(), "Unbreaking")) perkReduction++;
 
-                        cost -= unbreakingLevel;
-                        cost -= perkReduction;
-                        if (cost < 0) cost = 0;
+                            cost -= unbreakingLevel;
+                            cost -= perkReduction;
+                            if (cost < 0) cost = 0;
 
-                        dmgMeta.setDamage(dmgMeta.getDamage() + cost);
-                        hand.setItemMeta((org.bukkit.inventory.meta.ItemMeta) dmgMeta);
+                            dmgMeta.setDamage(dmgMeta.getDamage() + cost);
+                            hand.setItemMeta((org.bukkit.inventory.meta.ItemMeta) dmgMeta);
 
-                        if (dmgMeta.getDamage() >= hand.getType().getMaxDurability()) {
-                            hand.setAmount(0);
-                            player.playSound(player.getLocation(), Sound.ENTITY_ITEM_BREAK, 1.0f, 1.0f);
+                            if (dmgMeta.getDamage() >= hand.getType().getMaxDurability()) {
+                                hand.setAmount(0);
+                                player.playSound(player.getLocation(), Sound.ENTITY_ITEM_BREAK, 1.0f, 1.0f);
+                            } else {
+                                player.playSound(player.getLocation(), Sound.ENTITY_SHEEP_SHEAR, 1000.0f, 1.0f);
+                            }
                         } else {
                             player.playSound(player.getLocation(), Sound.ENTITY_SHEEP_SHEAR, 1000.0f, 1.0f);
                         }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -459,6 +459,7 @@ public class VillagerTradeManager implements Listener {
         toolsmithSells.add(createTradeMap("REDSTONE_GEMSTONE", 1, 32, 3)); // Custom Item
         toolsmithSells.add(createTradeMap("DIAMOND_GEMSTONE", 1, 64, 3)); // Custom Item
         toolsmithSells.add(createTradeMap("JACKHAMMER", 1, 32, 3)); // Custom Item
+        toolsmithSells.add(createTradeMap("UNBREAKABLE_SHEARS", 1, 128, 5)); // Custom Item
 
         defaultConfig.set("TOOLSMITH.sells", toolsmithSells);
 // Armorer Purchases
@@ -839,6 +840,8 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getDiamondGemstone();
             case "JACKHAMMER":
                 return ItemRegistry.getJackhammer();
+            case "UNBREAKABLE_SHEARS":
+                return ItemRegistry.getUnbreakableShears();
             case "SHEPHERD_ARTIFACT":
                 return ItemRegistry.getShepherdArtifact();
             case "SHEPHERD_ENCHANT":

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -3108,6 +3108,27 @@ public class ItemRegistry {
         );
     }
 
+    public static ItemStack getUnbreakableShears() {
+        ItemStack item = createCustomItem(
+                Material.SHEARS,
+                ChatColor.LIGHT_PURPLE + "Unbreakable Shears",
+                Arrays.asList(
+                        ChatColor.GRAY + "Shears that never dull.",
+                        ChatColor.DARK_PURPLE + "Artifact"
+                ),
+                1,
+                true,
+                true
+        );
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setUnbreakable(true);
+            meta.addItemFlags(ItemFlag.HIDE_UNBREAKABLE);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
     public static ItemStack getAbyssalInk() {
         return createCustomItem(
                 Material.BLACK_DYE,


### PR DESCRIPTION
## Summary
- add Unbreakable Shears custom item
- map the new item in villager trade manager and add a toolsmith sell trade
- ensure Overgrown relics no longer consume durability on unbreakable shears

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f79eb5ec833280799a37bc88551e