### PR TITLE
Add nightly horde spawning based on notoriety

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -16,6 +16,7 @@ import goat.minecraft.minecraftnew.subsystems.brewing.*;
 import goat.minecraft.minecraftnew.subsystems.brewing.custompotions.*;
 import goat.minecraft.minecraftnew.subsystems.combat.*;
 import goat.minecraft.minecraftnew.subsystems.combat.CombatSubsystemManager;
+import goat.minecraft.minecraftnew.subsystems.combat.NightHordeTask;
 
 import goat.minecraft.minecraftnew.subsystems.culinary.ShelfManager;
 import goat.minecraft.minecraftnew.subsystems.enchanting.*;
@@ -606,7 +607,8 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         }
         System.out.println("[MinecraftNew] Plugin enabled.");
 
-
+        // Spawn nightly zombie hordes for online players
+        new NightHordeTask(this).start();
 
         getServer().getPluginManager().registerEvents(new HordeInstinct(), this);
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/HostilityManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/HostilityManager.java
@@ -33,6 +33,36 @@ public class HostilityManager {
         return instance;
     }
 
+    /** Mapping thresholds from notoriety to hostility level. */
+    private static final int[] HOSTILITY_THRESHOLDS = {
+            20, 55, 90, 125, 160, 195, 230, 265, 300, 335,
+            370, 405, 440, 475, 510, 545, 580, 615, 650, 700
+    };
+
+    /**
+     * Convert a notoriety value directly to a hostility level using the
+     * {@link #HOSTILITY_THRESHOLDS} mapping.
+     */
+    public int getHostilityLevel(int notoriety) {
+        for (int i = HOSTILITY_THRESHOLDS.length - 1; i >= 0; i--) {
+            if (notoriety > HOSTILITY_THRESHOLDS[i]) {
+                return i + 1;
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Convenience method to get hostility level for a player.
+     */
+    public int getPlayerHostility(Player player) {
+        if (player == null) {
+            return 0;
+        }
+        int notoriety = Forestry.getInstance().getNotoriety(player);
+        return getHostilityLevel(notoriety);
+    }
+
     /**
      * Calculates the player's hostility tier based solely on forestry notoriety.
      *

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/NightHordeTask.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/NightHordeTask.java
@@ -1,0 +1,62 @@
+package goat.minecraft.minecraftnew.subsystems.combat;
+
+import goat.minecraft.minecraftnew.subsystems.forestry.Forestry;
+import goat.minecraft.minecraftnew.other.additionalfunctionality.Pathfinder;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Zombie;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.Random;
+
+/**
+ * Spawns hordes targeting players at night based on notoriety.
+ */
+public class NightHordeTask extends BukkitRunnable {
+
+    private final JavaPlugin plugin;
+    private final Pathfinder pathfinder = new Pathfinder();
+    private final Random random = new Random();
+
+    public NightHordeTask(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /** Start the repeating task. */
+    public void start() {
+        runTaskTimer(plugin, 0L, 1200L); // once per minute
+    }
+
+    @Override
+    public void run() {
+        for (World world : Bukkit.getWorlds()) {
+            long time = world.getTime();
+            if (time >= 13000 && time <= 23000) { // night only
+                for (Player player : world.getPlayers()) {
+                    int hostility = HostilityManager.getInstance(plugin)
+                            .getPlayerHostility(player);
+                    spawnHorde(player, hostility);
+                }
+            }
+        }
+    }
+
+    private void spawnHorde(Player player, int size) {
+        if (size <= 0) return;
+        World world = player.getWorld();
+        Location base = player.getLocation();
+        for (int i = 0; i < size; i++) {
+            Location spawn = base.clone().add(randomOffset(), 0, randomOffset());
+            Zombie zombie = (Zombie) world.spawnEntity(spawn, EntityType.ZOMBIE);
+            pathfinder.moveTo(zombie, player.getLocation());
+        }
+    }
+
+    private double randomOffset() {
+        return (random.nextDouble() * 10) - 5; // -5 to 5 blocks
+    }
+}


### PR DESCRIPTION
## Summary
- map player notoriety to 20 hostility levels in `HostilityManager`
- spawn nightly zombie hordes that pathfind to players via new `NightHordeTask`
- start the horde task on plugin enable

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861262d4fb083329bc9f81ccab756e2