### PR TITLE
Expand natures wrath flow

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/armorsets/FlowType.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/armorsets/FlowType.java
@@ -1,21 +1,48 @@
 package goat.minecraft.minecraftnew.subsystems.armorsets;
 
 import org.bukkit.Material;
+import org.bukkit.Particle;
 import org.bukkit.inventory.ItemStack;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
 
 /**
  * Types of Flow effects used for armor sets.
  */
 public enum FlowType {
-    NATURES_WRATH(Material.IRON_AXE);
+    NATURES_WRATH(
+            Arrays.asList(
+                    Material.OAK_LOG,
+                    Material.OAK_LEAVES,
+                    Material.BIRCH_LOG,
+                    Material.BIRCH_LEAVES,
+                    Material.GRASS_BLOCK,
+                    Material.VINE,
+                    Material.OAK_SAPLING,
+                    Material.SUNFLOWER,
+                    Material.DANDELION,
+                    Material.LILY_PAD
+            ),
+            Particle.SPORE_BLOSSOM_AIR
+    );
 
-    private final Material material;
+    private static final Random RANDOM = new Random();
+    private final List<Material> materials;
+    private final Particle particle;
 
-    FlowType(Material material) {
-        this.material = material;
+    FlowType(List<Material> materials, Particle particle) {
+        this.materials = materials;
+        this.particle = particle;
     }
 
     public ItemStack createItem() {
-        return new ItemStack(material);
+        Material mat = materials.get(RANDOM.nextInt(materials.size()));
+        return new ItemStack(mat);
+    }
+
+    public Particle getParticle() {
+        return particle;
     }
 }

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/PreviewFlowCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/PreviewFlowCommand.java
@@ -5,6 +5,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Particle;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -154,7 +155,7 @@ public class PreviewFlowCommand implements CommandExecutor, Listener {
                             pose.getZ()
                     ));
                     stand.getWorld().spawnParticle(
-                            org.bukkit.Particle.END_ROD,
+                            type.getParticle(),
                             loc, 1, 0, 0, 0, 0
                     );
                 }


### PR DESCRIPTION
## Summary
- support multiple materials for Nature's Wrath flow
- use a nature-themed particle

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686261624dd8833281f703b183dc2a58