### PR TITLE
Implement aura activation for blessed armor

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -518,6 +518,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new RightClickArtifacts(this), this);
         getServer().getPluginManager().registerEvents(new BlessingArtifactGUI(this), this);
         getServer().getPluginManager().registerEvents(new BlessingArmorStandListener(), this);
+        getServer().getPluginManager().registerEvents(new BlessedSetAuraListener(this, auraManager), this);
         getServer().getPluginManager().registerEvents(new AnvilRepair(MinecraftNew.getInstance()), this);
         getServer().getPluginManager().registerEvents(new InventoryClickListener(), this);
         getServer().getPluginManager().registerEvents(new EpicEnderDragonFight(this), this);

--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/BlessedSetAuraListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/BlessedSetAuraListener.java
@@ -1,0 +1,117 @@
+package goat.minecraft.minecraftnew.other.additionalfunctionality;
+
+import goat.minecraft.minecraftnew.subsystems.auras.Aura;
+import goat.minecraft.minecraftnew.subsystems.auras.AuraManager;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerInteractAtEntityEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Handles activating auras when players wear a full blessed armor set.
+ */
+public class BlessedSetAuraListener implements Listener {
+    private static final String META_KEY = "activeBlessing";
+
+    private final JavaPlugin plugin;
+    private final AuraManager auraManager;
+    private final Map<String, Aura> blessingAuraMap = new HashMap<>();
+
+    public BlessedSetAuraListener(JavaPlugin plugin, AuraManager auraManager) {
+        this.plugin = plugin;
+        this.auraManager = auraManager;
+        blessingAuraMap.put("Lost Legion", Aura.LOST_LEGION);
+        blessingAuraMap.put("Monolith", Aura.MONOLITH);
+        blessingAuraMap.put("Scorchsteel", Aura.SCORCHSTEEL);
+        blessingAuraMap.put("Dweller", Aura.DWELLER);
+        blessingAuraMap.put("Pastureshade", Aura.PASTURESHADE);
+        blessingAuraMap.put("Countershot", Aura.COUNTERSHOT);
+        blessingAuraMap.put("Shadowstep", Aura.SHADOWSTEP);
+        blessingAuraMap.put("Strider", Aura.STRIDER);
+        blessingAuraMap.put("Slayer", Aura.SLAYER);
+        blessingAuraMap.put("Duskblood", Aura.DUSKBLOOD);
+        blessingAuraMap.put("Thunderforge", Aura.THUNDERFORGE);
+        blessingAuraMap.put("Fathmic Iron", Aura.FATHMIC_IRON);
+        blessingAuraMap.put("Nature's Wrath", Aura.NATURES_WRATH);
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Bukkit.getScheduler().runTaskLater(plugin, () -> checkPlayer(event.getPlayer()), 1L);
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (event.getWhoClicked() instanceof Player player) {
+            Bukkit.getScheduler().runTaskLater(plugin, () -> checkPlayer(player), 1L);
+        }
+    }
+
+    @EventHandler
+    public void onArmorStandInteract(PlayerInteractAtEntityEvent event) {
+        if (event.getRightClicked() instanceof org.bukkit.entity.ArmorStand) {
+            Bukkit.getScheduler().runTaskLater(plugin, () -> checkPlayer(event.getPlayer()), 1L);
+        }
+    }
+
+    private void checkPlayer(Player player) {
+        String blessing = getBlessing(player.getInventory().getHelmet());
+        if (blessing == null) {
+            deactivate(player);
+            return;
+        }
+        if (!blessing.equals(getBlessing(player.getInventory().getChestplate()))) {
+            deactivate(player);
+            return;
+        }
+        if (!blessing.equals(getBlessing(player.getInventory().getLeggings()))) {
+            deactivate(player);
+            return;
+        }
+        if (!blessing.equals(getBlessing(player.getInventory().getBoots()))) {
+            deactivate(player);
+            return;
+        }
+        Aura aura = blessingAuraMap.get(blessing);
+        if (aura == null) {
+            deactivate(player);
+            return;
+        }
+        String current = player.hasMetadata(META_KEY) ? player.getMetadata(META_KEY).get(0).asString() : null;
+        if (!blessing.equals(current)) {
+            auraManager.activateAura(player, aura);
+            player.setMetadata(META_KEY, new FixedMetadataValue(plugin, blessing));
+        }
+    }
+
+    private void deactivate(Player player) {
+        if (player.hasMetadata(META_KEY)) {
+            auraManager.deactivateAura(player);
+            player.removeMetadata(META_KEY, plugin);
+        }
+    }
+
+    private String getBlessing(ItemStack item) {
+        if (item == null || item.getType() == org.bukkit.Material.AIR || !item.hasItemMeta()) {
+            return null;
+        }
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null || !meta.hasDisplayName()) {
+            return null;
+        }
+        String name = ChatColor.stripColor(meta.getDisplayName());
+        int idx = name.lastIndexOf(' ');
+        return idx > 0 ? name.substring(0, idx) : null;
+    }
+}


### PR DESCRIPTION
## Summary
- add new `BlessedSetAuraListener` to detect full blessed sets
- activate matching aura on join and armor change
- register the listener in `MinecraftNew`

## Testing
- `gradle --version`

------
https://chatgpt.com/codex/tasks/task_e_6863538d6f048332bbacdff6999e8930