### PR TITLE
Add trait system for pets

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetRegistry.java
@@ -411,6 +411,7 @@ public class PetRegistry {
         // Use PetManager's getSkullForPet to retrieve the proper icon.
         ItemStack icon = petManager.getSkullForPet(def.getName());
         // Create a new instance of the pet using PetManager's inner Pet class.
-        return petManager.new Pet(def.getName(), def.getRarity(), def.getMaxLevel(), icon, def.getParticle(), def.getPerks());
+        return petManager.new Pet(def.getName(), def.getRarity(), def.getMaxLevel(), icon,
+                def.getParticle(), def.getPerks(), PetTrait.HEALTHY, TraitRarity.COMMON);
     }
 }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetTrait.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetTrait.java
@@ -1,0 +1,44 @@
+package goat.minecraft.minecraftnew.subsystems.pets;
+
+/**
+ * Standard pet traits. Each trait defines a description of its
+ * effect and an array of stat values for each {@link TraitRarity}.
+ * The array order matches the enum order of TraitRarity.
+ */
+public enum PetTrait {
+    HEALTHY("Bonus health", new double[]{2,4,6,8,10,12,15}),
+    FAST("Bonus speed", new double[]{2,3,4,5,6,7,8}),
+    STRONG("Bonus damage", new double[]{2,4,6,8,10,12,15}),
+    RESILIENT("Damage reduction", new double[]{1,2,3,4,5,6,8}),
+    NAUTICAL("Swim speed", new double[]{1,2,3,4,5,6,8}),
+    HAUNTED("Spectral damage", new double[]{1,2,3,4,5,6,8}),
+    PRECISE("Accuracy", new double[]{1,2,3,4,5,6,8}),
+    FINANCIAL("Extra coins", new double[]{1,2,3,4,5,6,8}),
+    EVASIVE("Dodge chance", new double[]{1,2,3,4,5,6,8}),
+    TREASURED("Treasure chance", new double[]{1,2,3,4,5,6,8});
+
+    private final String description;
+    private final double[] values;
+
+    PetTrait(String description, double[] values) {
+        this.description = description;
+        this.values = values;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public double getValueForRarity(TraitRarity rarity) {
+        int index = rarity.ordinal();
+        if (index < 0 || index >= values.length) {
+            return 0;
+        }
+        return values[index];
+    }
+
+    public String getDisplayName() {
+        String lower = name().toLowerCase();
+        return Character.toUpperCase(lower.charAt(0)) + lower.substring(1);
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/TraitRarity.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/TraitRarity.java
@@ -1,0 +1,43 @@
+package goat.minecraft.minecraftnew.subsystems.pets;
+
+import org.bukkit.ChatColor;
+
+/**
+ * Rarity tiers for pet traits. Each tier has an associated weight
+ * used for random generation chances.
+ */
+public enum TraitRarity {
+    COMMON(50),
+    UNCOMMON(30),
+    RARE(10),
+    EPIC(5),
+    LEGENDARY(2),
+    MYTHIC(0.5),
+    UNIQUE(2.5);
+
+    private final double weight;
+
+    TraitRarity(double weight) {
+        this.weight = weight;
+    }
+
+    public double getWeight() {
+        return weight;
+    }
+
+    /**
+     * Returns a chat color for displaying this rarity.
+     */
+    public ChatColor getColor() {
+        switch (this) {
+            case COMMON: return ChatColor.WHITE;
+            case UNCOMMON: return ChatColor.GREEN;
+            case RARE: return ChatColor.BLUE;
+            case EPIC: return ChatColor.DARK_PURPLE;
+            case LEGENDARY: return ChatColor.GOLD;
+            case MYTHIC: return ChatColor.LIGHT_PURPLE;
+            case UNIQUE: return ChatColor.AQUA;
+            default: return ChatColor.WHITE;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `PetTrait` enum listing common traits and stat arrays
- add `TraitRarity` enum with weighted tiers
- extend `PetManager.Pet` to store a trait and trait rarity
- persist these fields when saving/loading pets
- show trait info in the pet GUI

## Testing
- `mvn -q package -DskipTests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a2b0b0e348332976799127690b537