### PR TITLE
Add Endless Warp pet perk

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/UltimateEnchantmentListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/UltimateEnchantmentListener.java
@@ -6,6 +6,7 @@ import goat.minecraft.minecraftnew.subsystems.forestry.EffigyUpgradeSystem;
 import goat.minecraft.minecraftnew.subsystems.forestry.ForestSpiritManager;
 import goat.minecraft.minecraftnew.subsystems.forestry.Forestry;
 import goat.minecraft.minecraftnew.subsystems.forestry.ForestryPetManager;
+import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import org.bukkit.*;
 import org.bukkit.block.Block;
@@ -794,6 +795,11 @@ public class UltimateEnchantmentListener implements Listener {
     }
 
     private int getAvailableWarpCharges(Player player) {
+        PetManager petManager = PetManager.getInstance(plugin);
+        PetManager.Pet activePet = petManager.getActivePet(player);
+        if (activePet != null && activePet.hasPerk(PetManager.PetPerk.ENDLESS_WARP)) {
+            return Integer.MAX_VALUE;
+        }
         List<Long> list = getWarpChargeList(player);
         long now = System.currentTimeMillis();
         int count = 0;
@@ -806,6 +812,11 @@ public class UltimateEnchantmentListener implements Listener {
     }
 
     private boolean consumeWarpCharge(Player player) {
+        PetManager petManager = PetManager.getInstance(plugin);
+        PetManager.Pet activePet = petManager.getActivePet(player);
+        if (activePet != null && activePet.hasPerk(PetManager.PetPerk.ENDLESS_WARP)) {
+            return true;
+        }
         List<Long> list = getWarpChargeList(player);
         long now = System.currentTimeMillis();
         for (int i = list.size() - 1; i >= 0; i--) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
@@ -645,6 +645,8 @@ public class PetManager implements Listener {
             case FLAME_TRAIL:
                 double flameDamage = 3.0 + (level * 0.08);
                 return "Creates " + ChatColor.RED + "explosive fire bursts " + ChatColor.GRAY + "while moving that deal " + ChatColor.RED + String.format("%.1f", flameDamage) + " damage " + ChatColor.GRAY + "to monsters within " + ChatColor.YELLOW + "8 blocks" + ChatColor.GRAY + ". Distance reduces damage.";
+            case ENDLESS_WARP:
+                return ChatColor.DARK_PURPLE + "Grants infinite Warp charges for the Warp enchant.";
             default:
                 return ChatColor.GRAY + "Static effect or undefined scaling.";
 
@@ -944,7 +946,8 @@ public class PetManager implements Listener {
         PARKOUR_ROLL("Parkour Roll", ChatColor.GOLD + ""),
         EARTHWORM("Earthworm", ChatColor.GOLD + ""),
         PHOENIX_REBIRTH("Phoenix Rebirth", ChatColor.GOLD + ""),
-        FLAME_TRAIL("Flame Trail", ChatColor.GOLD + "");
+        FLAME_TRAIL("Flame Trail", ChatColor.GOLD + ""),
+        ENDLESS_WARP("Endless Warp", ChatColor.GOLD + "");
 
         private final String displayName;
         private final String description;

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetRegistry.java
@@ -148,7 +148,7 @@ public class PetRegistry {
                 PetManager.Rarity.LEGENDARY,
                 100,
                 Particle.ASH,
-                Arrays.asList(PetManager.PetPerk.ELITE, PetManager.PetPerk.ASPECT_OF_THE_END, PetManager.PetPerk.COLLECTOR)
+                Arrays.asList(PetManager.PetPerk.ELITE, PetManager.PetPerk.ENDLESS_WARP, PetManager.PetPerk.COLLECTOR)
         ));
         registry.put("Blaze", new PetDefinition(
                 "Blaze",


### PR DESCRIPTION
## Summary
- add an `ENDLESS_WARP` pet perk
- change the Enderman pet to use the new perk
- allow the Warp enchantment to ignore charge limits when the perk is active

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685bd61cd0ac833292bcc1870fa641ed