### PR TITLE
Add faster upward flight

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -463,6 +463,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new PhoenixRebirth(this), this);
         getServer().getPluginManager().registerEvents(new FlameTrail(this), this);
         getServer().getPluginManager().registerEvents(new Spectral(this), this);
+        getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.other.qol.FastAscend(), this);
 
         this.getCommand("givecustomitem").setExecutor(new GiveCustomItem());
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/qol/FastAscend.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/qol/FastAscend.java
@@ -1,0 +1,39 @@
+package goat.minecraft.minecraftnew.other.qol;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.util.Vector;
+
+/**
+ * Gives players a quick upward boost when they look straight up while flying.
+ */
+public class FastAscend implements Listener {
+
+    // Triggered every time the player moves.
+    @EventHandler
+    public void onPlayerMove(PlayerMoveEvent event) {
+        Player player = event.getPlayer();
+
+        // Only apply when the player is currently flying
+        if (!player.isFlying()) {
+            return;
+        }
+
+        // Pitch is negative when looking up. About -90 is straight up.
+        if (player.getLocation().getPitch() > -85) {
+            return;
+        }
+
+        Vector velocity = player.getVelocity();
+        // Only boost if the player is already moving upward
+        if (velocity.getY() <= 0) {
+            return;
+        }
+
+        // Increase upward velocity but cap it to avoid excessive speed
+        double boostedY = Math.min(velocity.getY() + 0.5, 1.5);
+        player.setVelocity(new Vector(velocity.getX(), boostedY, velocity.getZ()));
+    }
+}


### PR DESCRIPTION
## Summary
- add `FastAscend` listener to boost vertical flight speed when looking up
- register the listener in `MinecraftNew` plugin setup

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68648f33811483329e1c66f9c1e0b1f2