### PR TITLE
Enable Preservation for all equipment

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
@@ -921,11 +921,12 @@ public class AnvilRepair implements Listener {
 
             return;
         }
-        else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Contingency Plan")&& ARMOR.contains(repairee.getType())) {
+        else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Contingency Plan") && (ARMOR.contains(repairee.getType()) || TOOLS.contains(repairee.getType()) || MELEE.contains(repairee.getType()) || isBow(repairee) || isCrossbow(repairee))) {
             CustomEnchantmentManager.addEnchantment(player, billItem, repairee, "Preservation", CustomEnchantmentManager.getEnchantmentLevel(repairee, "Preservation") + 1);
             player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
 
             return;
+        }
         }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Climbing Rope")&& TOOLS.contains(repairee.getType())){
             CustomEnchantmentManager.addEnchantment(player, billItem, repairee, "Rappel", CustomEnchantmentManager.getEnchantmentLevel(repairee, "Rappel") +1);
             player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -3324,7 +3324,7 @@ public class ItemRegistry {
         return createCustomItem(Material.ENDER_CHEST, ChatColor.YELLOW +
                 "Contingency Plan", Arrays.asList(
                 ChatColor.GRAY + "Inventory Technology.",
-                ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Adds 1 level of Preservation to Armor.",
+                ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Adds 1 level of Preservation to Equipment.",
                 ChatColor.DARK_PURPLE + "Smithing Item"
         ), 1, false, true);
     }


### PR DESCRIPTION
## Summary
- let the Preservation enchant work on all equipable items
- update item description for Preservation to say `Equipment`

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686122f91f64833291a50fbccc0f518f