### PR TITLE
Fix hostility level bounds

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/HostilityManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/HostilityManager.java
@@ -45,7 +45,9 @@ public class HostilityManager {
      */
     public int getHostilityLevel(int notoriety) {
         for (int i = HOSTILITY_THRESHOLDS.length - 1; i >= 0; i--) {
-            if (notoriety > HOSTILITY_THRESHOLDS[i]) {
+            // Use >= so the final threshold maps correctly to the
+            // maximum hostility level when notoriety reaches 700.
+            if (notoriety >= HOSTILITY_THRESHOLDS[i]) {
                 return i + 1;
             }
         }


### PR DESCRIPTION
## Summary
- ensure maximum hostility level is reached when notoriety hits 700

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68612dfd5b1083329463561469188e07