### PR TITLE
Add farmer villager relic maintenance

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerWorkCycleManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerWorkCycleManager.java
@@ -303,6 +303,15 @@ public class VillagerWorkCycleManager implements Listener, CommandExecutor {
         Speech speech = new Speech(plugin);
         speech.createText(villager.getLocation(), "I harvested your nearby crops and put them in that chest!", 30);
         villager.getWorld().playSound(villager.getLocation(), Sound.BLOCK_ROOTED_DIRT_BREAK, 1.0f, 1.0f);
+
+        // 25% chance to cure overgrown relics nearby
+        if (Math.random() < 0.25) {
+            VerdantRelicsSubsystem relics = VerdantRelicsSubsystem.getInstance(MinecraftNew.getInstance());
+            int cured = relics.cureOvergrownNearby(villager.getLocation(), 150);
+            if (cured > 0) {
+                villager.getWorld().playSound(villager.getLocation(), Sound.ITEM_HOE_TILL, 1.0f, 1.0f);
+            }
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- allow `VerdantRelicsSubsystem` to cure nearby overgrown relics
- give farmer villagers a chance to trim nearby relics every workcycle

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd15abdb083328987fdf11ccb66c8