### PR TITLE
Add skin removal using water cauldron

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -247,6 +247,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
 
         new Sleep(this);
         getServer().getPluginManager().registerEvents(new ShulkerBox(), this);
+        getServer().getPluginManager().registerEvents(new SkinRemovalCauldron(), this);
         getServer().getPluginManager().registerEvents(new BeaconManager(this), this);
         getServer().getPluginManager().registerEvents(new BeaconCharmGUI(this, null), this);
         BeaconPassivesGUI.init(this);

--- a/src/main/java/goat/minecraft/minecraftnew/other/qol/SkinRemovalCauldron.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/qol/SkinRemovalCauldron.java
@@ -1,0 +1,41 @@
+package goat.minecraft.minecraftnew.other.qol;
+
+import goat.minecraft.minecraftnew.utils.devtools.SkinManager;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Removes an item's skin when right-clicking a water cauldron.
+ */
+public class SkinRemovalCauldron implements Listener {
+
+    @EventHandler
+    public void onCauldronUse(PlayerInteractEvent event) {
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
+        if (event.getHand() != EquipmentSlot.HAND) return;
+
+        Block block = event.getClickedBlock();
+        if (block == null || block.getType() != Material.WATER_CAULDRON) return;
+
+        Player player = event.getPlayer();
+        ItemStack item = player.getInventory().getItemInMainHand();
+        if (item == null) return;
+
+        // Attempt to remove skin information
+        int before = (item.hasItemMeta() && item.getItemMeta().hasLore()) ? item.getItemMeta().getLore().size() : 0;
+        SkinManager.removeSkin(item);
+        int after = (item.hasItemMeta() && item.getItemMeta().hasLore()) ? item.getItemMeta().getLore().size() : 0;
+
+        if (after < before) {
+            player.sendMessage(ChatColor.GREEN + "Skin removed from item!");
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/SkinManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/SkinManager.java
@@ -48,5 +48,26 @@ public class SkinManager {
         item.setItemMeta(meta);
     }
 
+    /**
+     * Removes any skin information from the lore of the given ItemStack.
+     *
+     * @param item The ItemStack whose lore will be modified.
+     */
+    public static void removeSkin(ItemStack item) {
+        if (item == null) {
+            return; // No item provided
+        }
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null || !meta.hasLore()) {
+            return; // Nothing to remove
+        }
+
+        List<String> lore = new ArrayList<>(meta.getLore());
+        lore.removeIf(line -> line.startsWith(ChatColor.DARK_PURPLE + "Skin:"));
+        meta.setLore(lore);
+        item.setItemMeta(meta);
+    }
+
     // Additional helper methods can be added here if needed in the future.
 }


### PR DESCRIPTION
## Summary
- add helper in `SkinManager` to remove skin lore
- implement `SkinRemovalCauldron` listener to strip skins when a player right clicks a water cauldron
- register `SkinRemovalCauldron` in plugin initialization

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860966db1b08332b189c7114205559d