### PR TITLE
Enhance Chirp disc with relic growth boost

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/RightClickArtifacts.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/RightClickArtifacts.java
@@ -1045,7 +1045,8 @@ public class RightClickArtifacts implements Listener {
                 ChatColor.YELLOW,
                 List.of(
                         ChatColor.GRAY + "Triggers Timber Boost for 3 minutes 5 seconds",
-                        ChatColor.GRAY + "Chance to yield bonus logs and extra Forestry XP, as well as Forest Spirits"
+                        ChatColor.GRAY + "Chance to yield bonus logs and extra Forestry XP, as well as Forest Spirits",
+                        ChatColor.GRAY + "Speeds up Verdant Relic growth by 3 seconds every second"
                 )
         ));
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/VerdantRelicsSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/VerdantRelicsSubsystem.java
@@ -186,6 +186,20 @@ public class VerdantRelicsSubsystem implements Listener {
         return cured;
     }
 
+    /**
+     * Accelerates growth of all active relics by the given amount of seconds.
+     * Used by certain music discs to temporarily speed up farming progress.
+     *
+     * @param seconds amount of growth time to subtract from each relic
+     */
+    public void accelerateGrowthAll(int seconds) {
+        if (seconds <= 0) return;
+        for (RelicSession session : activeSessions.values()) {
+            session.accelerateGrowth(seconds);
+        }
+        saveAllRelics();
+    }
+
     // ─────────────────────────────────────────────────────────────────────────
     //                         Coordinate Utilities
     // ─────────────────────────────────────────────────────────────────────────
@@ -758,6 +772,19 @@ public class VerdantRelicsSubsystem implements Listener {
                 growthLine += ChatColor.GOLD + " [READY TO HARVEST]";
             }
             growthDisplayStand.setCustomName(growthLine);
+        }
+
+        /**
+         * Reduce the remaining growth time by the given seconds.
+         * Marks the relic ready for harvest if time reaches zero.
+         */
+        public void accelerateGrowth(int seconds) {
+            if (readyForHarvest || seconds <= 0) return;
+            growthTimeRemaining = Math.max(growthTimeRemaining - seconds, 0);
+            if (growthTimeRemaining == 0) {
+                readyForHarvest = true;
+            }
+            updateDisplayName();
         }
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/music/MusicDiscManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/music/MusicDiscManager.java
@@ -8,6 +8,7 @@ import goat.minecraft.minecraftnew.subsystems.forestry.Forestry;
 import goat.minecraft.minecraftnew.subsystems.mining.PlayerOxygenManager;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
 import goat.minecraft.minecraftnew.subsystems.pets.PetRegistry;
+import goat.minecraft.minecraftnew.subsystems.farming.VerdantRelicsSubsystem;
 import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
 import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
@@ -877,6 +878,21 @@ public class MusicDiscManager implements Listener {
                 ticks++;
             }
         }.runTaskTimer(plugin, 0L, 1L);
+
+        // Accelerate growth of all Verdant Relics by 3 seconds each second
+        VerdantRelicsSubsystem relics = VerdantRelicsSubsystem.getInstance(MinecraftNew.getInstance());
+        new BukkitRunnable() {
+            int elapsed = 0;
+            @Override
+            public void run() {
+                if (elapsed >= durationTicks) {
+                    cancel();
+                    return;
+                }
+                relics.accelerateGrowthAll(3);
+                elapsed += 20;
+            }
+        }.runTaskTimer(plugin, 0L, 20L);
 
         // Listener for block-breaking events during the Timber Boost
         Listener logBreakListener = new Listener() {

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/DiscsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/DiscsCommand.java
@@ -66,7 +66,8 @@ public class DiscsCommand implements CommandExecutor, Listener {
                 ChatColor.YELLOW,
                 Arrays.asList(
                         "Enrages the Forest Spirits for 3 minutes 5 seconds",
-                        "Chance to yield bonus logs and extra Forestry XP, as well as Tier 5 Forest Spirits"
+                        "Chance to yield bonus logs and extra Forestry XP, as well as Tier 5 Forest Spirits",
+                        "Speeds up Verdant Relic growth by 3 seconds every second"
                 )
         ));
         discDataMap.put(Material.MUSIC_DISC_FAR, new DiscData(


### PR DESCRIPTION
## Summary
- accelerate verdant relic growth via new helper
- expose accelerate method on each relic session
- make Chirp music disc speed up relic growth while active
- document growth boost for Chirp disc in /discs info

## Testing
- `mvn -q -DskipTests package` *(fails: network unreachable during plugin resolve)*

------
https://chatgpt.com/codex/tasks/task_e_6860a646ac08833288776fe66596bcfd