### PR TITLE
Add Witch pet with brewing perks

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
@@ -3,6 +3,7 @@ package goat.minecraft.minecraftnew.subsystems.brewing;
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
+import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.ConfigurationSection;
@@ -529,6 +530,13 @@ public class PotionBrewingSubsystem implements Listener {
                     PlayerMeritManager meritManager = PlayerMeritManager.getInstance(plugin);
                     if (meritManager.hasPerk(player.getUniqueId(), "Master Brewer")) {
                         brewTimeRemaining = (int) Math.ceil(brewTimeRemaining * 0.5);
+                    }
+
+                    PetManager petManager = PetManager.getInstance(plugin);
+                    PetManager.Pet pet = petManager.getActivePet(player);
+                    if (pet != null && pet.hasPerk(PetManager.PetPerk.SPLASH_POTION)) {
+                        double reduction = pet.getLevel() / 100.0;
+                        brewTimeRemaining = (int) Math.ceil(brewTimeRemaining * (1 - reduction));
                     }
                 }
             }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionManager.java
@@ -2,6 +2,7 @@ package goat.minecraft.minecraftnew.subsystems.brewing;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
+import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.ConfigurationSection;
@@ -44,6 +45,11 @@ public class PotionManager {
         if(playerMeritManager.hasPerk(player.getUniqueId(), "Strong Digestion")){
             duration = duration * 2;
             Bukkit.getLogger().info("Doubled Effect Duration from Strong Digestion Perk!");
+        }
+        PetManager petManager = PetManager.getInstance(plugin);
+        PetManager.Pet pet = petManager.getActivePet(player);
+        if(pet != null && pet.hasPerk(PetManager.PetPerk.EXPERIMENTATION)){
+            duration += 3 * pet.getLevel();
         }
         Map<String, Integer> playerEffects = activeEffects.getOrDefault(uuid, new HashMap<>());
         // If the effect is already active, add the new duration to the current duration

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
@@ -94,6 +94,7 @@ public class PetManager implements Listener {
         PET_TEXTURES.put("Poseidon", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYmVjYjJhYTNhNTE0MTQ4ODU3NzI4OGEyOGZmMzk0NmI0MzQyOWY1NmJkMjIzMDFkOTFmYTM3MWU3NjVmM2I4YSJ9fX0=");
         PET_TEXTURES.put("waterspider", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYzZhZjM5N2Q5N2I0NjcwMTQ5NmRmMmJkNmFmNGU0ZDdjZjYxMGY3MzcyMzlmZDMzYzlhMGE5MzMxOWUwODBmYiJ9fX0=");
         PET_TEXTURES.put("Midas", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZjZjNWVlY2QyMTljNWUyM2Q4MjFjZmZkYWNiNTk3ZWQyM2M2MzI3YTI3MjM2Yzk4MjFjZGQ5NjgyNmQ5Y2E0MyJ9fX0=");
+        PET_TEXTURES.put("Witch", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvN2U3MWE2ZWIzMDNhYjdlNmY3MGVkNTRkZjkxNDZhODBlYWRmMzk2NDE3Y2VlOTQ5NTc3M2ZmYmViZmFkODg3YyJ9fX0=");
         //mutations
         PET_TEXTURES.put("diver", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTc4MzBjMWQ4Mjg0NWM5MWI4MzQyOWY5ZGM1OTczMTc4NDE1MzhlMTRkNGZiZWQ2MWFlMWEzYjBlYjdjY2QifX19");
     }
@@ -649,6 +650,10 @@ public class PetManager implements Listener {
                 return "Creates " + ChatColor.RED + "explosive fire bursts " + ChatColor.GRAY + "while moving that deal " + ChatColor.RED + String.format("%.1f", flameDamage) + " damage " + ChatColor.GRAY + "to monsters within " + ChatColor.YELLOW + "8 blocks" + ChatColor.GRAY + ". Distance reduces damage.";
             case ENDLESS_WARP:
                 return ChatColor.DARK_PURPLE + "Grants infinite Warp charges for the Warp enchant.";
+            case SPLASH_POTION:
+                return "Reduces brew time by " + ChatColor.YELLOW + level + "%" + ChatColor.GRAY + ".";
+            case EXPERIMENTATION:
+                return "Potions last " + ChatColor.YELLOW + (3 * level) + "s" + ChatColor.GRAY + " longer.";
             default:
                 return ChatColor.GRAY + "Static effect or undefined scaling.";
 
@@ -950,7 +955,9 @@ public class PetManager implements Listener {
         EARTHWORM("Earthworm", ChatColor.GOLD + ""),
         PHOENIX_REBIRTH("Phoenix Rebirth", ChatColor.GOLD + ""),
         FLAME_TRAIL("Flame Trail", ChatColor.GOLD + ""),
-        ENDLESS_WARP("Endless Warp", ChatColor.GOLD + "");
+        ENDLESS_WARP("Endless Warp", ChatColor.GOLD + ""),
+        SPLASH_POTION("Splash Potion", ChatColor.GOLD + ""),
+        EXPERIMENTATION("Experimentation", ChatColor.GOLD + "");
 
         private final String displayName;
         private final String description;

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetRegistry.java
@@ -362,6 +362,13 @@ public class PetRegistry {
                 Particle.FLAME,
                 Arrays.asList(PetManager.PetPerk.PHOENIX_REBIRTH, PetManager.PetPerk.FLAME_TRAIL, PetManager.PetPerk.FIREPROOF, PetManager.PetPerk.FLIGHT, PetManager.PetPerk.ELITE)
         ));
+        registry.put("Witch", new PetDefinition(
+                "Witch",
+                PetManager.Rarity.EPIC,
+                100,
+                Particle.SPELL_WITCH,
+                Arrays.asList(PetManager.PetPerk.SPEED_BOOST, PetManager.PetPerk.ANTIDOTE, PetManager.PetPerk.FLIGHT, PetManager.PetPerk.SPLASH_POTION, PetManager.PetPerk.EXPERIMENTATION)
+        ));
     }
     // Inside PetManager class
     public void addPetByName(Player player, String petName) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/petdrops/PetDrops.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/petdrops/PetDrops.java
@@ -58,6 +58,7 @@ public class PetDrops implements Listener {
         mobToPetMap.put(EntityType.ZOMBIE, "Zombie");
         mobToPetMap.put(EntityType.VINDICATOR, "Vindicator");
         mobToPetMap.put(EntityType.ZOMBIFIED_PIGLIN, "Zombie Pigman");
+        mobToPetMap.put(EntityType.WITCH, "Witch");
         // Add more mappings as needed
     }
 
@@ -94,6 +95,11 @@ public class PetDrops implements Listener {
                 if (random.nextDouble() < 0.5) {
                     // Drop the pet item
                     petRegistry.addPetByName(player, "Warden");                }
+            }
+            if(entityType.equals(EntityType.WITCH)) {
+                if (random.nextDouble() < 0.1) {
+                    petRegistry.addPetByName(player, "Witch");
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- implement Splash Potion and Experimentation perks
- reduce brew time when Splash Potion perk is active
- extend potion duration when Experimentation perk is active
- add Witch pet data and drop logic

## Testing
- `mvn -q package -DskipTests` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6860b426ce1c8332b7a892a0c99a33bd