### PR TITLE
Add combat-aware notoriety milestones

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/KillMonster.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/KillMonster.java
@@ -93,7 +93,7 @@ public class KillMonster implements Listener {
                 // Add XP to the player
                 xpManager.addXP(playerKiller, "Combat", xpGain);
                 // Increase forestry notoriety from combat
-                Forestry.getInstance().addNotoriety(playerKiller, 1, false);
+                Forestry.getInstance().addNotoriety(playerKiller, 1, false, false);
             }
 
             // 20% chance for loot to drop normally, else clear drops

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/UltimateEnchantmentListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/UltimateEnchantmentListener.java
@@ -322,7 +322,7 @@ public class UltimateEnchantmentListener implements Listener {
             forestry.processDoubleDropChance(player, currentBlock, xpManager.getPlayerLevel(player, "Forestry"));
 
             if (visitedLogs.size() % 4 == 0) {
-                forestry.incrementNotoriety(player);
+                forestry.incrementNotoriety(player, true);
             }
 
             // 1% chance to summon a Forest Spirit if the block is wood

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/Forestry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/Forestry.java
@@ -104,7 +104,7 @@ public class Forestry implements Listener {
      * If the notoriety crosses a tier threshold, the player is notified.
      * @param player The player whose notoriety is incremented.
      */
-    public void incrementNotoriety(Player player) {
+    public void incrementNotoriety(Player player, boolean fromForestry) {
         UUID uuid = player.getUniqueId();
         int currentNotoriety = notorietyMap.getOrDefault(uuid, 0);
         int currentTier = getNotorietyTier(currentNotoriety);
@@ -112,15 +112,19 @@ public class Forestry implements Listener {
         notorietyMap.put(uuid, newNotoriety);
         int newTier = getNotorietyTier(newNotoriety);
         if (newTier > currentTier) {
-            notifyNotorietyMilestone(player, newTier);
+            notifyNotorietyMilestone(player, newTier, fromForestry);
         }
         saveNotoriety(player);
+    }
+
+    public void incrementNotoriety(Player player) {
+        incrementNotoriety(player, true);
     }
     /**
      * Adds the specified notoriety amount.
      */
     public void addNotoriety(Player player, int amount) {
-        addNotoriety(player, amount, true);
+        addNotoriety(player, amount, true, true);
     }
 
     /**
@@ -130,6 +134,10 @@ public class Forestry implements Listener {
      * @param notify Whether to notify the player about tier milestones.
      */
     public void addNotoriety(Player player, int amount, boolean notify) {
+        addNotoriety(player, amount, notify, true);
+    }
+
+    public void addNotoriety(Player player, int amount, boolean notify, boolean fromForestry) {
         UUID uuid = player.getUniqueId();
         int current = notorietyMap.getOrDefault(uuid, 0);
         int currentTier = getNotorietyTier(current);
@@ -137,7 +145,7 @@ public class Forestry implements Listener {
         notorietyMap.put(uuid, newValue);
         int newTier = getNotorietyTier(newValue);
         if (notify && newTier > currentTier) {
-            notifyNotorietyMilestone(player, newTier);
+            notifyNotorietyMilestone(player, newTier, fromForestry);
         }
         saveNotoriety(player);
     }
@@ -217,32 +225,32 @@ public class Forestry implements Listener {
      * @param player The player to notify.
      * @param tier The new notoriety tier.
      */
-    private void notifyNotorietyMilestone(Player player, int tier) {
+    private void notifyNotorietyMilestone(Player player, int tier, boolean fromForestry) {
         String message;
         ChatColor color;
         Sound sound;
         float pitch;
         switch (tier) {
             case 2:
-                message = "The forest seems uneasy...";
+                message = fromForestry ? "The forest seems uneasy..." : "You feel a bad presence...";
                 color = ChatColor.YELLOW;
                 sound = Sound.BLOCK_NOTE_BLOCK_PLING;
                 pitch = 1.0f;
                 break;
             case 3:
-                message = "The forest grows angry!";
+                message = fromForestry ? "The forest grows angry!" : "Dread settles over the area.";
                 color = ChatColor.GOLD;
                 sound = Sound.BLOCK_BELL_USE;
                 pitch = 1.0f;
                 break;
             case 4:
-                message = "The forest is enraged!";
+                message = fromForestry ? "The forest is enraged!" : "A dangerous aura surrounds you!";
                 color = ChatColor.RED;
                 sound = Sound.ENTITY_WITHER_SPAWN;
                 pitch = 1.0f;
                 break;
             case 5:
-                message = "The forest is in a murderous fury!";
+                message = fromForestry ? "The forest is in a murderous fury!" : "Pure malice closes in around you!";
                 color = ChatColor.DARK_RED;
                 sound = Sound.ENTITY_WITHER_DEATH;
                 pitch = 1.0f;
@@ -340,7 +348,7 @@ public class Forestry implements Listener {
             int fakeNews = EffigyUpgradeSystem.getUpgradeLevel(axe, EffigyUpgradeSystem.UpgradeType.FAKE_NEWS);
 
             int notorietyGain = 1 + (trespasser * 3);
-            addNotoriety(player, notorietyGain);
+            addNotoriety(player, notorietyGain, true, true);
             if (fakeNews > 0) {
                 decreaseNotoriety(player, fakeNews);
             }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/music/MusicDiscManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/music/MusicDiscManager.java
@@ -873,7 +873,7 @@ public class MusicDiscManager implements Listener {
                     return;
                 }
                 // Increment notoriety by 1 every tick
-                Forestry.getInstance(MinecraftNew.getInstance()).incrementNotoriety(player);
+                Forestry.getInstance(MinecraftNew.getInstance()).incrementNotoriety(player, true);
                 ticks++;
             }
         }.runTaskTimer(plugin, 0L, 1L);


### PR DESCRIPTION
## Summary
- differentiate notoriety milestone messages between forestry and combat
- propagate context flag through `incrementNotoriety` and `addNotoriety`
- update all calling sites with the proper context

## Testing
- `javac $(find src/main/java -name '*.java' | tr '\n' ' ') -d /tmp/classes` *(fails: illegal start of type in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_686127a3eef483328229d77b7489559e