### PR TITLE
Add remote villager trade command

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -580,6 +580,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         villagerWorkCycleManager = VillagerWorkCycleManager.getInstance(this);
         getCommand("forceworkcycle").setExecutor(villagerWorkCycleManager);
         getCommand("repair").setExecutor(new RepairCommand());
+        getCommand("openvillagertrademenu").setExecutor(new OpenVillagerTradeMenuCommand(this));
 
         getServer().getPluginManager().registerEvents(new MusicDiscManager(this), this);
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -1095,6 +1095,22 @@ public class VillagerTradeManager implements Listener {
         return Math.max(1, (int) Math.floor(finalCost));
     }
 
+    /**
+     * Opens the villager trade menu using a temporary villager instance.
+     * The spawned villager is removed once the menu closes.
+     */
+    public void openTradeMenu(Player player, Villager.Profession profession, int tier) {
+        int level = Math.max(1, Math.min(tier, MAX_VILLAGER_LEVEL));
+        Villager temp = player.getWorld().spawn(player.getLocation(), Villager.class);
+        temp.setAI(false);
+        temp.setInvisible(true);
+        temp.setProfession(profession);
+        temp.setVillagerLevel(level);
+        temp.setMetadata("tempTradeVillager", new FixedMetadataValue(plugin, true));
+        playerVillagerMap.put(player, temp);
+        openVillagerTradeGUI(player);
+    }
+
 
 
 
@@ -1324,6 +1340,12 @@ public class VillagerTradeManager implements Listener {
                         petManager.despawnPet(player);
                     }
                     player.playSound(player.getLocation(), Sound.BLOCK_FIRE_EXTINGUISH, 1.0f, 1.0f);
+                }
+
+                Villager stored = playerVillagerMap.get(player);
+                if (stored != null && stored.hasMetadata("tempTradeVillager")) {
+                    stored.remove();
+                    playerVillagerMap.remove(player);
                 }
 
                 // Reset the toggle-flag on close

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/OpenVillagerTradeMenuCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/OpenVillagerTradeMenuCommand.java
@@ -1,0 +1,56 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import goat.minecraft.minecraftnew.subsystems.villagers.VillagerTradeManager;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.Locale;
+
+/**
+ * Admin command to open a villager trade menu remotely.
+ * Usage: /openVillagerTradeMenu <profession> <tier>
+ */
+public class OpenVillagerTradeMenuCommand implements CommandExecutor {
+    private final JavaPlugin plugin;
+
+    public OpenVillagerTradeMenuCommand(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be used by players.");
+            return true;
+        }
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You do not have permission to use this command.");
+            return true;
+        }
+        if (args.length != 2) {
+            player.sendMessage(ChatColor.YELLOW + "Usage: /" + label + " <profession> <tier>");
+            return true;
+        }
+        Villager.Profession profession;
+        try {
+            profession = Villager.Profession.valueOf(args[0].toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            player.sendMessage(ChatColor.RED + "Unknown profession: " + args[0]);
+            return true;
+        }
+        int tier;
+        try {
+            tier = Integer.parseInt(args[1]);
+        } catch (NumberFormatException e) {
+            player.sendMessage(ChatColor.RED + "Tier must be a number.");
+            return true;
+        }
+        VillagerTradeManager.getInstance(plugin).openTradeMenu(player, profession, tier);
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -139,6 +139,10 @@ commands:
     description: Repairs the held item to full durability
     usage: /repair
     permission: continuity.admin
+  openvillagertrademenu:
+    description: Opens a villager trade menu for testing
+    usage: /openVillagerTradeMenu <profession> <tier>
+    permission: continuity.admin
   setskilllevel:
     description: Sets a player's skill level
     usage: /setskilllevel <player> <skill> <level>


### PR DESCRIPTION
## Summary
- add `/openVillagerTradeMenu` admin command
- spawn temporary invisible villager for GUI use
- clean up temporary villager when menu closes
- register command in plugin.yml and main plugin

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f45db965c8332b96768a80b55a7f4