### PR TITLE
Add hunger and saturation caching for Broomstick perk

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/Broomstick.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/Broomstick.java
@@ -14,12 +14,14 @@ import java.util.UUID;
 
 /**
  * Grants unlimited flight to the player but forces their health to remain at one
- * heart while flying.
+ * heart while flying. Hunger and saturation are restored when flight ends.
  */
 public class Broomstick implements Listener {
 
     private final PetManager petManager;
     private final Map<UUID, Double> previousHealth = new HashMap<>();
+    private final Map<UUID, Integer> previousFood = new HashMap<>();
+    private final Map<UUID, Float> previousSaturation = new HashMap<>();
 
     public Broomstick(JavaPlugin plugin) {
         this.petManager = PetManager.getInstance(plugin);
@@ -53,7 +55,11 @@ public class Broomstick implements Listener {
         }
 
         if (event.isFlying()) {
-            previousHealth.put(player.getUniqueId(), player.getHealth());
+            UUID id = player.getUniqueId();
+            previousHealth.put(id, player.getHealth());
+            previousFood.put(id, player.getFoodLevel());
+            previousSaturation.put(id, player.getSaturation());
+
             if (player.getHealth() > 1.0) {
                 player.setHealth(1.0);
             }
@@ -63,6 +69,18 @@ public class Broomstick implements Listener {
                 double prev = previousHealth.remove(id);
                 if (player.getHealth() < prev) {
                     player.setHealth(Math.min(prev, player.getMaxHealth()));
+                }
+            }
+            if (previousFood.containsKey(id)) {
+                int prevFood = previousFood.remove(id);
+                if (player.getFoodLevel() < prevFood) {
+                    player.setFoodLevel(Math.min(prevFood, 20));
+                }
+            }
+            if (previousSaturation.containsKey(id)) {
+                float prevSat = previousSaturation.remove(id);
+                if (player.getSaturation() < prevSat) {
+                    player.setSaturation(Math.min(prevSat, player.getFoodLevel()));
                 }
             }
         }


### PR DESCRIPTION
## Summary
- extend `Broomstick` perk to remember players' hunger and saturation
- restore cached health, hunger and saturation when flight ends

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860d0aac94883328ebcecf65adf79f6