### PR TITLE
Add Broomstick flight perk

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -386,6 +386,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new MithrilMiner(this), this);
         getServer().getPluginManager().registerEvents(new EmeraldSeeker(this), this);
         getServer().getPluginManager().registerEvents(new Flight(this), this);
+        getServer().getPluginManager().registerEvents(new Broomstick(this), this);
         getServer().getPluginManager().registerEvents(new Lullaby(this), this);
         getServer().getPluginManager().registerEvents(new Collector(this), this);
         getServer().getPluginManager().registerEvents(new Float(this), this);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
@@ -541,6 +541,8 @@ public class PetManager implements Listener {
                 return "Prevents " + ChatColor.DARK_GRAY + "monsters from spawning " + ChatColor.GRAY + "within " + ChatColor.YELLOW + ((level * 4) + 40) + " blocks.";
             case FLIGHT:
                 return "Gain the ability to " + ChatColor.YELLOW + "Fly for " + level * 0.01 + " km";
+            case BROOMSTICK:
+                return "Fly endlessly but your health drops to 1 while flying.";
             case EMERALD_SEEKER:
                 return "Gain a " + ChatColor.GREEN + "4% chance " + ChatColor.GRAY + "to mine an " + ChatColor.GREEN + "Emerald.";
             case MITHRIL_MINER:
@@ -940,6 +942,7 @@ public class PetManager implements Listener {
         COLLECTOR("Collector", ChatColor.GOLD + "Automatically collects nearby items upon walking nearby."),
         LUMBERJACK("Lumberjack", ChatColor.GOLD + "Grants 2 extra logs when chopping trees."),
         FLIGHT("Flight", ChatColor.GOLD + "Grants the ability to fly."),
+        BROOMSTICK("Broomstick", ChatColor.GOLD + "Infinite flight but health is reduced to 1 while flying."),
         SPEED_BOOST("Speed Boost", ChatColor.GOLD + "Increases your walking speed by 100%."),
         SECOND_WIND("Second Wind", ChatColor.GOLD + "Provides [Lvl] seconds of regeneration when taking damage."),
         SHOTCALLING("Shotcalling", ChatColor.GOLD + "Increases arrow damage by 1% per [Lvl]"),

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetRegistry.java
@@ -367,7 +367,7 @@ public class PetRegistry {
                 PetManager.Rarity.EPIC,
                 100,
                 Particle.SPELL_WITCH,
-                Arrays.asList(PetManager.PetPerk.SPEED_BOOST, PetManager.PetPerk.ANTIDOTE, PetManager.PetPerk.FLIGHT, PetManager.PetPerk.SPLASH_POTION, PetManager.PetPerk.EXPERIMENTATION)
+                Arrays.asList(PetManager.PetPerk.SPEED_BOOST, PetManager.PetPerk.ANTIDOTE, PetManager.PetPerk.BROOMSTICK, PetManager.PetPerk.SPLASH_POTION, PetManager.PetPerk.EXPERIMENTATION)
         ));
     }
     // Inside PetManager class

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/Broomstick.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/Broomstick.java
@@ -1,0 +1,70 @@
+package goat.minecraft.minecraftnew.subsystems.pets.perks;
+
+import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerToggleFlightEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Grants unlimited flight to the player but forces their health to remain at one
+ * heart while flying.
+ */
+public class Broomstick implements Listener {
+
+    private final PetManager petManager;
+    private final Map<UUID, Double> previousHealth = new HashMap<>();
+
+    public Broomstick(JavaPlugin plugin) {
+        this.petManager = PetManager.getInstance(plugin);
+    }
+
+    /**
+     * Ensure players with the perk can take flight.
+     */
+    @EventHandler
+    public void onPlayerMove(PlayerMoveEvent event) {
+        Player player = event.getPlayer();
+        PetManager.Pet activePet = petManager.getActivePet(player);
+
+        if (activePet != null && activePet.hasPerk(PetManager.PetPerk.BROOMSTICK)) {
+            if (!player.getAllowFlight()) {
+                player.setAllowFlight(true);
+            }
+        }
+    }
+
+    /**
+     * Handle the transition into and out of flight to adjust health accordingly.
+     */
+    @EventHandler
+    public void onToggleFlight(PlayerToggleFlightEvent event) {
+        Player player = event.getPlayer();
+        PetManager.Pet activePet = petManager.getActivePet(player);
+
+        if (activePet == null || !activePet.hasPerk(PetManager.PetPerk.BROOMSTICK)) {
+            return;
+        }
+
+        if (event.isFlying()) {
+            previousHealth.put(player.getUniqueId(), player.getHealth());
+            if (player.getHealth() > 1.0) {
+                player.setHealth(1.0);
+            }
+        } else {
+            UUID id = player.getUniqueId();
+            if (previousHealth.containsKey(id)) {
+                double prev = previousHealth.remove(id);
+                if (player.getHealth() < prev) {
+                    player.setHealth(Math.min(prev, player.getMaxHealth()));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `Broomstick` pet perk for the Witch
- register new perk events
- update Witch pet definition
- document Broomstick behavior in perk descriptions

## Testing
- `mvn -q -DskipTests install` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860bcc9f1dc8332b316b2cb7209bb4b