### PR TITLE
Add warp gate persistence

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -695,6 +695,9 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         if (shelfManager != null) {
             shelfManager.onDisable();
         }
+        if (warpGateManager != null) {
+            warpGateManager.onDisable();
+        }
         if(potionBrewingSubsystem != null){
             potionBrewingSubsystem.onDisable();
         }


### PR DESCRIPTION
## Summary
- persist warp gate instances
- load saved warp gate data on plugin start
- save warp gate data on plugin disable

## Testing
- `javac src/main/java/goat/minecraft/minecraftnew/subsystems/warpgate/WarpGateManager.java` *(fails: package org.bukkit does not exist)*
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867869e5bd48332a35453f7134bf823