### PR TITLE
Fix wither loot drop chance

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/KillMonster.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/KillMonster.java
@@ -106,7 +106,13 @@ public class KillMonster implements Listener {
                         }
                     }
                 }
-                boolean allowNormalDrops = random.nextInt(100) < 20;
+                boolean allowNormalDrops;
+                if (entity instanceof Wither) {
+                    // Always allow normal drops for Withers
+                    allowNormalDrops = true;
+                } else {
+                    allowNormalDrops = random.nextInt(100) < 20;
+                }
                 if (!allowNormalDrops && entity instanceof Zombie zombie) {
                     ItemStack main = zombie.getEquipment().getItemInMainHand();
                     if (main != null && main.getType() != Material.AIR && !main.getType().name().endsWith("_SWORD")) {


### PR DESCRIPTION
## Summary
- ensure the 80% reduction in monster drops doesn't affect withers

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba98abc248332acb87adef57f1ee5