### PR TITLE
Add Taming skill and legacy XP command

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -189,6 +189,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getCommand("merits").setExecutor(new MeritCommand(this, playerData));
         getCommand("grantmerit").setExecutor(new GrantMerit(this, playerData));
         getCommand("grantGhostPet").setExecutor(new GrantGhostPetCommand(petManager));
+        new GrantLegacyTamingCommand(this, petManager, xpManager);
 
         // Register event listener for inventory clicks
 
@@ -279,6 +280,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
 
 
         xpManager = new XPManager(this);
+        PetManager.getInstance(this).setXPManager(xpManager);
 
         // Initialize the new combat subsystem (replaces old combat event registrations)
         try {

--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TransfigurationPouchManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TransfigurationPouchManager.java
@@ -29,10 +29,10 @@ public class TransfigurationPouchManager implements Listener {
     private FileConfiguration pouchConfig;
     private final Map<UUID, Integer> pendingXP = new HashMap<>();
 
-    private static final String[] SKILLS = {"Fishing","Farming","Mining","Combat","Player","Forestry","Bartering","Culinary","Smithing","Brewing"};
+    private static final String[] SKILLS = {"Fishing","Farming","Mining","Combat","Player","Taming","Forestry","Bartering","Culinary","Smithing","Brewing"};
     private static final Material[] SKILL_ICONS = {
             Material.FISHING_ROD, Material.WHEAT, Material.IRON_PICKAXE,
-            Material.IRON_SWORD, Material.PLAYER_HEAD, Material.GOLDEN_AXE,
+            Material.IRON_SWORD, Material.PLAYER_HEAD, Material.LEAD, Material.GOLDEN_AXE,
             Material.EMERALD, Material.FURNACE, Material.DAMAGED_ANVIL,
             Material.BREWING_STAND
     };

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/music/MusicDiscManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/music/MusicDiscManager.java
@@ -1548,7 +1548,7 @@ public class MusicDiscManager implements Listener {
         int totalCycles = durationTicks / intervalTicks;
 
         // List of skills
-        String[] skills = {"Combat", "Fishing", "Forestry", "Mining", "Farming", "Bartering", "Smithing", "Culinary"};
+        String[] skills = {"Combat", "Fishing", "Forestry", "Mining", "Farming", "Bartering", "Smithing", "Culinary", "Taming"};
 
         // Colors for each skill
         Map<String, ChatColor> skillColors = new HashMap<>();
@@ -1558,8 +1558,8 @@ public class MusicDiscManager implements Listener {
         skillColors.put("Mining", ChatColor.GRAY);
         skillColors.put("Farming", ChatColor.YELLOW);
         skillColors.put("Bartering", ChatColor.GREEN);
-        skillColors.put("Culinary", ChatColor.YELLOW
-        );
+        skillColors.put("Culinary", ChatColor.YELLOW);
+        skillColors.put("Taming", ChatColor.LIGHT_PURPLE);
 
         Random random = new Random();
 
@@ -1786,7 +1786,7 @@ public class MusicDiscManager implements Listener {
                 Arrays.asList(ChatColor.GRAY + "Gain 500-1000 XP in a random skill."),
                 1, false, false);
         list.add(new LotteryReward(xpIcon, p -> {
-            String[] skills = {"Combat","Fishing","Forestry","Mining","Farming","Bartering","Smithing","Culinary"};
+            String[] skills = {"Combat","Fishing","Forestry","Mining","Farming","Bartering","Smithing","Culinary","Taming"};
             String skill = skills[random.nextInt(skills.length)];
             int xp = 5000 + random.nextInt(10000);
             xpManager.addXP(p, skill, xp);

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/SkillsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/SkillsCommand.java
@@ -55,7 +55,7 @@ public class SkillsCommand implements CommandExecutor {
         Inventory skillsInventory = Bukkit.createInventory(null, 27, ChatColor.GOLD + "Your Skills");
 
         // Define the skills to display
-        String[] skills = {"Fishing", "Farming", "Mining", "Combat", "Player", "Forestry", "Bartering", "Culinary", "Smithing", "Brewing"};
+        String[] skills = {"Fishing", "Farming", "Mining", "Combat", "Player", "Taming", "Forestry", "Bartering", "Culinary", "Smithing", "Brewing"};
 
         // Define icons for each skill (customize as desired)
         Material[] icons = {
@@ -64,11 +64,12 @@ public class SkillsCommand implements CommandExecutor {
                 Material.IRON_PICKAXE,   // Mining
                 Material.IRON_SWORD,     // Combat
                 Material.PLAYER_HEAD,    // Player
+                Material.LEAD,           // Taming
                 Material.GOLDEN_AXE,     // Forestry
                 Material.EMERALD,        // Bartering
                 Material.FURNACE,        // Culinary
-                Material.DAMAGED_ANVIL,    // Smithing
-                Material.BREWING_STAND    // Brewing
+                Material.DAMAGED_ANVIL,  // Smithing
+                Material.BREWING_STAND   // Brewing
         };
 
         // Populate the inventory with skill items

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/GrantLegacyTamingCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/GrantLegacyTamingCommand.java
@@ -1,0 +1,57 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
+import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.Map;
+
+public class GrantLegacyTamingCommand implements CommandExecutor {
+    private final XPManager xpManager;
+    private final PetManager petManager;
+
+    public GrantLegacyTamingCommand(JavaPlugin plugin, PetManager petManager, XPManager xpManager) {
+        this.petManager = petManager;
+        this.xpManager = xpManager;
+        plugin.getCommand("grantLegacyTaming").setExecutor(this);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("continuity.admin")) {
+            sender.sendMessage(ChatColor.RED + "You do not have permission to use this command.");
+            return true;
+        }
+        if (args.length != 1) {
+            sender.sendMessage(ChatColor.RED + "Usage: /grantLegacyTaming <player>");
+            return true;
+        }
+        Player target = Bukkit.getPlayer(args[0]);
+        if (target == null) {
+            sender.sendMessage(ChatColor.RED + "Player not found.");
+            return true;
+        }
+        double total = 0;
+        for (PetManager.Pet pet : petManager.getPlayerPets(target).values()) {
+            double xp = pet.getXp();
+            for (int lvl = 1; lvl < pet.getLevel(); lvl++) {
+                xp += 20 + (lvl - 1) * 2;
+            }
+            total += xp * 10; // Legacy rate
+            if (pet.getLevel() >= 100) {
+                total += 5000;
+            }
+        }
+        if (total > 0) {
+            xpManager.addXP(target, "Taming", total);
+        }
+        sender.sendMessage(ChatColor.GREEN + "Granted " + (int) total + " Taming XP to " + target.getName() + ".");
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -148,6 +148,10 @@ commands:
     description: Sets a player's skill level
     usage: /setskilllevel <player> <skill> <level>
     permission: continuity.admin
+  grantLegacyTaming:
+    description: Grants Taming XP based on existing pets
+    usage: /grantLegacyTaming <player>
+    permission: continuity.admin
   getnearestcatalysttype:
     description: Gets the nearest catalyst type in range of the player
     usage: /getnearestcatalysttype


### PR DESCRIPTION
## Summary
- introduce Taming skill gaining XP whenever a pet gains XP
- boost pet XP gains based on player's Taming level
- award extra Taming XP when a pet reaches level 100
- add `/grantLegacyTaming` command to retroactively grant Taming XP
- show Taming in skill GUIs and random XP rewards

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68620f4a95588332afd53a8a5b697bf8