### PR TITLE
Add Buddy System perk to turtle pet

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/FishingEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/FishingEvent.java
@@ -156,6 +156,15 @@ public class FishingEvent implements Listener {
                 seaCreatureChance += heartOfTheSeaBonus;
             }
 
+            if (activePet.hasPerk(PetManager.PetPerk.BUDDY_SYSTEM)) {
+                for (Player other : player.getWorld().getPlayers()) {
+                    if (!other.equals(player) && other.getLocation().distance(player.getLocation()) <= 20) {
+                        seaCreatureChance += 5;
+                        break;
+                    }
+                }
+            }
+
             if (activePet.hasPerk(PetManager.PetPerk.BAIT)) {
                 seaCreatureChance += (double) activePet.getLevel() / 10;; // +10% from Heart of the Sea perk
             }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
@@ -590,6 +590,8 @@ public class PetManager implements Listener {
             case ANGLER:
                 int anglerBonus = 5;
                 return "Grants " + ChatColor.AQUA + anglerBonus + "% Sea Creature Chance.";
+            case BUDDY_SYSTEM:
+                return "Grants " + ChatColor.AQUA + "+5 Sea Creature Chance " + ChatColor.GRAY + "near other players.";
             case HEART_OF_THE_SEA:
                 int heartBonus = 10;
                 return "Grants " + ChatColor.AQUA + heartBonus + "% Sea Creature Chance.";
@@ -920,6 +922,7 @@ public class PetManager implements Listener {
         COMFORTABLE("Comfortable","Grants you with 1 bonus health per 10 levels when eating."),
         LULLABY("Lullaby","Lulls monsters back to sleep, preventing their spawning."),
         ANGLER("Angler","+5 Sea Creature Chance"),
+        BUDDY_SYSTEM("Buddy System", "+5 Sea Creature Chance near other players"),
         ANTIDOTE("Antidote","Cures a random negative potion effect on eating."),
         LEAP("Leap","Enables you to leap forward when shifting."),
         SOFT_PAW("Soft Paw","Reduces fall damage."),

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetRegistry.java
@@ -88,7 +88,7 @@ public class PetRegistry {
                 PetManager.Rarity.EPIC,
                 100,
                 Particle.CRIMSON_SPORE,
-                Arrays.asList(PetManager.PetPerk.HEART_OF_THE_SEA, PetManager.PetPerk.BONE_PLATING, PetManager.PetPerk.COMFORTABLE)
+                Arrays.asList(PetManager.PetPerk.HEART_OF_THE_SEA, PetManager.PetPerk.BONE_PLATING, PetManager.PetPerk.COMFORTABLE, PetManager.PetPerk.BUDDY_SYSTEM)
         ));
         registry.put("Dolphin", new PetDefinition(
                 "Dolphin",


### PR DESCRIPTION
## Summary
- introduce new `BUDDY_SYSTEM` pet perk
- give the turtle pet the Buddy System perk
- add perk effect: +5 sea creature chance near other players

## Testing
- `mvn -q test` *(fails: Plugin resolution failed)*
- `mvn -q -DskipTests package` *(fails: Plugin resolution failed)*

------
https://chatgpt.com/codex/tasks/task_e_6860a6c429d48332a71ae4c6a2c24edd