### PR TITLE
Fix sea creature drop logic

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureDeathEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureDeathEvent.java
@@ -75,6 +75,8 @@ public class SeaCreatureDeathEvent implements Listener {
             return;
         }
 
+        // Prevent vanilla mob drops from being added to the loot table
+        event.getDrops().clear();
 
         SeaCreature seaCreature = optionalSeaCreature.get();
         Player killer = event.getEntity().getKiller();


### PR DESCRIPTION
## Summary
- clear default drops from sea creatures to disable normal mob loot

## Testing
- `mvn package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6860f231a4d08332bb0148040fc004f5