### PR TITLE
Fix zombie sword drops

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/KillMonster.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/KillMonster.java
@@ -109,11 +109,11 @@ public class KillMonster implements Listener {
                 boolean allowNormalDrops = random.nextInt(100) < 20;
                 if (!allowNormalDrops && entity instanceof Zombie zombie) {
                     ItemStack main = zombie.getEquipment().getItemInMainHand();
-                    if (main != null && main.getType() != Material.AIR) {
+                    if (main != null && main.getType() != Material.AIR && !main.getType().name().endsWith("_SWORD")) {
                         zombie.getWorld().dropItemNaturally(zombie.getLocation(), main.clone());
                     }
                     ItemStack off = zombie.getEquipment().getItemInOffHand();
-                    if (off != null && off.getType() != Material.AIR) {
+                    if (off != null && off.getType() != Material.AIR && !off.getType().name().endsWith("_SWORD")) {
                         zombie.getWorld().dropItemNaturally(zombie.getLocation(), off.clone());
                     }
                 }


### PR DESCRIPTION
## Summary
- stop zombies from dropping swords when loot is suppressed

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a05cd3fa88332a92d98d09d28854c