### PR TITLE
Add FlowManager with debug command

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -69,6 +69,7 @@ import goat.minecraft.minecraftnew.other.trinkets.TransfigurationPouchManager;
 import goat.minecraft.minecraftnew.other.trinkets.LavaBucketManager;
 import goat.minecraft.minecraftnew.other.trinkets.TrinketManager;
 import goat.minecraft.minecraftnew.subsystems.auras.AuraManager;
+import goat.minecraft.minecraftnew.subsystems.armorsets.FlowManager;
 import goat.minecraft.minecraftnew.subsystems.structureblocks.StructureBlockManager;
 import goat.minecraft.minecraftnew.subsystems.structureblocks.GetStructureBlockCommand;
 import goat.minecraft.minecraftnew.subsystems.structureblocks.SetStructureBlockPowerCommand;
@@ -113,6 +114,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
     private VerdantRelicsSubsystem verdantRelicsSubsystem;
     private CombatSubsystemManager combatSubsystemManager;
     private AuraManager auraManager;
+    private FlowManager flowManager;
 
     public ItemDisplayManager getItemDisplayManager() {
         return displayManager;
@@ -282,6 +284,8 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getCommand("getnearestcatalysttype").setExecutor(new GetNearestCatalystTypeCommand());
         getCommand("previewparticle").setExecutor(new PreviewParticleCommand(this));
         getCommand("previewflow").setExecutor(new PreviewFlowCommand(this));
+        flowManager = new FlowManager(this);
+        getCommand("flowdebug").setExecutor(new FlowDebugCommand(flowManager));
         auraManager = new AuraManager(this);
         getCommand("previewauratemplate").setExecutor(new PreviewAuraTemplateCommand(auraManager));
         getCommand("aura").setExecutor(new AuraCommand(auraManager));

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/armorsets/FlowManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/armorsets/FlowManager.java
@@ -1,0 +1,92 @@
+package goat.minecraft.minecraftnew.subsystems.armorsets;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Tracks per-player Flow levels. Flow increases when the player performs
+ * blessing related actions like killing monsters or breaking blocks. After
+ * 30 seconds of inactivity Flow starts to decay each second until it reaches
+ * zero.
+ */
+public class FlowManager implements Listener {
+
+    private final JavaPlugin plugin;
+
+    private static class FlowData {
+        int flow = 0;
+        long lastActivity = System.currentTimeMillis();
+    }
+
+    private final Map<UUID, FlowData> flowMap = new HashMap<>();
+
+    public FlowManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+        startDecayTask();
+    }
+
+    /**
+     * Returns the current flow level for the player.
+     */
+    public int getFlow(Player player) {
+        FlowData data = flowMap.get(player.getUniqueId());
+        return data == null ? 0 : data.flow;
+    }
+
+    /**
+     * Increase the player's flow and update their last activity timestamp.
+     */
+    public void addFlow(Player player, int amount) {
+        if (amount <= 0) return;
+        FlowData data = flowMap.computeIfAbsent(player.getUniqueId(), k -> new FlowData());
+        data.flow += amount;
+        data.lastActivity = System.currentTimeMillis();
+    }
+
+    private void startDecayTask() {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                long now = System.currentTimeMillis();
+                for (Map.Entry<UUID, FlowData> entry : flowMap.entrySet()) {
+                    FlowData data = entry.getValue();
+                    if (data.flow > 0 && now - data.lastActivity > 30_000) {
+                        data.flow--;
+                        if (data.flow == 0) {
+                            Player p = Bukkit.getPlayer(entry.getKey());
+                            if (p != null && p.isOnline()) {
+                                p.sendMessage(ChatColor.GRAY + "Your flow has faded.");
+                            }
+                        }
+                    }
+                }
+            }
+        }.runTaskTimer(plugin, 20L, 20L);
+    }
+
+    @EventHandler
+    public void onBlockBreak(BlockBreakEvent event) {
+        addFlow(event.getPlayer(), 1);
+    }
+
+    @EventHandler
+    public void onEntityKill(EntityDeathEvent event) {
+        Player killer = event.getEntity().getKiller();
+        if (killer != null) {
+            addFlow(killer, 1);
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/FlowDebugCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/FlowDebugCommand.java
@@ -1,0 +1,31 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import goat.minecraft.minecraftnew.subsystems.armorsets.FlowManager;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Debug command to display a player's current Flow level.
+ */
+public class FlowDebugCommand implements CommandExecutor {
+
+    private final FlowManager flowManager;
+
+    public FlowDebugCommand(FlowManager manager) {
+        this.flowManager = manager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("This command can only be used by players.");
+            return true;
+        }
+        int flow = flowManager.getFlow(player);
+        player.sendMessage(ChatColor.YELLOW + "Current Flow: " + flow);
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -194,3 +194,7 @@ commands:
     description: Toggles display of your active aura
     usage: /aura
     default: true
+  flowdebug:
+    description: Shows a player's current flow level
+    usage: /flowdebug
+    permission: continuity.admin


### PR DESCRIPTION
## Summary
- implement `FlowManager` to track Flow levels per player and decay over time
- create `FlowDebugCommand` to print a player's current Flow value
- wire up manager and command in plugin initialization
- register `flowdebug` in `plugin.yml`

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863539e1860833283730274fc5ff248