### PR TITLE
Implement armor set stats and bonuses

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -70,6 +70,7 @@ import goat.minecraft.minecraftnew.other.trinkets.LavaBucketManager;
 import goat.minecraft.minecraftnew.other.trinkets.TrinketManager;
 import goat.minecraft.minecraftnew.subsystems.auras.AuraManager;
 import goat.minecraft.minecraftnew.subsystems.armorsets.FlowManager;
+import goat.minecraft.minecraftnew.subsystems.armorsets.ArmorSetBonusListener;
 import goat.minecraft.minecraftnew.subsystems.structureblocks.StructureBlockManager;
 import goat.minecraft.minecraftnew.subsystems.structureblocks.GetStructureBlockCommand;
 import goat.minecraft.minecraftnew.subsystems.structureblocks.SetStructureBlockPowerCommand;
@@ -523,6 +524,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new BlessingArtifactGUI(this), this);
         getServer().getPluginManager().registerEvents(new BlessingArmorStandListener(), this);
         getServer().getPluginManager().registerEvents(new BlessedSetAuraListener(this, auraManager), this);
+        getServer().getPluginManager().registerEvents(new ArmorSetBonusListener(this, auraManager, flowManager), this);
         getServer().getPluginManager().registerEvents(new AnvilRepair(MinecraftNew.getInstance()), this);
         getServer().getPluginManager().registerEvents(new InventoryClickListener(), this);
         getServer().getPluginManager().registerEvents(new EpicEnderDragonFight(this), this);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/armorsets/ArmorSet.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/armorsets/ArmorSet.java
