### PR TITLE
Add aura template preview and toggle commands

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -55,6 +55,7 @@ import goat.minecraft.minecraftnew.subsystems.villagers.VillagerWorkCycleManager
 import goat.minecraft.minecraftnew.utils.commands.DiscsCommand;
 import goat.minecraft.minecraftnew.utils.commands.MeritCommand;
 import goat.minecraft.minecraftnew.utils.commands.SkillsCommand;
+import goat.minecraft.minecraftnew.utils.commands.AuraCommand;
 import goat.minecraft.minecraftnew.utils.developercommands.*;
 import goat.minecraft.minecraftnew.utils.devtools.*;
 import goat.minecraft.minecraftnew.utils.dimensions.end.BetterEnd;
@@ -67,6 +68,7 @@ import goat.minecraft.minecraftnew.other.trinkets.MiningPouchManager;
 import goat.minecraft.minecraftnew.other.trinkets.TransfigurationPouchManager;
 import goat.minecraft.minecraftnew.other.trinkets.LavaBucketManager;
 import goat.minecraft.minecraftnew.other.trinkets.TrinketManager;
+import goat.minecraft.minecraftnew.subsystems.auras.AuraManager;
 import goat.minecraft.minecraftnew.subsystems.structureblocks.StructureBlockManager;
 import goat.minecraft.minecraftnew.subsystems.structureblocks.GetStructureBlockCommand;
 import goat.minecraft.minecraftnew.subsystems.structureblocks.SetStructureBlockPowerCommand;
@@ -110,6 +112,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
     private PotionBrewingSubsystem potionBrewingSubsystem;
     private VerdantRelicsSubsystem verdantRelicsSubsystem;
     private CombatSubsystemManager combatSubsystemManager;
