### PR TITLE
Restrict spawnseacreature to admins

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SpawnSeaCreatureCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SpawnSeaCreatureCommand.java
@@ -29,6 +29,11 @@ public class SpawnSeaCreatureCommand implements CommandExecutor {
 
         Player player = (Player) sender;
 
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You do not have permission to use this command!");
+            return true;
+        }
+
         // Check if the player provided a sea creature name
         if (args.length != 1) {
             player.sendMessage(ChatColor.RED + "Usage: /spawnseacreature <creature_name>");

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -84,6 +84,7 @@ commands:
     description: opens difficulty GUI.
   spawnseacreature:
     description: Spawns a sea creature by name.
+    permission: continuity.admin
   givecustomitem:
     description: Gives a predefined custom item to the player.
     usage: /givecustomitem <customitem>


### PR DESCRIPTION
## Summary
- only allow players with `continuity.admin` permission to run `/spawnseacreature`
- declare the required permission in `plugin.yml`

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:2.6)*

------
https://chatgpt.com/codex/tasks/task_e_685e5522a64483329bb342fe9c54577c