@@ -1,0 +1,80 @@
+package goat.minecraft.minecraftnew.subsystems.armorsets;
+
+import goat.minecraft.minecraftnew.subsystems.auras.Aura;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+/**
+ * Defines per-piece stats and full set data for blessed armor sets.
+ */
+public enum ArmorSet {
+    LOST_LEGION("Lost Legion", new PieceStats(0, 0.5, 0.01), "Full Set Bonus: +25% Arrow Damage", Aura.LOST_LEGION),
+    MONOLITH("Monolith", new PieceStats(5, 0, 0), "Full Set Bonus: +20 Health, +20% Defense", Aura.MONOLITH),
+    SCORCHSTEEL("Scorchsteel", new PieceStats(0, 1, 0), "Full Set Bonus: +20 Fire Stacks, +40% Nether Monster Damage Reduction", Aura.SCORCHSTEEL),
+    DWELLER("Dweller", new PieceStats(2, 0, 0), "Full Set Bonus: +25% Ore Yield, +500 Oxygen", Aura.DWELLER),
+    PASTURESHADE("Pastureshade", new PieceStats(0, 0, 0), "Full Set Bonus: +100% Crop Yield, +1 Relic Yield", Aura.PASTURESHADE),
+    NATURES_WRATH("Nature's Wrath", new PieceStats(0, 0.5, 0), "Full Set Bonus: +4% Spirit Chance, +25% Spirit Defense, +25% Spirit Damage", Aura.NATURES_WRATH),
+    COUNTERSHOT("Countershot", new PieceStats(0, 0, 0), "Full Set Bonus: Arrow Deflection", Aura.COUNTERSHOT),
+    SHADOWSTEP("Shadowstep", new PieceStats(0, 0, 0.02), "Full Set Bonus: +60% Dodge Chance", Aura.SHADOWSTEP),
+    STRIDER("Strider", new PieceStats(0, 0, 0.03), "Full Set Bonus: +40 Walk Speed", Aura.STRIDER),
+    SLAYER("Slayer", new PieceStats(0, 1, 0), "Full Set Bonus: +20% Damage", Aura.SLAYER),
+    DUSKBLOOD("Duskblood", new PieceStats(0, 1, 0), "Full Set Bonus: +60 Warp Stacks", Aura.DUSKBLOOD),
+    THUNDERFORGE("Thunderforge", new PieceStats(0, 0.5, 0), "Full Set Bonus: +15% Fury Chance", Aura.THUNDERFORGE),
+    FATHMIC_IRON("Fathmic Iron", new PieceStats(0, 0, 0), "Full Set Bonus: Removes Common/Uncommon Sea Creatures, -20% Sea Creature Chance.", Aura.FATHMIC_IRON);
+
+    private final String displayName;
+    private final PieceStats stats;
+    private final String fullSetBonus;
+    private final Aura aura;
+
+    ArmorSet(String displayName, PieceStats stats, String fullSetBonus, Aura aura) {
+        this.displayName = displayName;
+        this.stats = stats;
+        this.fullSetBonus = fullSetBonus;
+        this.aura = aura;
+    }
+
+    public String displayName() {
+        return displayName;
+    }
+
+    public PieceStats stats() {
+        return stats;
+    }
+
+    public String fullSetBonus() {
+        return fullSetBonus;
+    }
+
+    public Aura aura() {
+        return aura;
+    }
+
+    /**
+     * Attempt to resolve an ArmorSet from the item name.
+     */
+    public static ArmorSet fromItem(ItemStack item) {
+        if (item == null || item.getType() == Material.AIR || !item.hasItemMeta()) {
+            return null;
+        }
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null || !meta.hasDisplayName()) return null;
+        String name = ChatColor.stripColor(meta.getDisplayName());
+        int idx = name.lastIndexOf(' ');
+        if (idx <= 0) return null;
+        String setName = name.substring(0, idx);
+        for (ArmorSet set : values()) {
+            if (set.displayName.equalsIgnoreCase(setName)) {
+                return set;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Simple record storing per-piece stat bonuses.
+     */
+    public record PieceStats(double health, double attackDamage, double speed) { }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/armorsets/ArmorSetBonusListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/armorsets/ArmorSetBonusListener.java
@@ -1,0 +1,116 @@
+package goat.minecraft.minecraftnew.subsystems.armorsets;
+
+import goat.minecraft.minecraftnew.subsystems.auras.AuraManager;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerInteractAtEntityEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.*;
+
+/**
+ * Applies per-piece armor set stats and handles full set bonuses.
+ */
+public class ArmorSetBonusListener implements Listener {
+
+    private final JavaPlugin plugin;
+    private final AuraManager auraManager;
+    private final FlowManager flowManager;
+    private final Map<UUID, ArmorSet> activeSets = new HashMap<>();
+
+    private static final UUID HEALTH_UUID = UUID.fromString("f3b46b64-96e7-4b96-a13a-9ff35a5ad9f1");
+    private static final UUID DAMAGE_UUID = UUID.fromString("653685b7-888b-4ef2-8dd1-4cb014a2a7f8");
+    private static final UUID SPEED_UUID = UUID.fromString("d082aa4a-dce9-4939-915a-402499697b22");
+
+    public ArmorSetBonusListener(JavaPlugin plugin, AuraManager auraManager, FlowManager flowManager) {
+        this.plugin = plugin;
+        this.auraManager = auraManager;
+        this.flowManager = flowManager;
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        Bukkit.getScheduler().runTaskLater(plugin, () -> update(event.getPlayer()), 1L);
+    }
+
+    @EventHandler
+    public void onInventory(InventoryClickEvent event) {
+        if (event.getWhoClicked() instanceof Player player) {
+            Bukkit.getScheduler().runTaskLater(plugin, () -> update(player), 1L);
+        }
+    }
+
+    @EventHandler
+    public void onArmorStand(PlayerInteractAtEntityEvent event) {
+        if (event.getRightClicked() instanceof ArmorStand) {
+            Bukkit.getScheduler().runTaskLater(plugin, () -> update(event.getPlayer()), 1L);
+        }
+    }
+
+    private void update(Player player) {
+        ItemStack helm = player.getInventory().getHelmet();
+        ItemStack chest = player.getInventory().getChestplate();
+        ItemStack legs = player.getInventory().getLeggings();
+        ItemStack boots = player.getInventory().getBoots();
+
+        ArmorSet hSet = ArmorSet.fromItem(helm);
+        ArmorSet cSet = ArmorSet.fromItem(chest);
+        ArmorSet lSet = ArmorSet.fromItem(legs);
+        ArmorSet bSet = ArmorSet.fromItem(boots);
+
+        double health = 0;
+        double damage = 0;
+        double speed = 0;
+
+        if (hSet != null) { health += hSet.stats().health(); damage += hSet.stats().attackDamage(); speed += hSet.stats().speed(); }
+        if (cSet != null) { health += cSet.stats().health(); damage += cSet.stats().attackDamage(); speed += cSet.stats().speed(); }
+        if (lSet != null) { health += lSet.stats().health(); damage += lSet.stats().attackDamage(); speed += lSet.stats().speed(); }
+        if (bSet != null) { health += bSet.stats().health(); damage += bSet.stats().attackDamage(); speed += bSet.stats().speed(); }
+
+        apply(player, Attribute.GENERIC_MAX_HEALTH, HEALTH_UUID, health);
+        apply(player, Attribute.GENERIC_ATTACK_DAMAGE, DAMAGE_UUID, damage);
+        apply(player, Attribute.GENERIC_MOVEMENT_SPEED, SPEED_UUID, speed);
+
+        ArmorSet full = null;
+        if (hSet != null && hSet == cSet && hSet == lSet && hSet == bSet) {
+            full = hSet;
+        }
+        ArmorSet current = activeSets.get(player.getUniqueId());
+        if (full != null && full != current) {
+            auraManager.activateAura(player, full.aura());
+            activeSets.put(player.getUniqueId(), full);
+            int flow = flowManager.getFlow(player);
+            if (flow > 0) {
+                player.sendMessage(ChatColor.GREEN + full.fullSetBonus() + " (Flow " + flow + ")");
+            } else {
+                player.sendMessage(ChatColor.GREEN + full.fullSetBonus());
+            }
+        } else if (full == null && current != null) {
+            auraManager.deactivateAura(player);
+            activeSets.remove(player.getUniqueId());
+        }
+    }
+
+    private void apply(Player player, Attribute attr, UUID id, double value) {
+        AttributeInstance inst = player.getAttribute(attr);
+        if (inst == null) return;
+        for (AttributeModifier mod : new ArrayList<>(inst.getModifiers())) {
+            if (mod.getUniqueId().equals(id)) {
+                inst.removeModifier(mod);
+            }
+        }
+        if (Math.abs(value) > 0.0001) {
+            inst.addModifier(new AttributeModifier(id, "armor-set", value, AttributeModifier.Operation.ADD_NUMBER));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `ArmorSet` enum describing all blessing sets
- add `ArmorSetBonusListener` that applies stat modifiers and activates bonuses
- hook listener into plugin startup

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686358ed62e48332810abafd83ca43a4