### PR TITLE
Switch hostility tiers to rely on notoriety

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatSubsystemManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatSubsystemManager.java
@@ -291,8 +291,6 @@ public class CombatSubsystemManager implements CommandExecutor {
      * Registers command executors.
      */
     private void registerCommands() {
-        plugin.getCommand("hostility").setExecutor(this);
-
         // Register reload command if it exists in plugin.yml
         if (plugin.getCommand("combatreload") != null) {
             plugin.getCommand("combatreload").setExecutor(new CombatReloadCommand(this));

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/HostilityManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/HostilityManager.java
@@ -1,49 +1,22 @@
 package goat.minecraft.minecraftnew.subsystems.combat;
 
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.Material;
-import org.bukkit.configuration.file.YamlConfiguration;
+import goat.minecraft.minecraftnew.subsystems.forestry.Forestry;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
-import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.inventory.*;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.UUID;
+/**
+ * Simplified manager for determining player hostility tiers.
+ * The tier now depends solely on Forestry notoriety and is no longer
+ * persisted to disk.
+ */
+public class HostilityManager {
 
-public class HostilityManager implements Listener {
-
-    private static HostilityManager instance; // Singleton instance
+    private static HostilityManager instance;
     private final JavaPlugin plugin;
-    private final File hostilityFile;
-    private final YamlConfiguration hostilityConfig;
 
-    private static final String CONFIG_KEY = "playerTiers";
-
-    public HostilityManager(JavaPlugin plugin) {
+    private HostilityManager(JavaPlugin plugin) {
         this.plugin = plugin;
-
-        // Initialize the configuration file
-        hostilityFile = new File(plugin.getDataFolder(), "hostility.yml");
-        if (!hostilityFile.exists()) {
-            try {
-                hostilityFile.createNewFile();
-            } catch (IOException e) {
-                plugin.getLogger().severe("[HostilityManager] Could not create hostility.yml!");
-                e.printStackTrace();
-            }
-        }
-        hostilityConfig = YamlConfiguration.loadConfiguration(hostilityFile);
-
-        // Register this class as an event listener
-        Bukkit.getPluginManager().registerEvents(this, plugin);
-        plugin.getLogger().info("[HostilityManager] Initialized and registered.");
+        plugin.getLogger().info("[HostilityManager] Initialized.");
     }
 
     public static synchronized HostilityManager getInstance(JavaPlugin plugin) {
@@ -54,185 +27,47 @@ public class HostilityManager implements Listener {
     }
 
     /**
-     * Returns the current HostilityManager instance without creating a new one.
-     * Used during shutdown to avoid registering events when the plugin is
-     * already disabled.
-     *
-     * @return the existing HostilityManager instance, or null if not initialized
+     * Returns the existing instance without creating a new one.
      */
     public static synchronized HostilityManager getExistingInstance() {
         return instance;
     }
 
+    /**
+     * Calculates the player's hostility tier based solely on forestry notoriety.
+     *
+     * @param player the player to check
+     * @return tier from 1 (lowest) to 5 (highest)
+     */
     public int getPlayerDifficultyTier(Player player) {
-        if(player == null){
+        if (player == null) {
             return 1;
         }
-        UUID uuid = player.getUniqueId();
-        String path = CONFIG_KEY + "." + uuid.toString();
-        return hostilityConfig.getInt(path, 1); // Default tier is 1
-    }
-
-    public void saveConfig() {
-        try {
-            hostilityConfig.save(hostilityFile);
-            plugin.getLogger().info("[HostilityManager] Configuration saved.");
-        } catch (IOException e) {
-            plugin.getLogger().severe("[HostilityManager] Could not save hostility.yml!");
-            e.printStackTrace();
+        int notoriety = Forestry.getInstance().getNotoriety(player);
+        if (notoriety <= 64) {
+            return 1;
+        } else if (notoriety <= 192) {
+            return 2;
+        } else if (notoriety <= 384) {
+            return 3;
+        } else if (notoriety <= 640) {
+            return 4;
+        } else {
+            return 5;
         }
-    }
-
-    public void setPlayerTier(Player player, int tier) {
-        UUID uuid = player.getUniqueId();
-        String path = CONFIG_KEY + "." + uuid.toString();
-        hostilityConfig.set(path, tier);
-        saveConfig();
     }
 
     /**
-     * Checks if the given tier is unlocked for a player's current level.
-     * Tier 1 = level >= 0
-     * Tier 2 = level >= 10
-     * Tier 3 = level >= 20
-     * ...
-     * Tier 10 = level >= 90
+     * Legacy method retained for API compatibility. No-op.
      */
-    private boolean isTierUnlocked(Player player, int tier) {
-        int requiredLevel = (tier - 1) * 10;
-        return player.getLevel() >= requiredLevel;
+    public void setPlayerTier(Player player, int tier) {
+        // Hostility tiers now derive from notoriety.
     }
 
-    @EventHandler
-    public void onInventoryClick(InventoryClickEvent event) {
-        if (event.getView().getTitle().equals(ChatColor.DARK_RED + "Select Hostility Tier")) {
-            event.setCancelled(true); // Prevent taking items
-
-            if (!(event.getWhoClicked() instanceof Player)) {
-                return;
-            }
-
-            Player player = (Player) event.getWhoClicked();
-            ItemStack clickedItem = event.getCurrentItem();
-
-            if (clickedItem == null || clickedItem.getType() == Material.AIR) {
-                return;
-            }
-
-            // Handle "Close" button
-            if (clickedItem.getType() == Material.BARRIER) {
-                player.closeInventory();
-                player.sendMessage(ChatColor.YELLOW + "Hostility selection closed.");
-                return;
-            }
-
-            // Handle tier selection
-            if (clickedItem.getType() == Material.RED_STAINED_GLASS_PANE
-                    || clickedItem.getType() == Material.GRAY_STAINED_GLASS_PANE) {
-                ItemMeta meta = clickedItem.getItemMeta();
-                if (meta != null && meta.hasDisplayName()) {
-                    String displayName = ChatColor.stripColor(meta.getDisplayName());
-                    if (displayName.startsWith("Tier ")) {
-                        try {
-                            int tier = Integer.parseInt(displayName.substring(5).trim());
-                            // Check if tier is unlocked
-                            if (!isTierUnlocked(player, tier)) {
-                                player.sendMessage(ChatColor.RED + "You haven't unlocked Tier " + tier + " yet!");
-                                player.closeInventory();
-                                return;
-                            }
-                            // If it is unlocked, set it
-                            if (tier >= 1 && tier <= 10) {
-                                setPlayerTier(player, tier);
-                                player.sendMessage(ChatColor.GREEN + "Your hostility tier has been set to Tier " + tier + "!");
-                                player.closeInventory();
-                            } else {
-                                player.sendMessage(ChatColor.RED + "Invalid tier selected.");
-                            }
-                        } catch (NumberFormatException e) {
-                            player.sendMessage(ChatColor.RED + "Invalid tier format.");
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    public class HostilityCommand implements org.bukkit.command.CommandExecutor {
-
-        @Override
-        public boolean onCommand(org.bukkit.command.CommandSender sender, org.bukkit.command.Command command, String label, String[] args) {
-            if (!(sender instanceof Player)) {
-                sender.sendMessage(ChatColor.RED + "Only players can use this command.");
-                return true;
-            }
-
-            Player player = (Player) sender;
-            openHostilityGUI(player);
-            return true;
-        }
-
-        /**
-         * Opens the improved Hostility GUI for the player,
-         * showing only the tiers they've unlocked in red,
-         * and locked tiers in gray.
-         */
-        public void openHostilityGUI(Player player) {
-            Inventory gui = Bukkit.createInventory(null, 54, ChatColor.DARK_RED + "Select Hostility Tier");
-
-            // Add decorative borders
-            ItemStack borderItem = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
-            ItemMeta borderMeta = borderItem.getItemMeta();
-            if (borderMeta != null) {
-                borderMeta.setDisplayName(ChatColor.GRAY + "Decoration");
-                borderItem.setItemMeta(borderMeta);
-            }
-            for (int i = 0; i < 54; i++) {
-                if (i < 9 || i >= 45 || i % 9 == 0 || i % 9 == 8) {
-                    gui.setItem(i, borderItem);
-                }
-            }
-
-            // Slots where tiers go
-            int[] tierSlots = {11, 13, 15, 20, 22, 24, 29, 31, 33, 40};
-            // Tier 1 -> 10
-            for (int i = 0; i < 10; i++) {
-                int tierNum = i + 1;
-                Material mat;
-                String display;
-                String lore;
-
-                if (isTierUnlocked(player, tierNum)) {
-                    mat = Material.RED_STAINED_GLASS_PANE;
-                    display = ChatColor.BOLD + "Tier " + tierNum;
-                    lore = ChatColor.GRAY + "Click to select Tier " + tierNum;
-                } else {
-                    // locked
-                    mat = Material.GRAY_STAINED_GLASS_PANE;
-                    display = ChatColor.BOLD + "Tier " + tierNum;
-                    lore = ChatColor.RED + "Locked until level " + ((tierNum - 1) * 10);
-                }
-
-                ItemStack tierItem = new ItemStack(mat);
-                ItemMeta meta = tierItem.getItemMeta();
-                if (meta != null) {
-                    meta.setDisplayName(display);
-                    meta.setLore(Collections.singletonList(lore));
-                    tierItem.setItemMeta(meta);
-                }
-                gui.setItem(tierSlots[i], tierItem);
-            }
-
-            // Add "Close" button at the bottom center
-            ItemStack closeItem = new ItemStack(Material.BARRIER);
-            ItemMeta closeMeta = closeItem.getItemMeta();
-            if (closeMeta != null) {
-                closeMeta.setDisplayName(ChatColor.RED + "Close");
-                closeItem.setItemMeta(closeMeta);
-            }
-            gui.setItem(49, closeItem);
-
-            player.openInventory(gui);
-        }
+    /**
+     * Legacy method retained for API compatibility. No-op.
+     */
+    public void saveConfig() {
+        // No persistent configuration.
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -83,8 +83,6 @@ commands:
     description: List all custom recipes in chat
   viewrecipe:
     description: Opens a GUI showing a particular recipe
-  hostility:
-    description: opens difficulty GUI.
   spawnseacreature:
     description: Spawns a sea creature by name.
     permission: continuity.admin


### PR DESCRIPTION
## Summary
- remove `/hostility` command from plugin.yml
- stop registering the hostility command
- overhaul `HostilityManager` to derive tiers directly from Forestry notoriety

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686123e87404833287c10ff5b5b06749