### PR TITLE
Add Potion of Oxygen Recovery

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -192,6 +192,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new PotionOfFountains(), this);
         getServer().getPluginManager().registerEvents(new PotionOfSwiftStep(), this);
         getServer().getPluginManager().registerEvents(new PotionOfRecurve(), this);
+        getServer().getPluginManager().registerEvents(new PotionOfOxygenRecovery(), this);
         getServer().getPluginManager().registerEvents(new PotionOfSolarFury(), this);
         getServer().getPluginManager().registerEvents(new PotionOfNightVision(), this);
         getServer().getPluginManager().registerEvents(new PotionOfRiptide(), this);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
@@ -283,6 +283,14 @@ public class PotionBrewingSubsystem implements Listener {
         recipeRegistry.add(
                 new PotionRecipe("Potion of Charismatic Bartering", charismaticIngredients, 60*10, new ItemStack(Material.POTION), charismaticColor, charismaticLore)
         );
+
+        // Potion of Oxygen Recovery
+        List<String> oxygenRecoveryIngredients = Arrays.asList("Glass Bottle", "Nether Wart", "Sponge", "Ghost");
+        List<String> oxygenRecoveryLore = Arrays.asList("Recover oxygen faster while mining", "Base Duration of " + baseDuration);
+        Color oxygenRecoveryColor = Color.fromRGB(0, 0, 0);
+        recipeRegistry.add(
+                new PotionRecipe("Potion of Oxygen Recovery", oxygenRecoveryIngredients, 60*10, new ItemStack(Material.POTION), oxygenRecoveryColor, oxygenRecoveryLore)
+        );
     }
 
     private PotionRecipe findRecipeByName(String potionName) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfOxygenRecovery.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfOxygenRecovery.java
