### PR TITLE
Display rarity with pet traits

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
@@ -619,6 +619,7 @@ public class PetManager implements Listener {
                 }
                 lore.add(ChatColor.GRAY + "Trait: "
                         + pet.getTraitRarity().getColor()
+                        + "[" + pet.getTraitRarity().getDisplayName() + "] "
                         + pet.getTrait().getDisplayName());
                 double traitValue = pet.getTrait().getValueForRarity(pet.getTraitRarity());
                 lore.add(ChatColor.GRAY + pet.getTrait().getDescription() + ": "
@@ -845,7 +846,8 @@ public class PetManager implements Listener {
                         pet.setTrait(trait, rarity);
                         savePets();
                         player.sendMessage(ChatColor.GREEN + "Your pet " + pet.getName() + " gained the "
-                                + rarity.getColor() + trait.getDisplayName() + ChatColor.GREEN + " trait!");
+                                + rarity.getColor() + "[" + rarity.getDisplayName() + "] "
+                                + trait.getDisplayName() + ChatColor.GREEN + " trait!");
                         openPetGUI(player, currentPage);
                     } else {
                         summonPet(player, petName);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/TraitRarity.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/TraitRarity.java
@@ -40,4 +40,12 @@ public enum TraitRarity {
             default: return ChatColor.WHITE;
         }
     }
+
+    /**
+     * Returns a nicely formatted name for this rarity.
+     */
+    public String getDisplayName() {
+        String lower = name().toLowerCase();
+        return Character.toUpperCase(lower.charAt(0)) + lower.substring(1);
+    }
 }


### PR DESCRIPTION
## Summary
- add display name helper for `TraitRarity`
- show rarity brackets when displaying a pet's trait
- include rarity in the message when pets gain new traits

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_686a3082055483328ffb38b9af5db7c9