### PR TITLE
Prevent sea creatures from transforming into knights

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SpawnMonsters.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SpawnMonsters.java
@@ -331,8 +331,8 @@ public class SpawnMonsters implements Listener {
         }
 
         if (entity instanceof Zombie zombie) {
-            //knight mutation
-            if (shouldMutationOccur(playerHostility)) {
+            //knight mutation - skip sea creatures
+            if (!entity.hasMetadata("SEA_CREATURE") && shouldMutationOccur(playerHostility)) {
                 KnightMob knightMob = new KnightMob(plugin);
                 knightMob.transformToKnight(zombie);
                 zombie.setCustomName(ChatColor.GRAY + "Knight");
@@ -387,7 +387,8 @@ public class SpawnMonsters implements Listener {
             }
         }
         if (entity instanceof WitherSkeleton ws) {
-            if (shouldMutationOccur(playerHostility)) {
+            //knight mutation - skip sea creatures
+            if (!entity.hasMetadata("SEA_CREATURE") && shouldMutationOccur(playerHostility)) {
                 KnightMob knightMob = new KnightMob(plugin);
                 knightMob.transformToKnight(ws);
                 ws.setCustomName(ChatColor.GRAY + "Knight");


### PR DESCRIPTION
## Summary
- avoid knight transformation for mobs marked as `SEA_CREATURE`

## Testing
- `mvn -q package -DskipTests` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68609e94e6a883328a3d3be8bcc0b7e0