### PR TITLE
Allow cakes to exceed saturation cap

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/qol/CakeHungerListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/qol/CakeHungerListener.java
@@ -1,28 +1,47 @@
 package goat.minecraft.minecraftnew.other.qol;
 
+import goat.minecraft.minecraftnew.MinecraftNew;
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.block.Action;
 import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
 
 public class CakeHungerListener implements Listener {
 
     @EventHandler
     public void onCakeRightClick(PlayerInteractEvent event) {
-        // Check if the action is a right-click on a block
-        if (event.getAction() == Action.RIGHT_CLICK_BLOCK) {
-            // Check if the clicked block is a cake
-            if (event.getClickedBlock() != null && event.getClickedBlock().getType() == Material.CAKE) {
-                Player player = event.getPlayer();
-                // Check if the player has less than full hunger
-                if (player.getFoodLevel() < 20) {
-                    // Set the player's hunger and saturation to full
-                    player.setFoodLevel(19);
-                    player.setSaturation(20);
-                }
-            }
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
+            return;
         }
+
+        if (event.getClickedBlock() == null || event.getClickedBlock().getType() != Material.CAKE) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+
+        // Record the player's saturation before vanilla handles the eating
+        float startSaturation = player.getSaturation();
+
+        // Force the player to be able to eat the cake even when at full hunger
+        player.setFoodLevel(19);
+
+        // Apply saturation changes after the slice is consumed so the cake block
+        // still decreases normally
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                float newSaturation;
+                if (startSaturation < 20f) {
+                    newSaturation = 20f;
+                } else {
+                    newSaturation = Math.min(startSaturation + 10f, 60f);
+                }
+                player.setSaturation(newSaturation);
+            }
+        }.runTaskLater(MinecraftNew.getInstance(), 1L);
     }
 }


### PR DESCRIPTION
## Summary
- update `CakeHungerListener` to grant extra saturation up to 60
- allow eating cake even at full hunger to gain the saturation buff

## Testing
- `mvn -q package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e4372b1a08332a36ca47ee2d32521