@@ -1,0 +1,34 @@
+package goat.minecraft.minecraftnew.subsystems.brewing.custompotions;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
+import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Potion of Oxygen Recovery - reduces oxygen recovery interval while active.
+ */
+public class PotionOfOxygenRecovery implements Listener {
+
+    @EventHandler
+    public void onPotionDrink(PlayerItemConsumeEvent event) {
+        ItemStack item = event.getItem();
+        if (item != null && item.hasItemMeta() && item.getItemMeta().hasDisplayName()) {
+            String displayName = ChatColor.stripColor(item.getItemMeta().getDisplayName());
+            if (displayName.equals("Potion of Oxygen Recovery")) {
+                Player player = event.getPlayer();
+                XPManager xpManager = new XPManager(MinecraftNew.getInstance());
+                int brewingLevel = xpManager.getPlayerLevel(player, "Brewing");
+                int duration = (60 * 3) + (brewingLevel * 10);
+                PotionManager.addCustomPotionEffect("Potion of Oxygen Recovery", player, duration);
+                player.sendMessage(ChatColor.AQUA + "Potion of Oxygen Recovery activated for " + duration + " seconds!");
+                xpManager.addXP(player, "Brewing", 100);
+            }
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureDeathEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureDeathEvent.java
@@ -105,6 +105,11 @@ public class SeaCreatureDeathEvent implements Listener {
             }
         }
 
+        // 2% chance to drop the Ghost relic
+        if (random.nextInt(100) < 2) {
+            event.getDrops().add(ItemRegistry.getGhost());
+        }
+
         Bukkit.getLogger().info("Player " + killer.getName() + " gained " + boostedXP + " Fishing XP.");
 
         if(seaCreature.getSkullName().equals("Pirate")){

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/mining/PlayerOxygenManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/mining/PlayerOxygenManager.java
@@ -3,6 +3,7 @@ package goat.minecraft.minecraftnew.subsystems.mining;
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager; // Remove this if no longer needed anywhere else
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -64,6 +65,13 @@ public class PlayerOxygenManager implements Listener {
     // that’s roughly 12 seconds per oxygen increment when empty.
     private static final int RECOVERY_INTERVAL_SECONDS = 6;
     private int recoveryCounter = 0; // Counts seconds for recovery pacing
+
+    private int getRecoveryIntervalSeconds(Player player) {
+        if (PotionManager.isActive("Potion of Oxygen Recovery", player)) {
+            return 2;
+        }
+        return RECOVERY_INTERVAL_SECONDS;
+    }
 
     public PlayerOxygenManager(MinecraftNew plugin) {
         this.plugin = plugin;
@@ -196,7 +204,7 @@ public class PlayerOxygenManager implements Listener {
         } else {
             // Handle oxygen recovery
             if (currentOxygen < initialOxygen) {
-                if (recoveryCounter % RECOVERY_INTERVAL_SECONDS == 0) {
+                if (recoveryCounter % getRecoveryIntervalSeconds(player) == 0) {
                     currentOxygen++;
                     playerOxygenLevels.put(uuid, currentOxygen);
                 }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -328,6 +328,7 @@ public class VillagerTradeManager implements Listener {
         clericPurchases.add(createTradeMap("RECURVE", 1, 16, 2)); // Material
         clericPurchases.add(createTradeMap("STRENGTH", 1, 16, 2)); // Material
         clericPurchases.add(createTradeMap("SWIFT_STEP", 1, 16, 2)); // Material
+        clericPurchases.add(createTradeMap("OXYGEN_RECOVERY", 1, 16, 2)); // Material
         clericPurchases.add(createTradeMap("SOVEREIGNTY", 1, 16, 2)); // Material
         clericPurchases.add(createTradeMap("LIQUID_LUCK", 1, 32, 2)); // Material
         clericPurchases.add(createTradeMap("FOUNTAINS", 1, 32, 2)); // Material
@@ -688,6 +689,8 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getRecurvePotionRecipePaper();
             case "SWIFT_STEP":
                 return ItemRegistry.getSwiftStepPotionRecipePaper();
+            case "OXYGEN_RECOVERY":
+                return ItemRegistry.getOxygenRecoveryRecipePaper();
             case "SOVEREIGNTY":
                 return ItemRegistry.getSovereigntyPotionRecipePaper();
             case "LIQUID_LUCK":

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -558,6 +558,24 @@ public class ItemRegistry {
         );
     }
 
+    // ------------------------------------------------------------------
+    // Ghost Relic
+    // ------------------------------------------------------------------
+
+    public static ItemStack getGhost() {
+        return createCustomItem(
+                Material.GHAST_TEAR,
+                ChatColor.GOLD + "Ghost",
+                Arrays.asList(
+                        ChatColor.GRAY + "A relic humming with spectral energy.",
+                        ChatColor.BLUE + "Used in brewing the Potion of Oxygen Recovery."
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
 
     public static ItemStack getRecurvePotionRecipePaper() {
         // This returns a piece of PAPER with a custom name + lore that says "Potion of Recurve Recipe".
@@ -700,6 +718,21 @@ public class ItemRegistry {
                 ChatColor.LIGHT_PURPLE + "Potion of Charismatic Bartering Recipe (Potion Recipe)",
                 Arrays.asList(
                         ChatColor.GRAY + "Brewing instructions for Charismatic Bartering",
+                        ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Right-click a Brewing Stand to begin",
+                        ChatColor.DARK_PURPLE + "Potion Recipe"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
+    public static ItemStack getOxygenRecoveryRecipePaper() {
+        return createCustomItem(
+                Material.PAPER,
+                ChatColor.LIGHT_PURPLE + "Potion of Oxygen Recovery Recipe (Potion Recipe)",
+                Arrays.asList(
+                        ChatColor.GRAY + "Brewing instructions for Oxygen Recovery",
                         ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Right-click a Brewing Stand to begin",
                         ChatColor.DARK_PURPLE + "Potion Recipe"
                 ),


### PR DESCRIPTION
## Summary
- implement Potion of Oxygen Recovery custom effect
- allow oxygen to recover faster when the potion is active
- register potion recipe and listener
- add Ghost relic and recipe paper items
- drop Ghost from sea creatures
- add cleric trade for the new potion recipe

## Testing
- `mvn -q package -DskipTests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e57d1f294833297739c16f35f02a0