### PR TITLE
Fix remote warp menu

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/warpgate/WarpGateManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/warpgate/WarpGateManager.java
@@ -286,7 +286,9 @@ public class WarpGateManager implements Listener {
 
     @EventHandler
     public void onMenuClose(InventoryCloseEvent event) {
-        openMenus.remove(event.getPlayer().getUniqueId());
+        if (event.getView().getTitle().equals("Warp Gate")) {
+            openMenus.remove(event.getPlayer().getUniqueId());
+        }
     }
 
     @EventHandler


### PR DESCRIPTION
## Summary
- ensure Warp Gate menu tracking isn't cleared when closing other inventories

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68677e38e96883329087eca5efb9f70d