### PR TITLE
Enhance PreviewParticle command

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -180,3 +180,5 @@ commands:
     description: Shows a particle effect around the player until they move
     usage: /previewparticle <particle> <intensity>
     permission: continuity.admin
+    aliases:
+      - preview_particle


### PR DESCRIPTION
## Summary
- extend PreviewParticleCommand to act as a listener and cancel on left click
- allow dynamic movement so particles follow the player
- register preview_particle alias in plugin.yml for underscore usage

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686257e676c083328d437c562ddff134