### PR TITLE
Implement Flow stack animations

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/armorsets/FlowManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/armorsets/FlowManager.java
@@ -1,17 +1,28 @@
 package goat.minecraft.minecraftnew.subsystems.armorsets;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.other.additionalfunctionality.BlessingUtils;
+import goat.minecraft.minecraftnew.subsystems.armorsets.FlowType;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.EulerAngle;
+
+import java.util.ArrayList;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -31,6 +42,8 @@ public class FlowManager implements Listener {
     }
 
     private final Map<UUID, FlowData> flowMap = new HashMap<>();
+    private final Map<UUID, Integer> animationTasks = new HashMap<>();
+    private final Map<UUID, List<ArmorStand>> animationStands = new HashMap<>();
 
     public FlowManager(JavaPlugin plugin) {
         this.plugin = plugin;
@@ -56,6 +69,22 @@ public class FlowManager implements Listener {
         data.lastActivity = System.currentTimeMillis();
     }
 
+    /**
+     * Adds flow stacks and triggers the appropriate animation if the player
+     * is wearing a blessed armor set.
+     */
+    public void addFlowStacks(Player player, int amount) {
+        if (amount <= 0) return;
+        FlowData data = flowMap.computeIfAbsent(player.getUniqueId(), k -> new FlowData());
+        data.flow += amount;
+        data.lastActivity = System.currentTimeMillis();
+        if (data.flow <= 0) {
+            stopAnimation(player);
+            return;
+        }
+        refreshAnimation(player, data.flow);
+    }
+
     private void startDecayTask() {
         new BukkitRunnable() {
             @Override
@@ -69,6 +98,7 @@ public class FlowManager implements Listener {
                             Player p = Bukkit.getPlayer(entry.getKey());
                             if (p != null && p.isOnline()) {
                                 p.sendMessage(ChatColor.GRAY + "Your flow has faded.");
+                                stopAnimation(p);
                             }
                         }
                     }
@@ -79,14 +109,111 @@ public class FlowManager implements Listener {
 
     @EventHandler
     public void onBlockBreak(BlockBreakEvent event) {
-        addFlow(event.getPlayer(), 1);
+        addFlowStacks(event.getPlayer(), 1);
     }
 
     @EventHandler
     public void onEntityKill(EntityDeathEvent event) {
         Player killer = event.getEntity().getKiller();
         if (killer != null) {
-            addFlow(killer, 1);
+            addFlowStacks(killer, 1);
+        }
+    }
+
+    private void refreshAnimation(Player player, int intensity) {
+        String blessing = BlessingUtils.getBlessing(player.getInventory().getHelmet());
+        if (blessing == null || !BlessingUtils.hasFullSetBonus(player, blessing)) {
+            stopAnimation(player);
+            return;
+        }
+        String enumName = blessing.toUpperCase().replace(" ", "_").replace("'", "");
+        FlowType type;
+        try {
+            type = FlowType.valueOf(enumName);
+        } catch (IllegalArgumentException e) {
+            return;
+        }
+        startAnimation(player, type, intensity);
+    }
+
+    private void startAnimation(Player player, FlowType type, int intensity) {
+        intensity = Math.max(1, Math.min(intensity, 24));
+        Integer existing = animationTasks.remove(player.getUniqueId());
+        if (existing != null) {
+            Bukkit.getScheduler().cancelTask(existing);
+            List<ArmorStand> prev = animationStands.remove(player.getUniqueId());
+            if (prev != null) prev.forEach(Entity::remove);
+        }
+        List<ArmorStand> spawned = new ArrayList<>();
+        Location base = player.getLocation();
+        double radius = 12.0;
+        for (int i = 0; i < intensity; i++) {
+            double angle = 2 * Math.PI * i / intensity;
+            double x = radius * Math.cos(angle);
+            double z = radius * Math.sin(angle);
+            Location loc = base.clone().add(x, 0.5, z);
+            ArmorStand stand = player.getWorld().spawn(loc, ArmorStand.class, s -> {
+                s.setGravity(false);
+                s.setVisible(false);
+                s.setMarker(true);
+                ItemStack item = type.createItem();
+                if (item.getType() != Material.AIR) {
+                    s.setItemInHand(item);
+                }
+            });
+            spawned.add(stand);
+        }
+        animationStands.put(player.getUniqueId(), spawned);
+        final Location[] center = {player.getLocation()};
+        BukkitRunnable runnable = new BukkitRunnable() {
+            double angle = 0;
+            int tick = 0;
+            @Override
+            public void run() {
+                if (!player.isOnline()) {
+                    cancel();
+                    spawned.forEach(Entity::remove);
+                    animationTasks.remove(player.getUniqueId());
+                    animationStands.remove(player.getUniqueId());
+                    return;
+                }
+                if (++tick % 2 == 0) {
+                    center[0] = player.getLocation();
+                }
+                angle += 0.05;
+                for (int i = 0; i < spawned.size(); i++) {
+                    ArmorStand stand = spawned.get(i);
+                    if (!stand.isValid()) continue;
+                    double off = angle + 2 * Math.PI * i / spawned.size();
+                    double x = radius * Math.cos(off);
+                    double z = radius * Math.sin(off);
+                    Location loc = center[0].clone().add(x, 0.5, z);
+                    stand.teleport(loc);
+                    EulerAngle pose = stand.getRightArmPose();
+                    stand.setRightArmPose(new EulerAngle(
+                            pose.getX() + Math.toRadians(15),
+                            pose.getY(),
+                            pose.getZ()
+                    ));
+                    stand.getWorld().spawnParticle(
+                            type.getParticle(),
+                            loc, 1, 0, 0, 0, 0
+                    );
+                }
+            }
+        };
+        int id = runnable.runTaskTimer(plugin, 0L, 1L).getTaskId();
+        animationTasks.put(player.getUniqueId(), id);
+    }
+
+    private void stopAnimation(Player player) {
+        Integer id = animationTasks.remove(player.getUniqueId());
+        if (id != null) {
+            Bukkit.getScheduler().cancelTask(id);
+        }
+        List<ArmorStand> list = animationStands.remove(player.getUniqueId());
+        if (list != null) {
+            list.forEach(Entity::remove);
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend FlowManager to track particle animations
- add `addFlowStacks` to apply flow and refresh visuals
- show flow animation when breaking blocks or killing mobs

## Testing
- `mvn -q -DskipTests compile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68635f40bb288332b57ce60e1fd5edb2