### PR TITLE
Persist forestry notoriety across reloads

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -672,6 +672,13 @@ public class MinecraftNew extends JavaPlugin implements Listener {
             CatalystManager.getInstance().shutdown();
         }
 
+        // Persist forestry notoriety data on shutdown
+        try {
+            Forestry.getInstance().saveAllNotoriety();
+        } catch (Exception e) {
+            getLogger().warning("Failed to save notoriety data: " + e.getMessage());
+        }
+
 
         PetManager.getInstance(this).savePets();
         PetManager.getInstance(this).saveLastActivePets();


### PR DESCRIPTION
## Summary
- load and save forestry notoriety for players
- load notoriety on join and save on quit
- save all notoriety during plugin shutdown

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_686129dc019483328980c8ed46025ed0