### PR TITLE
Add Blessing artifact item, trade and GUI

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/armorsets/BlessingSelectionGUI.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/armorsets/BlessingSelectionGUI.java
@@ -1,0 +1,89 @@
+package goat.minecraft.minecraftnew.subsystems.armorsets;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Simple GUI listing available armor set blessings.
+ */
+public class BlessingSelectionGUI implements Listener {
+
+    private final JavaPlugin plugin;
+    private static final String TITLE = ChatColor.LIGHT_PURPLE + "Select Blessing";
+
+    public BlessingSelectionGUI(JavaPlugin plugin) {
+        this.plugin = plugin;
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    /**
+     * Opens the Blessing selection interface showing all armor set names.
+     */
+    public void openGUI(Player player) {
+        Inventory gui = Bukkit.createInventory(null, 54, TITLE);
+
+        // Decorative filler for all slots
+        ItemStack filler = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+        ItemMeta fMeta = filler.getItemMeta();
+        if (fMeta != null) {
+            fMeta.setDisplayName(" ");
+            filler.setItemMeta(fMeta);
+        }
+        for (int i = 0; i < gui.getSize(); i++) {
+            gui.setItem(i, filler);
+        }
+
+        int slot = 10; // start from second row
+        for (FlowType type : FlowType.values()) {
+            if (slot >= gui.getSize()) break;
+            if (slot % 9 == 0) slot++; // skip left border
+
+            ItemStack icon = type.createItem();
+            if (icon.getType() == Material.AIR) {
+                icon = new ItemStack(Material.PAPER);
+            }
+            ItemMeta meta = icon.getItemMeta();
+            if (meta != null) {
+                meta.setDisplayName(ChatColor.GOLD + type.name());
+                List<String> lore = new ArrayList<>();
+                lore.add(ChatColor.YELLOW + "Click to select");
+                meta.setLore(lore);
+                icon.setItemMeta(meta);
+            }
+            gui.setItem(slot, icon);
+            slot++;
+        }
+
+        player.openInventory(gui);
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) return;
+        if (!event.getView().getTitle().equals(TITLE)) return;
+
+        event.setCancelled(true);
+        ItemStack clicked = event.getCurrentItem();
+        if (clicked == null || !clicked.hasItemMeta()) return;
+
+        String name = ChatColor.stripColor(clicked.getItemMeta().getDisplayName());
+        try {
+            FlowType.valueOf(name.toUpperCase());
+            player.sendMessage(ChatColor.GREEN + "Selected Blessing: " + name);
+            player.closeInventory();
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -228,6 +228,7 @@ public class VillagerTradeManager implements Listener {
         weaponsmithPurchases.add(createTradeMap("WEAPONSMITH_BANE_OF_ARTHROPODS", 1, 64, 4)); // ItemRegistry.getWeaponsmithBaneofAnthropods()
 
         weaponsmithPurchases.add(createTradeMap("WEAPONSMITH_ENCHANT", 1, 64, 4)); // ItemRegistry.getWeaponsmithEnchant()
+        weaponsmithPurchases.add(createTradeMap("BLESSING", 1, 64, 4)); // ItemRegistry.getBlessing()
         weaponsmithPurchases.add(createTradeMap("LEGENDARY_SWORD_REFORGE", 1, 512, 5)); // ItemRegistry.getLegendarySwordReforge()
         weaponsmithPurchases.add(createTradeMap("BLUE_LANTERN", 1, 512, 5)); // Custom Item
         defaultConfig.set("WEAPONSMITH.purchases", weaponsmithPurchases);
@@ -1032,6 +1033,8 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getVindicatorDrop();
             case "WITCH_DROP":
                 return ItemRegistry.getWitchDrop();
+            case "BLESSING":
+                return ItemRegistry.getBlessing();
             default:
                 plugin.getLogger().warning("Unknown custom item ID: " + identifier);
                 return null;

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -4182,6 +4182,23 @@ public class ItemRegistry {
         );
     }
 
+    /** Artifact granting a random armor blessing. */
+    public static ItemStack getBlessing() {
+        return createCustomItem(
+                Material.TOTEM_OF_UNDYING,
+                ChatColor.GOLD + "Blessing",
+                Arrays.asList(
+                        ChatColor.GRAY + "A sacred charm said to choose",
+                        ChatColor.GRAY + "a worthy armor set.",
+                        ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Opens the Blessing selector.",
+                        ChatColor.DARK_PURPLE + "Artifact"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
     /** Smithing item unlocking Unbreaking VI. */
     public static ItemStack getUnbreakingVI() {
         return createCustomItem(


### PR DESCRIPTION
## Summary
- add Blessing artifact item in `ItemRegistry`
- create weaponsmith trade for the Blessing artifact
- map Blessing identifier for villager trades
- implement `BlessingSelectionGUI` for choosing armor set blessings

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68631eee25188332acfe69119e5c49c4