### PR TITLE
Add admin commands for Structure Block

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -66,6 +66,9 @@ import goat.minecraft.minecraftnew.other.trinkets.MiningPouchManager;
 import goat.minecraft.minecraftnew.other.trinkets.TransfigurationPouchManager;
 import goat.minecraft.minecraftnew.other.trinkets.LavaBucketManager;
 import goat.minecraft.minecraftnew.other.trinkets.TrinketManager;
+import goat.minecraft.minecraftnew.subsystems.structureblocks.StructureBlockManager;
+import goat.minecraft.minecraftnew.subsystems.structureblocks.GetStructureBlockCommand;
+import goat.minecraft.minecraftnew.subsystems.structureblocks.SetStructureBlockPowerCommand;
 
 import goat.minecraft.minecraftnew.subsystems.music.PigStepArena;
 import goat.minecraft.minecraftnew.subsystems.realms.Tropic;
@@ -267,6 +270,8 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getCommand("continuitytp").setExecutor(new ContinuityTpCommand());
         getCommand("warp").setExecutor(new WarpCommand());
         getCommand("setbeaconpower").setExecutor(new SetBeaconPowerCommand());
+        getCommand("getstructureblock").setExecutor(new GetStructureBlockCommand());
+        getCommand("setstructureblockpower").setExecutor(new SetStructureBlockPowerCommand());
         getCommand("getnearestcatalysttype").setExecutor(new GetNearestCatalystTypeCommand());
 
 
@@ -292,6 +297,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         TransfigurationPouchManager.init(this);
         LavaBucketManager.init(this);
         TrinketManager.init(this);
+        StructureBlockManager.init(this);
         //getServer().getPluginManager().registerEvents(new GamblingTable(this), this);
 
         forestryPetManager = new ForestryPetManager(this);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/structureblocks/GetStructureBlockCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/structureblocks/GetStructureBlockCommand.java
