### PR TITLE
Add Pocket Portal warp access

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TrinketManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TrinketManager.java
@@ -148,6 +148,12 @@ public class TrinketManager implements Listener {
                     event.setCancelled(true);
                 }
             }
+            case "Pocket Portal" -> {
+                if (event.getClick().isLeftClick()) {
+                    MinecraftNew.getInstance().getWarpGateManager().openWarpMenu(player);
+                    event.setCancelled(true);
+                }
+            }
             case "Enchanted Lava Bucket" -> {
                 if (event.getClick() == ClickType.LEFT && event.getCursor() != null && event.getCursor().getType() != Material.AIR) {
                     event.getWhoClicked().setItemOnCursor(null);


### PR DESCRIPTION
## Summary
- let TrinketManager handle Pocket Portal clicks
- add remote cooldown and openWarpMenu method

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68678acc63ec8332a3e25012ebe4db2e