### PR TITLE
Prevent combat XP from sea creatures and spirits

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/KillMonster.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/KillMonster.java
@@ -87,8 +87,11 @@ public class KillMonster implements Listener {
                 xpGain += bonusXP;
             }
     
-            // Add XP to the player
-            xpManager.addXP(playerKiller, "Combat", xpGain);
+            // Skip combat XP for sea creatures and forest spirits
+            if (!entity.hasMetadata("SEA_CREATURE") && !entity.hasMetadata("forestSpirit")) {
+                // Add XP to the player
+                xpManager.addXP(playerKiller, "Combat", xpGain);
+            }
 
             // 20% chance for loot to drop normally, else clear drops
             Random random = new Random();


### PR DESCRIPTION
## Summary
- ensure combat XP isn't granted for sea creatures or forest spirits

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686114bc24e48332a7354f723d51ac05