### PR TITLE
Update Grand Auction rewards

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/music/MusicDiscManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/music/MusicDiscManager.java
@@ -1130,9 +1130,15 @@ public class MusicDiscManager implements Listener {
         auctionItems.add(new AuctionItem(ItemRegistry.getFishermanReforge(), 8));
         auctionItems.add(new AuctionItem(ItemRegistry.getFishermanLuckoftheSea(), 8));
         auctionItems.add(new AuctionItem(ItemRegistry.getPowerCrystal(), 8));
+        auctionItems.add(new AuctionItem(ItemRegistry.getPowerCrystal(), 8));
+        auctionItems.add(new AuctionItem(ItemRegistry.getPearlOfTheDeep(), 8));
         auctionItems.add(new AuctionItem(ItemRegistry.getPearlOfTheDeep(), 8));
         auctionItems.add(new AuctionItem(ItemRegistry.getEntBark(), 8));
+        auctionItems.add(new AuctionItem(ItemRegistry.getEntBark(), 8));
         auctionItems.add(new AuctionItem(ItemRegistry.getBlueLantern(), 8));
+        auctionItems.add(new AuctionItem(ItemRegistry.getBlueLantern(), 8));
+        auctionItems.add(new AuctionItem(ItemRegistry.getNetherStardust(), 16));
+        auctionItems.add(new AuctionItem(new ItemStack(Material.MUSIC_DISC_PIGSTEP), 16));
         auctionItems.add(new AuctionItem(ItemRegistry.getEngineeringDegree(), 8));
 
 


### PR DESCRIPTION
## Summary
- extend the Grand Auction loot table
- boost odds of power crystal, pearl of the deep, ent bark and blue lantern
- include Nether Stardust and a Pigstep disc

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6859f844fc9c8332bcb450b30c2ad4d4