### PR TITLE
Add Blessing Artifact feature

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -516,6 +516,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new SeaCreatureDeathEvent(), MinecraftNew.getInstance());
         //getServer().getPluginManager().registerEvents(new CancelBrewing(MinecraftNew.getInstance()), MinecraftNew.getInstance());
         getServer().getPluginManager().registerEvents(new RightClickArtifacts(this), this);
+        getServer().getPluginManager().registerEvents(new BlessingArtifactGUI(this), this);
         getServer().getPluginManager().registerEvents(new AnvilRepair(MinecraftNew.getInstance()), this);
         getServer().getPluginManager().registerEvents(new InventoryClickListener(), this);
         getServer().getPluginManager().registerEvents(new EpicEnderDragonFight(this), this);

--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/BlessingArtifactGUI.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/BlessingArtifactGUI.java
@@ -1,0 +1,79 @@
+package goat.minecraft.minecraftnew.other.additionalfunctionality;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.List;
+
+public class BlessingArtifactGUI implements Listener {
+    private static final String GUI_TITLE = ChatColor.DARK_PURPLE + "Select Blessing";
+    private final JavaPlugin plugin;
+
+    public BlessingArtifactGUI(JavaPlugin plugin) {
+        this.plugin = plugin;
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    private ItemStack createChoice(Material material, String name) {
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(name);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private void openGUI(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 9, GUI_TITLE);
+        inv.setItem(2, createChoice(Material.FEATHER, ChatColor.GREEN + "Feather"));
+        inv.setItem(4, createChoice(Material.SHIELD, ChatColor.GREEN + "Shield"));
+        inv.setItem(6, createChoice(Material.SUGAR, ChatColor.GREEN + "Speed"));
+        player.openInventory(inv);
+    }
+
+    @EventHandler
+    public void onInteract(PlayerInteractEvent event) {
+        if (event.getAction() != Action.RIGHT_CLICK_AIR && event.getAction() != Action.RIGHT_CLICK_BLOCK)
+            return;
+        ItemStack item = event.getItem();
+        if (item == null || item.getType() == Material.AIR) return;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null || !meta.hasDisplayName()) return;
+        if (!meta.getDisplayName().equals(ChatColor.YELLOW + "Blessing Artifact")) return;
+        event.setCancelled(true);
+        openGUI(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        if (!event.getView().getTitle().equals(GUI_TITLE)) return;
+        event.setCancelled(true);
+        ItemStack clicked = event.getCurrentItem();
+        if (clicked == null || clicked.getType() == Material.AIR) return;
+        ItemMeta meta = clicked.getItemMeta();
+        if (meta == null || !meta.hasDisplayName()) return;
+        String blessing = ChatColor.stripColor(meta.getDisplayName());
+        Player player = (Player) event.getWhoClicked();
+        ItemStack artifact = player.getInventory().getItemInMainHand();
+        if (artifact == null || !artifact.hasItemMeta()) return;
+        ItemMeta artMeta = artifact.getItemMeta();
+        if (artMeta == null || !artMeta.hasDisplayName()) return;
+        if (!artMeta.getDisplayName().equals(ChatColor.YELLOW + "Blessing Artifact")) return;
+        artMeta.setDisplayName(ChatColor.YELLOW + "Blessing Artifact - " + blessing);
+        artMeta.setLore(List.of(ChatColor.GRAY + "Blessing: " + blessing));
+        artifact.setItemMeta(artMeta);
+        player.closeInventory();
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -488,6 +488,7 @@ public class VillagerTradeManager implements Listener {
         armorerPurchases.add(createTradeMap("ARMOR_SMITH_THORNS", 1, 64, 4)); // Custom Item
         armorerPurchases.add(createTradeMap("ARMOR_SMITH_FEATHER_FALLING", 1, 64, 4)); // Custom Item
         armorerPurchases.add(createTradeMap("ARMORER_ENCHANT", 1, 16, 4)); // Custom Item
+        armorerPurchases.add(createTradeMap("BLESSING_ARTIFACT", 1, 64, 4)); // Custom Item
 
         armorerPurchases.add(createTradeMap("LEGENDARY_ARMOR_REFORGE", 1, 128, 5)); // Custom Item
         armorerPurchases.add(createTradeMap("ARMORSMITH_REFORGE", 1, 32, 5)); // Custom Item
@@ -858,6 +859,8 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getLeatherworkerEnchant();
             case "LEATHERWORKER_ARTIFACT":
                 return ItemRegistry.getLeatherworkerArtifact();
+            case "BLESSING_ARTIFACT":
+                return ItemRegistry.getBlessingArtifact();
             case "WORKBENCH_TRINKET":
                 return ItemRegistry.getWorkbenchTrinket();
             case "DIVIDER_TRINKET":

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -4246,6 +4246,21 @@ public class ItemRegistry {
         );
     }
 
+    /** Simple artifact that lets players choose a blessing. */
+    public static ItemStack getBlessingArtifact() {
+        return createCustomItem(
+                Material.GOLD_NUGGET,
+                ChatColor.YELLOW + "Blessing Artifact",
+                List.of(
+                        ChatColor.GRAY + "Right-click to choose a blessing.",
+                        ChatColor.DARK_PURPLE + "Artifact"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
     /** Provides the Structure Block Charm for building assistance. */
     public static ItemStack getStructureBlockCharm() {
         StructureBlockManager manager = StructureBlockManager.getInstance();


### PR DESCRIPTION
## Summary
- create `BlessingArtifactGUI` for selecting a blessing when using the artifact
- add `getBlessingArtifact` to `ItemRegistry`
- include Blessing Artifact trades for the Armorer and map it in villager trade lookup
- register the new listener in plugin startup

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68632d0a99e08332938d13f268a9f42f