### PR TITLE
Add Vaccination artifact

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/RightClickArtifacts.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/RightClickArtifacts.java
@@ -22,6 +22,7 @@ import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemFlag;
@@ -809,6 +810,67 @@ public class RightClickArtifacts implements Listener {
         } else {
             player.getInventory().removeItem(item);
         }
+    }
+
+    /**
+     * Handles using the Vaccination artifact on Zombie Villagers.
+     */
+    @EventHandler
+    public void onEntityInteract(PlayerInteractEntityEvent event) {
+        if (!(event.getRightClicked() instanceof ZombieVillager zombie)) {
+            return;
+        }
+        Player player = event.getPlayer();
+        ItemStack itemInHand = player.getInventory().getItemInMainHand();
+        if (itemInHand == null || !itemInHand.hasItemMeta()) {
+            return;
+        }
+        ItemMeta meta = itemInHand.getItemMeta();
+        if (meta == null || !meta.hasDisplayName()) {
+            return;
+        }
+        if (!meta.getDisplayName().equals(ChatColor.YELLOW + "Vaccination")) {
+            return;
+        }
+
+        event.setCancelled(true);
+        cureZombieVillager(player, zombie);
+        decrementItemAmount(itemInHand, player);
+    }
+
+    /**
+     * Converts the given ZombieVillager back to a Villager after a short delay.
+     */
+    private void cureZombieVillager(Player player, ZombieVillager zombie) {
+        World world = zombie.getWorld();
+        Location loc = zombie.getLocation();
+        Villager.Profession profession = zombie.getVillagerProfession();
+        Villager.Type type = zombie.getVillagerType();
+
+        world.playSound(loc, Sound.ENTITY_ZOMBIE_VILLAGER_CURE, 1f, 1f);
+
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!zombie.isValid()) return;
+                zombie.remove();
+                Villager villager = (Villager) world.spawnEntity(loc, EntityType.VILLAGER);
+                villager.setProfession(profession);
+                villager.setVillagerType(type);
+
+                String rawName = zombie.getCustomName() != null ? zombie.getCustomName() : "";
+                // Remove color codes then strip any level prefix such as "[Lv: 10] "
+                String stripped = ChatColor.stripColor(rawName).replaceFirst("(?i)^\\s*\\[?\\s*(?:level|lv\\.?|lvl)\\s*:?\\s*\\d+\\s*\\]?\\s*", "");
+                if (!stripped.isEmpty()) {
+                    ChatColor nameColor = stripped.equalsIgnoreCase("Bartender") ? ChatColor.GOLD : ChatColor.GREEN;
+                    villager.setCustomName(nameColor + stripped);
+                    villager.setCustomNameVisible(true);
+                }
+
+                world.spawnParticle(Particle.VILLAGER_HAPPY, loc.add(0, 1, 0), 30, 0.5, 0.5, 0.5, 0.1);
+                world.playSound(loc, Sound.ENTITY_VILLAGER_CELEBRATE, 1f, 1f);
+            }
+        }.runTaskLater(MinecraftNew.getInstance(), 100L); // 5 seconds
     }
 
     /**

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -335,6 +335,7 @@ public class VillagerTradeManager implements Listener {
         clericPurchases.add(createTradeMap("RIPTIDE", 1, 32, 2)); // Material
         clericPurchases.add(createTradeMap("SOLAR_FURY", 1, 32, 2)); // Material
         clericPurchases.add(createTradeMap("NIGHT_VISION", 1, 32, 2)); // Material
+        clericPurchases.add(createTradeMap("VACCINATION", 1, 32, 2)); // Custom item
         clericPurchases.add(createTradeMap("CHARISMATIC_BARTERING", 1, 64, 2)); // Material
 
         clericPurchases.add(createTradeMap("CLERIC_ENCHANT", 1, 64, 3)); // Custom Item
@@ -889,6 +890,8 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getShinyEmerald();
             case "PESTICIDE":
                 return ItemRegistry.getPesticide();
+            case "VACCINATION":
+                return ItemRegistry.getVaccination();
             case "CARTOGRAPHER_MINESHAFT":
                 return ItemRegistry.getCartographerMineshaft();
             case "CARTOGRAPHER_VILLAGE":

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -317,6 +317,24 @@ public class ItemRegistry {
         );
     }
 
+    /**
+     * Vaccination artifact used to cure Zombie Villagers.
+     */
+    public static ItemStack getVaccination() {
+        return createCustomItem(
+                Material.HONEY_BOTTLE,
+                ChatColor.YELLOW + "Vaccination",
+                Arrays.asList(
+                        ChatColor.GRAY + "A potent cure for zombification.",
+                        ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Right-click a Zombie Villager to cure it.",
+                        ChatColor.DARK_PURPLE + "Artifact"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
 
     public static ItemStack getEntionPlastIngredient() {
         return createCustomItem(


### PR DESCRIPTION
## Summary
- add Vaccination artifact item
- allow clerics to sell the Vaccination at tier 2
- cure zombie villagers when right-clicked with the artifact
- keep villager's original name (stripping level prefix)

## Testing
- `mvn -q test` *(fails: Plugin resolution error due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685e717f430c83328b410504808078c4