### PR TITLE
Add Rejuvenation catalyst

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -251,6 +251,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         beaconPassiveEffects.reapplyAllPassiveEffects();
         // Initialize catalyst manager for beacon charm catalysts
         CatalystManager.initialize(this);
+        getServer().getPluginManager().registerEvents(new RejuvenationCatalystListener(this), this);
 
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/BeaconManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/BeaconManager.java
@@ -513,6 +513,7 @@ public class BeaconManager implements Listener {
             case "Catalyst of Depth": return ChatColor.DARK_AQUA.toString();
             case "Catalyst of Insanity": return ChatColor.DARK_PURPLE.toString();
             case "Catalyst of Oxygen": return ChatColor.BLUE.toString();
+            case "Catalyst of Rejuvenation": return ChatColor.GOLD.toString();
             case "Catalyst of Prosperity": return ChatColor.GREEN.toString();
             default: return ChatColor.WHITE.toString();
         }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/CatalystType.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/CatalystType.java
@@ -11,6 +11,7 @@ public enum CatalystType {
     DEPTH("Catalyst of Depth", Particle.NAUTILUS, Sound.BLOCK_CONDUIT_AMBIENT, ChatColor.DARK_AQUA),
     INSANITY("Catalyst of Insanity", Particle.SPELL_WITCH, Sound.BLOCK_WOOD_BREAK, ChatColor.DARK_PURPLE),
     OXYGEN("Catalyst of Oxygen", Particle.SMOKE_LARGE, Sound.BLOCK_STONE_BREAK, ChatColor.BLUE),
+    REJUVENATION("Catalyst of Rejuvenation", Particle.HEART, Sound.ITEM_TOTEM_USE, ChatColor.GOLD),
     PROSPERITY("Catalyst of Prosperity", Particle.VILLAGER_HAPPY, Sound.ENTITY_PLAYER_LEVELUP, ChatColor.GREEN);
 
     private final String displayName;

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/RejuvenationCatalystListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/RejuvenationCatalystListener.java
@@ -1,0 +1,120 @@
+package goat.minecraft.minecraftnew.subsystems.beacon;
+
+import goat.minecraft.minecraftnew.subsystems.mining.PlayerOxygenManager;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Handles the effects of the Catalyst of Rejuvenation.
+ * Players within range slowly recover health, hunger, saturation, absorption,
+ * oxygen and item durability.
+ */
+public class RejuvenationCatalystListener {
+
+    private final JavaPlugin plugin;
+    private final Map<UUID, Map<Integer, Integer>> repairTargets = new HashMap<>();
+
+    public RejuvenationCatalystListener(JavaPlugin plugin) {
+        this.plugin = plugin;
+        startTask();
+    }
+
+    private void startTask() {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                CatalystManager manager = CatalystManager.getInstance();
+                if (manager == null) {
+                    return;
+                }
+                for (Player player : plugin.getServer().getOnlinePlayers()) {
+                    if (manager.isNearCatalyst(player.getLocation(), CatalystType.REJUVENATION)) {
+                        Catalyst catalyst = manager.findNearestCatalyst(player.getLocation(), CatalystType.REJUVENATION);
+                        if (catalyst != null) {
+                            int tier = manager.getCatalystTier(catalyst);
+                            applyRejuvenation(player, tier);
+                        }
+                    } else {
+                        repairTargets.remove(player.getUniqueId());
+                    }
+                }
+            }
+        }.runTaskTimer(plugin, 20L, 20L);
+    }
+
+    private void applyRejuvenation(Player player, int tier) {
+        double healPercent = 0.025 * (tier + 1);
+        double maxHealth = player.getMaxHealth();
+        player.setHealth(Math.min(player.getHealth() + maxHealth * healPercent, maxHealth));
+
+        player.setFoodLevel(Math.min(player.getFoodLevel() + 1, 20));
+        player.setSaturation(Math.min(player.getSaturation() + 1f, 10f));
+        player.setAbsorptionAmount(Math.min(player.getAbsorptionAmount() + 1.0, 20.0));
+
+        PlayerOxygenManager oxygenManager = PlayerOxygenManager.getInstance();
+        int currentOxy = oxygenManager.getPlayerOxygen(player);
+        int maxOxy = oxygenManager.calculateInitialOxygen(player);
+        oxygenManager.setPlayerOxygenLevel(player, Math.min(currentOxy + 1, maxOxy));
+
+        handleDurability(player);
+    }
+
+    private void handleDurability(Player player) {
+        UUID uuid = player.getUniqueId();
+        Map<Integer, Integer> targets = repairTargets.computeIfAbsent(uuid, k -> new HashMap<>());
+
+        for (int slot = 0; slot < player.getInventory().getSize(); slot++) {
+            ItemStack item = player.getInventory().getItem(slot);
+            if (item == null) {
+                targets.remove(slot);
+                continue;
+            }
+            int maxDur = item.getType().getMaxDurability();
+            if (maxDur <= 0) {
+                targets.remove(slot);
+                continue;
+            }
+            if (!(item.getItemMeta() instanceof Damageable)) {
+                targets.remove(slot);
+                continue;
+            }
+
+            Damageable meta = (Damageable) item.getItemMeta();
+            int damage = meta.getDamage();
+            if (damage <= 0) {
+                targets.remove(slot);
+                continue;
+            }
+
+            if (maxDur <= 100) {
+                meta.setDamage(0);
+                item.setItemMeta(meta);
+                targets.remove(slot);
+                continue;
+            }
+
+            int target = targets.computeIfAbsent(slot, s -> damage - (int) Math.floor(damage * 0.25));
+            if (damage < target) {
+                target = damage - (int) Math.floor(damage * 0.25);
+                targets.put(slot, target);
+            }
+            if (damage > target) {
+                meta.setDamage(Math.max(damage - 1, target));
+                item.setItemMeta(meta);
+            } else {
+                targets.remove(slot);
+            }
+        }
+
+        if (targets.isEmpty()) {
+            repairTargets.remove(uuid);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `REJUVENATION` catalyst type
- color mapping for new catalyst
- register `RejuvenationCatalystListener`
- implement `RejuvenationCatalystListener` for health, hunger, saturation, oxygen, absorption, and durability recovery

## Testing
- `mvn -q package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685a8873a9648332bbc462ce27553d62