### PR TITLE
Add failsafe when depositing items into pouches

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/CulinaryPouchManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/CulinaryPouchManager.java
@@ -95,11 +95,10 @@ public class CulinaryPouchManager implements Listener {
         for (int i = 0; i < inv.getSize(); i++) {
             ItemStack item = inv.getItem(i);
             if (isCulinaryDelight(item)) {
-                total += item.getAmount();
-                inv.setItem(i, null);
                 ItemStack leftover = addToStorage(player.getUniqueId(), item.clone());
-                if (leftover != null) {
-                    player.getWorld().dropItemNaturally(player.getLocation(), leftover);
+                if (leftover == null) {
+                    total += item.getAmount();
+                    inv.setItem(i, null);
                 }
             }
         }

--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/PotionPouchManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/PotionPouchManager.java
@@ -89,11 +89,10 @@ public class PotionPouchManager implements Listener {
         for (int i = 0; i < inv.getSize(); i++) {
             ItemStack item = inv.getItem(i);
             if (isPotion(item)) {
-                total += item.getAmount();
-                inv.setItem(i, null);
                 ItemStack leftover = addToStorage(player.getUniqueId(), item.clone());
-                if (leftover != null) {
-                    player.getWorld().dropItemNaturally(player.getLocation(), leftover);
+                if (leftover == null) {
+                    total += item.getAmount();
+                    inv.setItem(i, null);
                 }
             }
         }

--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/SeedPouchManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/SeedPouchManager.java
@@ -91,11 +91,10 @@ public class SeedPouchManager implements Listener {
         for (int i = 0; i < inv.getSize(); i++) {
             ItemStack item = inv.getItem(i);
             if (isVerdantSeed(item)) {
-                total += item.getAmount();
-                inv.setItem(i, null);
                 ItemStack leftover = addToStorage(player.getUniqueId(), item.clone());
-                if (leftover != null) {
-                    player.getWorld().dropItemNaturally(player.getLocation(), leftover);
+                if (leftover == null) {
+                    total += item.getAmount();
+                    inv.setItem(i, null);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- prevent item loss when depositing items into seed, potion and culinary pouches
- only remove items from inventory if the pouch accepts them

## Testing
- `javac -version`
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef2edaa648332abec17106dc3927d