### PR TITLE
Add potion pouch item

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -60,6 +60,7 @@ import goat.minecraft.minecraftnew.utils.dimensions.end.BetterEnd;
 import goat.minecraft.minecraftnew.other.trinkets.BankAccountManager;
 import goat.minecraft.minecraftnew.other.trinkets.SatchelManager;
 import goat.minecraft.minecraftnew.other.trinkets.SeedPouchManager;
+import goat.minecraft.minecraftnew.other.trinkets.PotionPouchManager;
 import goat.minecraft.minecraftnew.other.trinkets.LavaBucketManager;
 import goat.minecraft.minecraftnew.other.trinkets.TrinketManager;
 
@@ -279,6 +280,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         BankAccountManager.init(this);
         SatchelManager.init(this);
         SeedPouchManager.init(this);
+        PotionPouchManager.init(this);
         LavaBucketManager.init(this);
         TrinketManager.init(this);
         //getServer().getPluginManager().registerEvents(new GamblingTable(this), this);

--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/PotionPouchManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/PotionPouchManager.java
@@ -1,0 +1,210 @@
+package goat.minecraft.minecraftnew.other.trinkets;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class PotionPouchManager implements Listener {
+    private static PotionPouchManager instance;
+    private final JavaPlugin plugin;
+    private File pouchFile;
+    private FileConfiguration pouchConfig;
+
+    private PotionPouchManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        initFile();
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    public static void init(JavaPlugin plugin) {
+        if (instance == null) {
+            instance = new PotionPouchManager(plugin);
+        }
+    }
+
+    public static PotionPouchManager getInstance() {
+        return instance;
+    }
+
+    private void initFile() {
+        pouchFile = new File(plugin.getDataFolder(), "potion_pouches.yml");
+        if (!pouchFile.exists()) {
+            try {
+                plugin.getDataFolder().mkdirs();
+                pouchFile.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        pouchConfig = YamlConfiguration.loadConfiguration(pouchFile);
+    }
+
+    private void save() {
+        try {
+            pouchConfig.save(pouchFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private boolean isPotion(ItemStack item) {
+        if (item == null) return false;
+        Material type = item.getType();
+        return type == Material.POTION || type == Material.SPLASH_POTION || type == Material.LINGERING_POTION;
+    }
+
+    private ItemStack addToStorage(UUID id, ItemStack stack) {
+        String base = id.toString();
+        for (int i = 0; i < 54; i++) {
+            String path = base + "." + i;
+            if (!pouchConfig.contains(path) || pouchConfig.getItemStack(path) == null) {
+                pouchConfig.set(path, stack);
+                save();
+                return null;
+            }
+        }
+        return stack; // no space left
+    }
+
+    public int depositPotions(Player player) {
+        Inventory inv = player.getInventory();
+        int total = 0;
+        for (int i = 0; i < inv.getSize(); i++) {
+            ItemStack item = inv.getItem(i);
+            if (isPotion(item)) {
+                total += item.getAmount();
+                inv.setItem(i, null);
+                ItemStack leftover = addToStorage(player.getUniqueId(), item.clone());
+                if (leftover != null) {
+                    player.getWorld().dropItemNaturally(player.getLocation(), leftover);
+                }
+            }
+        }
+        if (total > 0) {
+            save();
+        }
+        return total;
+    }
+
+    public void openPouch(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 54, "Potion Pouch");
+        String base = player.getUniqueId().toString();
+        for (int i = 0; i < 54; i++) {
+            String path = base + "." + i;
+            ItemStack stack = pouchConfig.getItemStack(path);
+            if (stack != null) {
+                inv.setItem(i, stack);
+            } else {
+                inv.setItem(i, createPane());
+            }
+        }
+        player.openInventory(inv);
+    }
+
+    private ItemStack createPane() {
+        ItemStack pane = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+        ItemMeta meta = pane.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(" ");
+            pane.setItemMeta(meta);
+        }
+        return pane;
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        if (!event.getView().getTitle().equals("Potion Pouch")) return;
+        if (event.getClickedInventory() == null || event.getClickedInventory() != event.getInventory()) {
+            return;
+        }
+        event.setCancelled(true);
+        ItemStack clicked = event.getCurrentItem();
+        if (clicked == null || clicked.getType() == Material.AIR || clicked.getType() == Material.GRAY_STAINED_GLASS_PANE) return;
+        Player player = (Player) event.getWhoClicked();
+        if (event.isLeftClick()) {
+            ItemStack toGive = clicked.clone();
+            event.getInventory().setItem(event.getSlot(), createPane());
+            saveInventory(player, event.getInventory());
+            var notFit = player.getInventory().addItem(toGive);
+            if (!notFit.isEmpty()) {
+                for (ItemStack left : notFit.values()) {
+                    player.getWorld().dropItemNaturally(player.getLocation(), left);
+                }
+            }
+            refreshPouchLore(player);
+        }
+    }
+
+    @EventHandler
+    public void onClose(InventoryCloseEvent event) {
+        if (!event.getView().getTitle().equals("Potion Pouch")) return;
+        Player player = (Player) event.getPlayer();
+        saveInventory(player, event.getInventory());
+        refreshPouchLore(player);
+    }
+
+    private void saveInventory(Player player, Inventory inv) {
+        String base = player.getUniqueId().toString();
+        for (int i = 0; i < 54; i++) {
+            ItemStack item = inv.getItem(i);
+            if (item != null && item.getType() != Material.AIR && item.getType() != Material.GRAY_STAINED_GLASS_PANE) {
+                pouchConfig.set(base + "." + i, item);
+            } else {
+                pouchConfig.set(base + "." + i, null);
+            }
+        }
+        save();
+    }
+
+    public int countPotions(UUID id) {
+        String base = id.toString();
+        int count = 0;
+        for (int i = 0; i < 54; i++) {
+            ItemStack stack = pouchConfig.getItemStack(base + "." + i);
+            if (stack != null) count += stack.getAmount();
+        }
+        return count;
+    }
+
+    private void updateLore(ItemStack item, int count) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        List<String> lore = new ArrayList<>();
+        lore.add(ChatColor.GRAY + "Stores potions");
+        lore.add(ChatColor.BLUE + "Left-click" + ChatColor.GRAY + ": Store potions");
+        lore.add(ChatColor.BLUE + "Shift-Right-click" + ChatColor.GRAY + ": Open pouch");
+        lore.add(ChatColor.GRAY + "Potions: " + ChatColor.GREEN + count);
+        meta.setLore(lore);
+        item.setItemMeta(meta);
+    }
+
+    public void refreshPouchLore(Player player) {
+        int count = countPotions(player.getUniqueId());
+        for (ItemStack stack : player.getInventory().getContents()) {
+            if (stack == null) continue;
+            ItemMeta meta = stack.getItemMeta();
+            if (meta == null || !meta.hasDisplayName()) continue;
+            if (ChatColor.stripColor(meta.getDisplayName()).equals("Pouch of Potions")) {
+                updateLore(stack, count);
+            }
+        }
+        player.updateInventory();
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TrinketManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TrinketManager.java
@@ -2,6 +2,7 @@ package goat.minecraft.minecraftnew.other.trinkets;
 
 import goat.minecraft.minecraftnew.other.additionalfunctionality.CustomBundleGUI;
 import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.other.trinkets.PotionPouchManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -91,6 +92,16 @@ public class TrinketManager implements Listener {
                     event.setCancelled(true);
                 }
             }
+            case "Pouch of Potions" -> {
+                if (event.getClick() == ClickType.LEFT) {
+                    PotionPouchManager.getInstance().depositPotions(player);
+                    PotionPouchManager.getInstance().refreshPouchLore(player);
+                    event.setCancelled(true);
+                } else if (event.getClick() == ClickType.SHIFT_RIGHT) {
+                    PotionPouchManager.getInstance().openPouch(player);
+                    event.setCancelled(true);
+                }
+            }
             case "Pouch of Seeds" -> {
                 if (event.getClick() == ClickType.LEFT) {
                     SeedPouchManager.getInstance().depositSeeds(player);
@@ -161,6 +172,18 @@ public class TrinketManager implements Listener {
         item.setItemMeta(meta);
     }
 
+    private void updatePotionPouchLore(ItemStack item, int count) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        List<String> lore = new ArrayList<>();
+        lore.add(ChatColor.GRAY + "Stores potions");
+        lore.add(ChatColor.BLUE + "Left-click" + ChatColor.GRAY + ": Store potions");
+        lore.add(ChatColor.BLUE + "Shift-Right-click" + ChatColor.GRAY + ": Open pouch");
+        lore.add(ChatColor.GRAY + "Potions: " + ChatColor.GREEN + count);
+        meta.setLore(lore);
+        item.setItemMeta(meta);
+    }
+
     public void refreshPouchLore(Player player) {
         int count = SeedPouchManager.getInstance().countSeeds(player.getUniqueId());
         for (ItemStack stack : player.getInventory().getContents()) {
@@ -169,6 +192,19 @@ public class TrinketManager implements Listener {
             if (meta == null || !meta.hasDisplayName()) continue;
             if (ChatColor.stripColor(meta.getDisplayName()).equals("Pouch of Seeds")) {
                 updatePouchLore(stack, count);
+            }
+        }
+        player.updateInventory();
+    }
+
+    public void refreshPotionPouchLore(Player player) {
+        int count = PotionPouchManager.getInstance().countPotions(player.getUniqueId());
+        for (ItemStack stack : player.getInventory().getContents()) {
+            if (stack == null) continue;
+            ItemMeta meta = stack.getItemMeta();
+            if (meta == null || !meta.hasDisplayName()) continue;
+            if (ChatColor.stripColor(meta.getDisplayName()).equals("Pouch of Potions")) {
+                updatePotionPouchLore(stack, count);
             }
         }
         player.updateInventory();

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -366,6 +366,7 @@ public class VillagerTradeManager implements Listener {
         leatherworkerPurchases.add(createTradeMap("BLACK_SATCHEL", 1, 90, 3));
         leatherworkerPurchases.add(createTradeMap("GREEN_SATCHEL", 1, 90, 3));
         leatherworkerPurchases.add(createTradeMap("POUCH_OF_SEEDS", 1, 90, 3));
+        leatherworkerPurchases.add(createTradeMap("POUCH_OF_POTIONS", 1, 90, 3));
         leatherworkerPurchases.add(createTradeMap("ENCHANTED_LAVA_BUCKET_TRINKET", 1, 90, 3));
         leatherworkerPurchases.add(createTradeMap("SHULKER_SHELL", 1, 64, 3)); // Material
         leatherworkerPurchases.add(createTradeMap("ANVIL_TRINKET", 1, 90, 4));
@@ -866,6 +867,8 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getGreenSatchelTrinket();
             case "POUCH_OF_SEEDS":
                 return ItemRegistry.getSeedPouchTrinket();
+            case "POUCH_OF_POTIONS":
+                return ItemRegistry.getPotionPouchTrinket();
             case "ENCHANTED_LAVA_BUCKET_TRINKET":
                 return ItemRegistry.getEnchantedLavaBucketTrinket();
             case "CLERIC_ENCHANT":

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -1105,6 +1105,20 @@ public class ItemRegistry {
         );
     }
 
+    public static ItemStack getPotionPouchTrinket() {
+        return createCustomItem(
+                Material.BUNDLE,
+                ChatColor.YELLOW + "Pouch of Potions",
+                List.of(
+                        ChatColor.BLUE + "Left-click" + ChatColor.GRAY + ": Store potions",
+                        ChatColor.BLUE + "Shift-Right-click" + ChatColor.GRAY + ": Open pouch"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
     public static ItemStack getEnchantedLavaBucketTrinket() {
         return createCustomItem(
                 Material.LAVA_BUCKET,


### PR DESCRIPTION
## Summary
- implement PotionPouchManager to store potions in a persistent inventory
- register the potion pouch trinket
- handle potion pouch usage in TrinketManager
- offer potion pouch via villager trades
- initialize the new manager in `MinecraftNew`

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859fdfcc06483329ee3880218173883