### PR TITLE
Prevent zombie reinforcement spam

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatSubsystemManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatSubsystemManager.java
@@ -15,6 +15,7 @@ import goat.minecraft.minecraftnew.subsystems.combat.notification.DamageNotifica
 import goat.minecraft.minecraftnew.subsystems.combat.notification.PlayerFeedbackService;
 import goat.minecraft.minecraftnew.subsystems.combat.FireDamageHandler;
 import goat.minecraft.minecraftnew.subsystems.combat.DeteriorationDamageHandler;
+import goat.minecraft.minecraftnew.subsystems.combat.ZombieReinforcementBlocker;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
@@ -46,6 +47,7 @@ public class CombatSubsystemManager implements CommandExecutor {
 
     private FireDamageHandler fireDamageHandler;
     private DeteriorationDamageHandler decayDamageHandler;
+    private ZombieReinforcementBlocker reinforcementBlocker;
     
     // Controllers and handlers
     private CombatEventHandler eventHandler;
@@ -267,7 +269,8 @@ public class CombatSubsystemManager implements CommandExecutor {
 
         fireDamageHandler = new FireDamageHandler(plugin, notificationService);
         decayDamageHandler = DeteriorationDamageHandler.getInstance(plugin, notificationService);
-        
+        reinforcementBlocker = new ZombieReinforcementBlocker();
+
         logger.fine("Combat controllers and handlers initialized");
     }
     
@@ -279,6 +282,7 @@ public class CombatSubsystemManager implements CommandExecutor {
         Bukkit.getPluginManager().registerEvents(hostilityGUIController, plugin);
         Bukkit.getPluginManager().registerEvents(fireDamageHandler, plugin);
         Bukkit.getPluginManager().registerEvents(decayDamageHandler, plugin);
+        Bukkit.getPluginManager().registerEvents(reinforcementBlocker, plugin);
         // Register blood moon assault listener
         logger.fine("Combat event listeners registered");
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/ZombieReinforcementBlocker.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/ZombieReinforcementBlocker.java
@@ -1,0 +1,19 @@
+package goat.minecraft.minecraftnew.subsystems.combat;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.entity.Zombie;
+
+/**
+ * Prevents zombies from spawning reinforcements.
+ */
+public class ZombieReinforcementBlocker implements Listener {
+    @EventHandler
+    public void onZombieReinforcementSpawn(CreatureSpawnEvent event) {
+        if (event.getSpawnReason() == CreatureSpawnEvent.SpawnReason.REINFORCEMENTS
+                && event.getEntity() instanceof Zombie) {
+            event.setCancelled(true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- cancel reinforcement spawns on zombies
- hook new blocker into combat subsystem

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a7c0c6ab08332843ef6a3ab27cd68