### PR TITLE
Implement Champion spawns and XP cap

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -575,6 +575,8 @@ public class MinecraftNew extends JavaPlugin implements Listener {
 
 
         getServer().getPluginManager().registerEvents(new KnightMob(this), this);
+        getServer().getPluginManager().registerEvents(
+                goat.minecraft.minecraftnew.subsystems.combat.champion.ChampionManager.getInstance(this), this);
         getServer().getPluginManager().registerEvents(new SwordReforge(new ReforgeManager()), this);
         getServer().getPluginManager().registerEvents(new ArmorReforge(new ReforgeManager()), this);
         getServer().getPluginManager().registerEvents(new ToolReforge(new ReforgeManager()), this);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/KillMonster.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/KillMonster.java
@@ -5,6 +5,7 @@ import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.other.additionalfunctionality.Pathfinder;
 import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import goat.minecraft.minecraftnew.subsystems.combat.ChampionManager;
 import goat.minecraft.minecraftnew.subsystems.combat.utils.EntityLevelExtractor;
 import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
 import goat.minecraft.minecraftnew.subsystems.forestry.Forestry;
@@ -90,14 +91,13 @@ public class KillMonster implements Listener {
 
             // Skip combat XP for sea creatures and forest spirits
             if (!entity.hasMetadata("SEA_CREATURE") && !entity.hasMetadata("forestSpirit")) {
-                // Add XP to the player
-                if (monsterLevel > 100) {
-                    xpGain = Math.min(xpGain, 150);
-                }
-
+                // Cap combat XP and award it
+                xpGain = Math.min(xpGain, 125);
                 xpManager.addXP(playerKiller, "Combat", xpGain);
                 // Increase forestry notoriety from combat
                 Forestry.getInstance().addNotoriety(playerKiller, 1, false, false);
+                ChampionManager.getInstance(MinecraftNew.getInstance())
+                        .recordKill(playerKiller, entity.getLocation());
             }
 
             // 20% chance for loot to drop normally, else clear drops

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/champion/ChampionManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/champion/ChampionManager.java
@@ -1,0 +1,203 @@
+package goat.minecraft.minecraftnew.subsystems.combat.champion;
+
+import com.mojang.authlib.properties.Property;
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.combat.HostilityManager;
+import goat.minecraft.minecraftnew.subsystems.combat.SpawnMonsters;
+import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import org.bukkit.*;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.*;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class ChampionManager implements Listener {
+    private static ChampionManager instance;
+
+    private final JavaPlugin plugin;
+    private final XPManager xpManager;
+    private final Map<UUID, KillInfo> killMap = new HashMap<>();
+    private static final long WINDOW_MS = 5 * 60 * 1000L;
+
+    private static class KillInfo {
+        int notoriety;
+        long start;
+    }
+
+    public static synchronized ChampionManager getInstance(JavaPlugin plugin) {
+        if (instance == null) {
+            instance = new ChampionManager(plugin);
+        }
+        return instance;
+    }
+
+    public static ChampionManager getInstance() {
+        return instance;
+    }
+
+    private ChampionManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.xpManager = new XPManager(plugin);
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    public void recordKill(Player player, Location loc) {
+        if (player == null) return;
+        long now = System.currentTimeMillis();
+        KillInfo info = killMap.get(player.getUniqueId());
+        if (info == null || now - info.start > WINDOW_MS) {
+            info = new KillInfo();
+            info.start = now;
+            info.notoriety = 0;
+        }
+        info.notoriety += 1;
+        killMap.put(player.getUniqueId(), info);
+        if (info.notoriety >= 100) {
+            spawnChampion(player, loc);
+            info.notoriety = 0;
+            info.start = now;
+        }
+    }
+
+    private enum Tier {
+        WRATH(100, 1,
+                "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZjc3OWNmOTdlYzU2ZjgyMDQwNzM5NTU4ODZiMDNhZjJjNTZkOTk5YjEwMDU1N2VkYjVhMGJkYjFiNDdkYmUyNCJ9fX0=",
+                ChatColor.WHITE + "Champion of Wrath", Color.WHITE, 1),
+        FURY(200, 3,
+                "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYmE2OGM2ZDcyYzhkNzA0ZWNmNDczOWMzZWY5MDgyMTY3ZjBhZTQ2MWQ0ZTdmN2I5MDlhYjRmNjE1YTgxM2ExNiJ9fX0=",
+                ChatColor.RED + "Champion of Fury", Color.BLACK, 3),
+        VENGEANCE(300, 6,
+                "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTY0MzIwNGE5ZDA3MjI4OGY3MmQyZmQwMmQxODljNWEzYjA0MTM4MzU4YzAyMmZiMmNkNTJlMTE1OTM4NDJmNyJ9fX0=",
+                ChatColor.GOLD + "Champion of Vengeance", Color.fromRGB(255,215,0), 6);
+
+        final int level;
+        final int speed;
+        final String texture;
+        final String display;
+        final Color armorColor;
+        Tier(int level,int speed,String texture,String display,Color armorColor){
+            this.level=level;this.speed=speed;this.texture=texture;this.display=display;this.armorColor=armorColor;}
+    }
+
+    private void spawnChampion(Player player, Location loc) {
+        int hostility = HostilityManager.getInstance(plugin).getPlayerHostility(player);
+        Tier tier = hostility < 10 ? Tier.WRATH : hostility < 15 ? Tier.FURY : Tier.VENGEANCE;
+
+        Zombie champion = (Zombie) loc.getWorld().spawnEntity(loc, EntityType.ZOMBIE);
+        champion.setMetadata("championTier", new FixedMetadataValue(plugin, tier.ordinal()));
+        champion.setCustomName(tier.display);
+        champion.setCustomNameVisible(true);
+        equipChampion(champion, tier);
+        champion.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, Integer.MAX_VALUE, tier.speed - 1, true));
+        SpawnMonsters.getInstance(xpManager).applyMobAttributes(champion, tier.level);
+
+        loc.getWorld().strikeLightningEffect(loc);
+        loc.getWorld().spawnParticle(Particle.SMOKE_LARGE, loc, 40, 1,1,1,0.1);
+        if (tier == Tier.FURY || tier == Tier.VENGEANCE) {
+            loc.getWorld().playSound(loc, Sound.ENTITY_WITHER_SPAWN, 1f, 1f);
+        }
+        if (tier == Tier.VENGEANCE) {
+            loc.getWorld().createExplosion(loc, 0F);
+        }
+    }
+
+    private void equipChampion(Zombie zombie, Tier tier){
+        EntityEquipment eq = zombie.getEquipment();
+        if(eq==null) return;
+
+        ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+        SkullMeta skullMeta = (SkullMeta) head.getItemMeta();
+        skullMeta = setCustomSkullTexture(skullMeta, tier.texture);
+        head.setItemMeta(skullMeta);
+
+        ItemStack chest = coloredArmor(Material.LEATHER_CHESTPLATE, tier.armorColor);
+        ItemStack legs = coloredArmor(Material.LEATHER_LEGGINGS, Color.RED);
+        ItemStack boots = coloredArmor(Material.LEATHER_BOOTS, Color.RED);
+
+        ItemStack weapon;
+        if (tier == Tier.WRATH) {
+            weapon = new ItemStack(Material.IRON_SWORD);
+        } else if (tier == Tier.FURY) {
+            weapon = new ItemStack(Material.DIAMOND_SWORD);
+            weapon.addEnchantment(Enchantment.KNOCKBACK,5);
+        } else {
+            weapon = new ItemStack(Material.DIAMOND_AXE);
+        }
+
+        eq.setHelmet(head);
+        eq.setChestplate(chest);
+        eq.setLeggings(legs);
+        eq.setBoots(boots);
+        eq.setItemInMainHand(weapon);
+    }
+
+    private ItemStack coloredArmor(Material mat, Color color){
+        ItemStack item = new ItemStack(mat);
+        if(item.getItemMeta() instanceof LeatherArmorMeta meta){
+            meta.setColor(color);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private SkullMeta setCustomSkullTexture(SkullMeta skullMeta, String texture) {
+        GameProfile profile = new GameProfile(UUID.randomUUID(), null);
+        profile.getProperties().put("textures", new Property("textures", texture));
+        try {
+            Field profileField = skullMeta.getClass().getDeclaredField("profile");
+            profileField.setAccessible(true);
+            profileField.set(skullMeta, profile);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        return skullMeta;
+    }
+
+    @EventHandler
+    public void onChampionDeath(EntityDeathEvent event){
+        if(!(event.getEntity() instanceof Zombie zombie)) return;
+        if(!zombie.hasMetadata("championTier")) return;
+        int tier = zombie.getMetadata("championTier").get(0).asInt();
+        Player killer = zombie.getKiller();
+        if(killer!=null){
+            int xp = tier==0?1000:tier==1?2000:3000;
+            xpManager.addXP(killer, "Combat", xp);
+        }
+    }
+
+    @EventHandler
+    public void onChampionHit(EntityDamageByEntityEvent event){
+        if(!(event.getDamager() instanceof LivingEntity entity)) return;
+        if(!entity.hasMetadata("championTier")) return;
+        int tier = entity.getMetadata("championTier").get(0).asInt();
+        if(tier==1 && event.getEntity() instanceof LivingEntity target){
+            double dmg = event.getDamage();
+            new BukkitRunnable(){
+                @Override
+                public void run(){ target.damage(dmg, entity); }
+            }.runTaskLater(plugin,20L);
+            new BukkitRunnable(){
+                @Override
+                public void run(){ target.damage(dmg, entity); }
+            }.runTaskLater(plugin,40L);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- cap combat XP per kill at 125
- spawn Champion mobs after earning 100 notoriety from monster kills within 5 minutes
- scale Champion power with hostility level and drop large combat XP when slain
- register Champion manager in plugin startup

## Testing
- `mvn -q test` *(fails: could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861ecfb4ed08332bac7fdf7a6a5b12d