@@ -1,0 +1,35 @@
+package goat.minecraft.minecraftnew.subsystems.structureblocks;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+public class GetStructureBlockCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be used by players!");
+            return true;
+        }
+
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You don't have permission to use this command!");
+            return true;
+        }
+
+        StructureBlockManager manager = StructureBlockManager.getInstance();
+        if (manager == null) {
+            player.sendMessage(ChatColor.RED + "StructureBlockManager not initialized!");
+            return true;
+        }
+
+        ItemStack block = manager.createStructureBlock();
+        player.getInventory().addItem(block);
+        player.sendMessage(ChatColor.GREEN + "You have received a Structure Block Charm.");
+        return true;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/structureblocks/SetStructureBlockPowerCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/structureblocks/SetStructureBlockPowerCommand.java
@@ -1,0 +1,60 @@
+package goat.minecraft.minecraftnew.subsystems.structureblocks;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class SetStructureBlockPowerCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be used by players!");
+            return true;
+        }
+
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You don't have permission to use this command!");
+            return true;
+        }
+
+        if (args.length != 1) {
+            player.sendMessage(ChatColor.RED + "Usage: /setstructureblockpower <power>");
+            return true;
+        }
+
+        int power;
+        try {
+            power = Integer.parseInt(args[0]);
+        } catch (NumberFormatException e) {
+            player.sendMessage(ChatColor.RED + "Invalid number!");
+            return true;
+        }
+
+        if (power < 0 || power > 10000) {
+            player.sendMessage(ChatColor.RED + "Power must be between 0 and 10,000!");
+            return true;
+        }
+
+        ItemStack item = player.getInventory().getItemInMainHand();
+        StructureBlockManager manager = StructureBlockManager.getInstance();
+        if (manager == null) {
+            player.sendMessage(ChatColor.RED + "StructureBlockManager not initialized!");
+            return true;
+        }
+
+        if (!manager.isStructureBlock(item)) {
+            player.sendMessage(ChatColor.RED + "You must be holding a Structure Block Charm!");
+            return true;
+        }
+
+        manager.setStructureBlockPower(item, power);
+        player.sendMessage(ChatColor.GREEN + "Structure Block power set to " + power + ".");
+        return true;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/structureblocks/StructureBlockManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/structureblocks/StructureBlockManager.java
@@ -1,0 +1,364 @@
+package goat.minecraft.minecraftnew.subsystems.structureblocks;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.NamespacedKey;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+public class StructureBlockManager implements Listener {
+
+    private static StructureBlockManager instance;
+    private final JavaPlugin plugin;
+
+    private File dataFile;
+    private FileConfiguration dataConfig;
+
+    private final NamespacedKey powerKey;
+    private final NamespacedKey idKey;
+    private final NamespacedKey functionKey;
+
+    private StructureBlockManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.powerKey = new NamespacedKey(plugin, "sb_power");
+        this.idKey = new NamespacedKey(plugin, "sb_id");
+        this.functionKey = new NamespacedKey(plugin, "sb_function");
+        initFile();
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    public static void init(JavaPlugin plugin) {
+        if (instance == null) {
+            instance = new StructureBlockManager(plugin);
+        }
+    }
+
+    public static StructureBlockManager getInstance() {
+        return instance;
+    }
+
+    private void initFile() {
+        dataFile = new File(plugin.getDataFolder(), "structureblocks.yml");
+        if (!dataFile.exists()) {
+            plugin.getDataFolder().mkdirs();
+            try {
+                dataFile.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        dataConfig = YamlConfiguration.loadConfiguration(dataFile);
+    }
+
+    // Create a new Structure Block charm with starting power 0
+    public ItemStack createStructureBlock() {
+        ItemStack item = new ItemStack(Material.STRUCTURE_BLOCK);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName(ChatColor.LIGHT_PURPLE + "Structure Block Charm");
+        List<String> lore = new ArrayList<>();
+        lore.add(ChatColor.AQUA + "Power: " + ChatColor.YELLOW + "0");
+        lore.add(ChatColor.GRAY + "Function: None");
+        meta.setLore(lore);
+
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        container.set(powerKey, PersistentDataType.INTEGER, 0);
+        container.set(idKey, PersistentDataType.STRING, UUID.randomUUID().toString());
+        container.set(functionKey, PersistentDataType.STRING, "None");
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    /** Determines if the given ItemStack is a Structure Block Charm. */
+    public boolean isStructureBlock(ItemStack item) {
+        if (item == null || item.getType() != Material.STRUCTURE_BLOCK) return false;
+        if (!item.hasItemMeta() || !item.getItemMeta().hasDisplayName()) return false;
+        String name = ChatColor.stripColor(item.getItemMeta().getDisplayName());
+        return name.equals("Structure Block Charm");
+    }
+
+    /** Sets the power of a Structure Block Charm. */
+    public void setStructureBlockPower(ItemStack item, int power) {
+        if (item == null) return;
+        setPower(item, power);
+    }
+
+    /** Returns the current power stored in a Structure Block Charm. */
+    public int getStructureBlockPower(ItemStack item) {
+        return getPower(item);
+    }
+
+    private int getPower(ItemStack item) {
+        if (item == null || item.getType() != Material.STRUCTURE_BLOCK) return 0;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return 0;
+        Integer val = meta.getPersistentDataContainer().get(powerKey, PersistentDataType.INTEGER);
+        return val == null ? 0 : val;
+    }
+
+    private void setPower(ItemStack item, int power) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        meta.getPersistentDataContainer().set(powerKey, PersistentDataType.INTEGER, power);
+        List<String> lore = meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
+        boolean found = false;
+        for (int i = 0; i < lore.size(); i++) {
+            String s = ChatColor.stripColor(lore.get(i));
+            if (s.startsWith("Power:")) {
+                lore.set(i, ChatColor.AQUA + "Power: " + ChatColor.YELLOW + power);
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            lore.add(0, ChatColor.AQUA + "Power: " + ChatColor.YELLOW + power);
+        }
+        meta.setLore(lore);
+        item.setItemMeta(meta);
+    }
+
+    private UUID getId(ItemStack item) {
+        if (item == null || !item.hasItemMeta()) return null;
+        String idStr = item.getItemMeta().getPersistentDataContainer().get(idKey, PersistentDataType.STRING);
+        if (idStr == null) return null;
+        try { return UUID.fromString(idStr); } catch (IllegalArgumentException e) { return null; }
+    }
+
+    private void setFunction(ItemStack item, String function) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        meta.getPersistentDataContainer().set(functionKey, PersistentDataType.STRING, function);
+        List<String> lore = meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
+        boolean found = false;
+        for (int i = 0; i < lore.size(); i++) {
+            String s = ChatColor.stripColor(lore.get(i));
+            if (s.startsWith("Function:")) {
+                lore.set(i, ChatColor.GRAY + "Function: " + ChatColor.YELLOW + function);
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            lore.add(ChatColor.GRAY + "Function: " + ChatColor.YELLOW + function);
+        }
+        meta.setLore(lore);
+        item.setItemMeta(meta);
+    }
+
+    private String getFunction(ItemStack item) {
+        if (item == null || !item.hasItemMeta()) return "None";
+        String val = item.getItemMeta().getPersistentDataContainer().get(functionKey, PersistentDataType.STRING);
+        return val == null ? "None" : val;
+    }
+
+    private ItemStack getStoredMaterial(UUID id) {
+        if (id == null) return null;
+        return dataConfig.getItemStack(id.toString());
+    }
+
+    private void saveStoredMaterial(UUID id, ItemStack stack) {
+        if (id == null) return;
+        if (stack == null || stack.getType() == Material.AIR) {
+            dataConfig.set(id.toString(), null);
+        } else {
+            dataConfig.set(id.toString(), stack);
+        }
+        try {
+            dataConfig.save(dataFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @EventHandler
+    public void onInteract(PlayerInteractEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) return;
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK && event.getAction() != Action.LEFT_CLICK_AIR) return;
+        Player player = event.getPlayer();
+        ItemStack item = player.getInventory().getItemInMainHand();
+        if (item == null || item.getType() != Material.STRUCTURE_BLOCK) return;
+        if (!item.hasItemMeta() || !item.getItemMeta().hasDisplayName()) return;
+        String name = ChatColor.stripColor(item.getItemMeta().getDisplayName());
+        if (!name.equals("Structure Block Charm")) return;
+        event.setCancelled(true);
+        new StructureBlockGUI(plugin, item).open(player);
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player)) return;
+        Player player = (Player) event.getWhoClicked();
+        ItemStack cursor = event.getCursor();
+        ItemStack clicked = event.getCurrentItem();
+        if (cursor == null || clicked == null) return;
+        if (clicked.getType() != Material.STRUCTURE_BLOCK) return;
+        if (!clicked.hasItemMeta() || !ChatColor.stripColor(clicked.getItemMeta().getDisplayName()).equals("Structure Block Charm")) return;
+        if (!cursor.getType().isBlock()) return;
+        // Only handle top inventory or player inventory? Follows beacon logic.
+        int add = cursor.getType() == Material.OBSIDIAN ? 10 : 1;
+        int amount = cursor.getAmount();
+        int current = getPower(clicked);
+        int newVal = Math.min(current + add * amount, 10000);
+        if (newVal == current) {
+            player.sendMessage(ChatColor.RED + "This Structure Block is already at maximum power (10,000)!");
+            return;
+        }
+        setPower(clicked, newVal);
+        player.playSound(player.getLocation(), Sound.BLOCK_BEACON_POWER_SELECT, 1f, 1.2f);
+        player.sendMessage(ChatColor.GOLD + "Added " + ChatColor.YELLOW + amount + "x " + cursor.getType().name().toLowerCase().replace('_',' ') + ChatColor.GOLD + " (+" + (add*amount) + " Power)" );
+        event.setCursor(null);
+        event.setCancelled(true);
+    }
+
+    class StructureBlockGUI implements Listener {
+        private final JavaPlugin plugin;
+        private final ItemStack blockItem;
+        private final String title;
+        private final UUID id;
+        private org.bukkit.inventory.Inventory gui;
+
+        StructureBlockGUI(JavaPlugin plugin, ItemStack item) {
+            this.plugin = plugin;
+            this.blockItem = item;
+            this.title = ChatColor.LIGHT_PURPLE + "Structure Block";
+            this.id = getId(item);
+            Bukkit.getPluginManager().registerEvents(this, plugin);
+        }
+
+        void open(Player player) {
+            gui = Bukkit.createInventory(null, 27, title);
+            ItemStack stored = getStoredMaterial(id);
+            if (stored != null) gui.setItem(13, stored);
+
+            ItemStack func = new ItemStack(Material.WRITABLE_BOOK);
+            ItemMeta fm = func.getItemMeta();
+            fm.setDisplayName(ChatColor.GREEN + "Functions");
+            List<String> lore = new ArrayList<>();
+            lore.add(ChatColor.GRAY + "Current: " + ChatColor.YELLOW + getFunction(blockItem));
+            lore.add(ChatColor.YELLOW + "Click to change!");
+            fm.setLore(lore);
+            func.setItemMeta(fm);
+            gui.setItem(11, func);
+
+            ItemStack coming = new ItemStack(Material.BARRIER);
+            ItemMeta cm = coming.getItemMeta();
+            cm.setDisplayName(ChatColor.RED + "Coming Soon");
+            coming.setItemMeta(cm);
+            gui.setItem(15, coming);
+
+            fill(gui);
+            player.openInventory(gui);
+        }
+
+        private void fill(org.bukkit.inventory.Inventory inv) {
+            ItemStack filler = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+            ItemMeta meta = filler.getItemMeta();
+            meta.setDisplayName(" ");
+            filler.setItemMeta(meta);
+            for (int i=0;i<inv.getSize();i++) {
+                if (inv.getItem(i)==null) inv.setItem(i, filler);
+            }
+        }
+
+        @EventHandler
+        public void onClick(InventoryClickEvent event) {
+            if (!event.getView().getTitle().equals(title)) return;
+            event.setCancelled(true);
+            if (!(event.getWhoClicked() instanceof Player)) return;
+            Player player = (Player) event.getWhoClicked();
+            int slot = event.getRawSlot();
+            if (slot == 13) {
+                // allow placing one item as material
+                ItemStack cursor = event.getCursor();
+                if (cursor != null && cursor.getType() != Material.AIR) {
+                    ItemStack single = cursor.clone();
+                    single.setAmount(1);
+                    gui.setItem(13, single);
+                    event.setCursor(null);
+                }
+            } else if (slot == 11) {
+                new FunctionGUI(plugin, blockItem).open(player);
+            }
+        }
+
+        @EventHandler
+        public void onClose(org.bukkit.event.inventory.InventoryCloseEvent event) {
+            if (!event.getView().getTitle().equals(title)) return;
+            org.bukkit.inventory.Inventory inv = event.getInventory();
+            ItemStack mat = inv.getItem(13);
+            saveStoredMaterial(id, mat);
+            HandlerList.unregisterAll(this);
+        }
+
+    }
+
+    class FunctionGUI implements Listener {
+        private final JavaPlugin plugin;
+        private final ItemStack blockItem;
+        private final String title = ChatColor.GREEN + "Select Function";
+
+        FunctionGUI(JavaPlugin plugin, ItemStack item) {
+            this.plugin = plugin;
+            this.blockItem = item;
+            Bukkit.getPluginManager().registerEvents(this, plugin);
+        }
+
+        void open(Player player) {
+            org.bukkit.inventory.Inventory inv = Bukkit.createInventory(null, 9, title);
+            inv.setItem(1, create(Material.STONE, "3x3 Wall", "3x3"));
+            inv.setItem(3, create(Material.LADDER, "Vertical Fill", "Vertical"));
+            inv.setItem(5, create(Material.OAK_PLANKS, "Horizontal Fill", "Horizontal"));
+            inv.setItem(7, create(Material.CHEST, "Custom Cuboid", "Custom"));
+            player.openInventory(inv);
+        }
+
+        private ItemStack create(Material mat, String name, String id) {
+            ItemStack item = new ItemStack(mat);
+            ItemMeta meta = item.getItemMeta();
+            meta.setDisplayName(ChatColor.YELLOW + name);
+            meta.getPersistentDataContainer().set(new NamespacedKey(plugin, "func"), PersistentDataType.STRING, id);
+            item.setItemMeta(meta);
+            return item;
+        }
+
+        @EventHandler
+        public void onClick(InventoryClickEvent event) {
+            if (!event.getView().getTitle().equals(title)) return;
+            event.setCancelled(true);
+            ItemStack clicked = event.getCurrentItem();
+            if (clicked == null || !clicked.hasItemMeta()) return;
+            String func = clicked.getItemMeta().getPersistentDataContainer().get(new NamespacedKey(plugin, "func"), PersistentDataType.STRING);
+            if (func == null) return;
+            setFunction(blockItem, func);
+            ((Player)event.getWhoClicked()).sendMessage(ChatColor.GREEN + "Function set to " + func);
+            event.getWhoClicked().closeInventory();
+            HandlerList.unregisterAll(this);
+        }
+
+        @EventHandler
+        public void onClose(org.bukkit.event.inventory.InventoryCloseEvent event) {
+            if (event.getView().getTitle().equals(title)) {
+                HandlerList.unregisterAll(this);
+            }
+        }
+    }
+}
+

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -2,6 +2,7 @@ package goat.minecraft.minecraftnew.utils.devtools;
 
 
 import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.structureblocks.StructureBlockManager;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -4243,5 +4244,14 @@ public class ItemRegistry {
                 false,
                 true
         );
+    }
+
+    /** Provides the Structure Block Charm for building assistance. */
+    public static ItemStack getStructureBlockCharm() {
+        StructureBlockManager manager = StructureBlockManager.getInstance();
+        if (manager == null) {
+            return null;
+        }
+        return manager.createStructureBlock();
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -163,3 +163,11 @@ commands:
     description: Skip the assault rest period
     usage: /skip
     default: true
+  getstructureblock:
+    description: Gives a Structure Block Charm with zero power
+    usage: /getstructureblock
+    permission: continuity.admin
+  setstructureblockpower:
+    description: Sets the power of a Structure Block Charm in your hand
+    usage: /setstructureblockpower <power>
+    permission: continuity.admin


### PR DESCRIPTION
## Summary
- expose Structure Block manager methods
- add `/getstructureblock` and `/setstructureblockpower` commands
- register commands in `MinecraftNew`
- document commands in plugin.yml

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6860568542e88332a307b0a14d3b1d3c