### PR TITLE
Fix backpack GUI refresh and add open delay

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/InventoryClickListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/InventoryClickListener.java
@@ -38,14 +38,13 @@ public class InventoryClickListener implements Listener {
             if (isBackpackItem(item)) {
                 event.setCancelled(true);
                 Player player = (Player) event.getWhoClicked();
-                CustomBundleGUI.getInstance().openBundleGUI(player);
+                CustomBundleGUI.getInstance().openBundleGUIDelayed(player);
                 new BukkitRunnable() {
                     @Override
                     public void run() {
                         TrinketManager.getInstance().refreshBankLore(player);
                     }
-                }.runTaskLater(MinecraftNew.getInstance(), 10L);
-                player.playSound(player.getLocation(), Sound.ITEM_ARMOR_EQUIP_LEATHER, 10, 10);
+                }.runTaskLater(MinecraftNew.getInstance(), 20L);
             }
         }
     }

--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/RightClickArtifacts.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/RightClickArtifacts.java
@@ -551,16 +551,15 @@ public class RightClickArtifacts implements Listener {
                 decrementItemAmount(itemInHand, player);
             }
             if(displayName.equals(ChatColor.YELLOW + "Backpack")){
-                CustomBundleGUI.getInstance().openBundleGUI(player);
+                CustomBundleGUI.getInstance().openBundleGUIDelayed(player);
                 new BukkitRunnable() {
                     @Override
                     public void run() {
                         // <-- your code here
                         TrinketManager.getInstance().refreshBankLore(player);
                     }
-                }.runTaskLater(MinecraftNew.getInstance(), 10L);
-                player.playSound(player.getLocation(), Sound.ITEM_ARMOR_EQUIP_LEATHER, 10, 10);
-
+                }.runTaskLater(MinecraftNew.getInstance(), 20L);
+                
             }
             StructureUtils structureUtils = new StructureUtils();
             if(displayName.equals(ChatColor.YELLOW + "Mineshaft Location")){


### PR DESCRIPTION
## Summary
- add delayed backpack opening with sound in `CustomBundleGUI`
- refresh player inventory after closing the backpack
- use delayed opening in `InventoryClickListener` and `RightClickArtifacts`

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4a470cb083328d4637c163306aba