### PR TITLE
Add Pocket Portal trinket

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -366,6 +366,7 @@ public class VillagerTradeManager implements Listener {
         leatherworkerPurchases.add(createTradeMap("TRANSFIGURATION_POUCH", 1, 90, 3));
         leatherworkerPurchases.add(createTradeMap("ENCHANTED_LAVA_BUCKET_TRINKET", 1, 90, 3));
         leatherworkerPurchases.add(createTradeMap("ANVIL_TRINKET", 1, 90, 4));
+        leatherworkerPurchases.add(createTradeMap("POCKET_PORTAL", 1, 90, 4));
 
 
         leatherworkerPurchases.add(createTradeMap("BUNDLE", 1, 64, 3)); // Material
@@ -881,6 +882,8 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getBankAccountTrinket();
             case "ANVIL_TRINKET":
                 return ItemRegistry.getAnvilTrinket();
+            case "POCKET_PORTAL":
+                return ItemRegistry.getPocketPortal();
             case "BLUE_SATCHEL":
                 return ItemRegistry.getBlueSatchelTrinket();
             case "BLACK_SATCHEL":

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -1228,6 +1228,20 @@ public class ItemRegistry {
         );
     }
 
+    public static ItemStack getPocketPortal() {
+        return createCustomItem(
+                Material.ENDER_EYE,
+                ChatColor.YELLOW + "Pocket Portal",
+                List.of(
+                        ChatColor.BLUE + "Left-click" + ChatColor.GRAY + ": Open Ender Chest",
+                        ChatColor.BLUE + "Right-click" + ChatColor.GRAY + ": Pick up"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
     public static ItemStack getClericEnchant() {
         return createCustomItem(Material.SUGAR_CANE, ChatColor.YELLOW +
                 "Alchemical Bundle", Arrays.asList(


### PR DESCRIPTION
## Summary
- add `getPocketPortal` item to `ItemRegistry`
- register POCKET_PORTAL trade for Leatherworkers
- support `POCKET_PORTAL` identifier in `VillagerTradeManager`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68678acbca588332b02ff159633adfe4