### PR TITLE
Adjust Preservation cooldown behavior

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/enchantingeffects/Preservation.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/enchanting/enchantingeffects/Preservation.java
@@ -22,6 +22,7 @@ import java.util.List;
 public class Preservation implements Listener {
 
     private static final int COOLDOWN_DAYS = 7;
+    private static final String COOLDOWN_PREFIX = "Preservation: This item will be unusable until Day ";
 
     private Integer getPreservedDay(ItemStack item) {
         if (item == null || !item.hasItemMeta()) return null;
@@ -29,10 +30,9 @@ public class Preservation implements Listener {
         if (meta == null || !meta.hasLore()) return null;
         for (String line : meta.getLore()) {
             String stripped = ChatColor.stripColor(line);
-            int idx = stripped.indexOf("preserved this item on Day ");
-            if (idx != -1) {
+            if (stripped.startsWith(COOLDOWN_PREFIX)) {
                 try {
-                    return Integer.parseInt(stripped.substring(idx + 25).trim());
+                    return Integer.parseInt(stripped.substring(COOLDOWN_PREFIX.length()).trim());
                 } catch (NumberFormatException ignored) {}
             }
         }
@@ -44,7 +44,7 @@ public class Preservation implements Listener {
         ItemMeta meta = item.getItemMeta();
         if (meta == null || !meta.hasLore()) return;
         List<String> lore = new ArrayList<>(meta.getLore());
-        lore.removeIf(l -> ChatColor.stripColor(l).contains("preserved this item on Day "));
+        lore.removeIf(l -> ChatColor.stripColor(l).startsWith(COOLDOWN_PREFIX));
         meta.setLore(lore);
         item.setItemMeta(meta);
     }
@@ -61,7 +61,10 @@ public class Preservation implements Listener {
         item.setDurability((short) (item.getType().getMaxDurability() - 1));
         ItemMeta meta = item.getItemMeta();
         List<String> lore = meta != null && meta.hasLore() ? meta.getLore() : new ArrayList<>();
-        lore.add(ChatColor.DARK_RED + player.getName() + " preserved this item on Day " + SpawnMonsters.getDayCount(player));
+        if (getPreservedDay(item) == null) {
+            int untilDay = SpawnMonsters.getDayCount(player) + COOLDOWN_DAYS;
+            lore.add(ChatColor.DARK_RED + COOLDOWN_PREFIX + untilDay);
+        }
         if (meta == null) meta = item.getItemMeta();
         meta.setLore(lore);
         item.setItemMeta(meta);
@@ -91,7 +94,7 @@ public class Preservation implements Listener {
         Integer day = getPreservedDay(clicked);
         if (day == null) return;
         int current = SpawnMonsters.getDayCount(player);
-        if (current - day >= COOLDOWN_DAYS) {
+        if (current >= day) {
             removeCooldownLore(clicked);
             event.setCurrentItem(clicked);
             return;
@@ -99,7 +102,7 @@ public class Preservation implements Listener {
         event.setCancelled(true);
         event.setCurrentItem(null);
         CustomBundleGUI.getInstance().addItemToBackpack(player, clicked);
-        player.sendMessage(ChatColor.RED + "This item is still on cooldown!");
+        player.sendMessage(ChatColor.RED + "You cannot use items that are repairing themselves.");
     }
 
     @EventHandler
@@ -110,7 +113,7 @@ public class Preservation implements Listener {
         Integer day = getPreservedDay(item);
         if (day == null) return;
         int current = SpawnMonsters.getDayCount(player);
-        if (current - day >= COOLDOWN_DAYS) {
+        if (current >= day) {
             removeCooldownLore(item);
             player.getInventory().setItem(event.getNewSlot(), item);
             return;
@@ -118,7 +121,7 @@ public class Preservation implements Listener {
         CustomBundleGUI.getInstance().addItemToBackpack(player, item.clone());
         player.getInventory().setItem(event.getNewSlot(), null);
         player.updateInventory();
-        player.sendMessage(ChatColor.RED + "This item is still on cooldown!");
+        player.sendMessage(ChatColor.RED + "You cannot use items that are repairing themselves.");
         event.setCancelled(true);
     }
 
@@ -132,7 +135,7 @@ public class Preservation implements Listener {
         if (day == null) return;
 
         int current = SpawnMonsters.getDayCount(player);
-        if (current - day >= COOLDOWN_DAYS) {
+        if (current >= day) {
             removeCooldownLore(item);
             return;
         }
@@ -143,8 +146,7 @@ public class Preservation implements Listener {
         removeIfWorn(player, item);
         CustomBundleGUI.getInstance().addItemToBackpack(player, item.clone());
         player.updateInventory();
-        int remaining = COOLDOWN_DAYS - (current - day);
-        player.sendMessage(ChatColor.RED + "Preservation prevented using a damaged item. Try again in " + remaining + " Days.");
+        player.sendMessage(ChatColor.RED + "You cannot use items that are repairing themselves.");
     }
 
     /**


### PR DESCRIPTION
## Summary
- tweak Preservation enchant cooldown lore text
- prevent multiple Preservation cooldown lines
- send unusable items to backpack with a consistent message

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686219b0320483328338f0a2fd7ef8b5