+    private AuraManager auraManager;
 
     public ItemDisplayManager getItemDisplayManager() {
         return displayManager;
@@ -279,6 +282,9 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getCommand("getnearestcatalysttype").setExecutor(new GetNearestCatalystTypeCommand());
         getCommand("previewparticle").setExecutor(new PreviewParticleCommand(this));
         getCommand("previewflow").setExecutor(new PreviewFlowCommand(this));
+        auraManager = new AuraManager(this);
+        getCommand("previewauratemplate").setExecutor(new PreviewAuraTemplateCommand(auraManager));
+        getCommand("aura").setExecutor(new AuraCommand(auraManager));
 
 
         xpManager = new XPManager(this);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/auras/Aura.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/auras/Aura.java
@@ -1,0 +1,38 @@
+package goat.minecraft.minecraftnew.subsystems.auras;
+
+import org.bukkit.Particle;
+
+/**
+ * Template definition for an aura effect.
+ */
+public enum Aura {
+    NATURES_WRATH_AURA(Particle.SOUL, ParticleStyle.AMBIENT, 1, 5.0);
+
+    private final Particle particle;
+    private final ParticleStyle style;
+    private final int count;
+    private final double frequency;
+
+    Aura(Particle particle, ParticleStyle style, int count, double frequency) {
+        this.particle = particle;
+        this.style = style;
+        this.count = count;
+        this.frequency = frequency;
+    }
+
+    public Particle getParticle() {
+        return particle;
+    }
+
+    public ParticleStyle getStyle() {
+        return style;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public double getFrequency() {
+        return frequency;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/auras/AuraManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/auras/AuraManager.java
@@ -1,0 +1,134 @@
+package goat.minecraft.minecraftnew.subsystems.auras;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.Vector;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Manages player auras and handles particle display tasks.
+ */
+public class AuraManager {
+    private final JavaPlugin plugin;
+    private final Map<UUID, Aura> activeAuras = new HashMap<>();
+    private final Map<UUID, Integer> taskIds = new HashMap<>();
+
+    public AuraManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Activate the given aura for the player.
+     * Any previously active aura will be replaced.
+     */
+    public void activateAura(Player player, Aura aura) {
+        deactivateAura(player);
+        activeAuras.put(player.getUniqueId(), aura);
+        startAuraTask(player, aura);
+        player.sendMessage(ChatColor.GREEN + "Activated aura: " + aura.name().toLowerCase());
+    }
+
+    /**
+     * Toggle display of the player's current aura.
+     */
+    public void toggleAura(Player player) {
+        Aura aura = activeAuras.get(player.getUniqueId());
+        if (aura == null) {
+            player.sendMessage(ChatColor.RED + "You have no active aura.");
+            return;
+        }
+        Integer id = taskIds.remove(player.getUniqueId());
+        if (id != null) {
+            Bukkit.getScheduler().cancelTask(id);
+            player.sendMessage(ChatColor.GRAY + "Aura hidden.");
+        } else {
+            startAuraTask(player, aura);
+            player.sendMessage(ChatColor.GREEN + "Aura shown.");
+        }
+    }
+
+    /**
+     * Stop and remove any active aura for the player.
+     */
+    public void deactivateAura(Player player) {
+        Integer id = taskIds.remove(player.getUniqueId());
+        if (id != null) {
+            Bukkit.getScheduler().cancelTask(id);
+        }
+        activeAuras.remove(player.getUniqueId());
+    }
+
+    private void startAuraTask(Player player, Aura aura) {
+        final Location[] center = {player.getLocation()};
+        double radius = 1.5;
+        int count = Math.max(1, aura.getCount());
+        long period = Math.max(1L, Math.round(20.0 / aura.getFrequency()));
+        BukkitRunnable runnable = new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!player.isOnline()) {
+                    cancel();
+                    taskIds.remove(player.getUniqueId());
+                    return;
+                }
+                switch (aura.getStyle()) {
+                    case RING -> {
+                        if (player.getLocation().distanceSquared(center[0]) > 0.01) {
+                            center[0] = player.getLocation();
+                        }
+                        for (int i = 0; i < count; i++) {
+                            double angle = (2 * Math.PI / count) * i;
+                            double x = radius * Math.cos(angle);
+                            double z = radius * Math.sin(angle);
+                            Location loc = center[0].clone().add(x, 0.5, z);
+                            player.getWorld().spawnParticle(aura.getParticle(), loc, 0, 0, 0, 0, 0);
+                        }
+                    }
+                    case AMBIENT -> {
+                        Location base = player.getLocation();
+                        for (int i = 0; i < count; i++) {
+                            double dx = (Math.random() - 0.5) * 4;
+                            double dy = Math.random() * 2;
+                            double dz = (Math.random() - 0.5) * 4;
+                            Location loc = base.clone().add(dx, dy + 0.5, dz);
+                            player.getWorld().spawnParticle(aura.getParticle(), loc, 0, 0, 0, 0, 0);
+                        }
+                    }
+                    case TRAIL -> {
+                        Location loc = player.getLocation().add(0, 0.1, 0);
+                        player.getWorld().spawnParticle(aura.getParticle(), loc, count, 0, 0, 0, 0);
+                    }
+                    case RAIN -> {
+                        Location base = player.getLocation();
+                        for (int i = 0; i < count; i++) {
+                            double dx = (Math.random() - 0.5) * 4;
+                            double dz = (Math.random() - 0.5) * 4;
+                            Location loc = base.clone().add(dx, 5 + Math.random() * 2, dz);
+                            player.getWorld().spawnParticle(aura.getParticle(), loc, 0, 0, -0.2, 0, 0);
+                        }
+                    }
+                    case BURST -> {
+                        Vector back = player.getLocation().getDirection().multiply(-1);
+                        Location start = player.getLocation().add(back);
+                        for (int i = 0; i < count; i++) {
+                            Vector offset = new Vector((Math.random() - 0.5) * 0.5, Math.random() * 0.5,
+                                    (Math.random() - 0.5) * 0.5);
+                            Vector vel = offset.clone().multiply(0.5);
+                            player.getWorld().spawnParticle(aura.getParticle(), start, 0,
+                                    vel.getX(), vel.getY(), vel.getZ(), 0.1);
+                        }
+                    }
+                }
+            }
+        };
+        int id = runnable.runTaskTimer(plugin, 0L, period).getTaskId();
+        taskIds.put(player.getUniqueId(), id);
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/auras/ParticleStyle.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/auras/ParticleStyle.java
@@ -1,0 +1,12 @@
+package goat.minecraft.minecraftnew.subsystems.auras;
+
+/**
+ * Styles of particle display used for auras.
+ */
+public enum ParticleStyle {
+    RING,
+    AMBIENT,
+    TRAIL,
+    RAIN,
+    BURST
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/AuraCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/AuraCommand.java
@@ -1,0 +1,29 @@
+package goat.minecraft.minecraftnew.utils.commands;
+
+import goat.minecraft.minecraftnew.subsystems.auras.AuraManager;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Player command to toggle visibility of their active aura.
+ */
+public class AuraCommand implements CommandExecutor {
+    private final AuraManager auraManager;
+
+    public AuraCommand(AuraManager auraManager) {
+        this.auraManager = auraManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+        auraManager.toggleAura(player);
+        return true;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/PreviewAuraTemplateCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/PreviewAuraTemplateCommand.java
@@ -1,0 +1,49 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import goat.minecraft.minecraftnew.subsystems.auras.Aura;
+import goat.minecraft.minecraftnew.subsystems.auras.AuraManager;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Locale;
+
+/**
+ * Command: /previewauratemplate <name>
+ * Activates a predefined aura template for the player.
+ */
+public class PreviewAuraTemplateCommand implements CommandExecutor {
+    private final AuraManager auraManager;
+
+    public PreviewAuraTemplateCommand(AuraManager auraManager) {
+        this.auraManager = auraManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be used by players.");
+            return true;
+        }
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You do not have permission to use this command.");
+            return true;
+        }
+        if (args.length != 1) {
+            player.sendMessage(ChatColor.YELLOW + "Usage: /" + label + " <name>");
+            return true;
+        }
+        Aura aura;
+        try {
+            aura = Aura.valueOf(args[0].toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            player.sendMessage(ChatColor.RED + "Unknown aura: " + args[0]);
+            return true;
+        }
+        auraManager.activateAura(player, aura);
+        player.sendMessage(ChatColor.GRAY + "Use /aura to toggle visibility.");
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -186,3 +186,11 @@ commands:
     description: Shows flow entities spinning around the player
     usage: /previewflow <flow> <intensity>
     permission: continuity.admin
+  previewauratemplate:
+    description: Shows an aura effect using a template
+    usage: /previewauratemplate <name>
+    permission: continuity.admin
+  aura:
+    description: Toggles display of your active aura
+    usage: /aura
+    default: true


### PR DESCRIPTION
## Summary
- implement Aura subsystem with templates and display manager
- add `/previewauratemplate` developer command
- add `/aura` player command to toggle current aura
- register new commands in plugin and plugin.yml

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68626bb880508332b9d4dff648ab7e38