### PR TITLE
Add color-coded pet traits

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
@@ -620,10 +620,10 @@ public class PetManager implements Listener {
                 lore.add(ChatColor.GRAY + "Trait: "
                         + pet.getTraitRarity().getColor()
                         + "[" + pet.getTraitRarity().getDisplayName() + "] "
-                        + pet.getTrait().getDisplayName());
+                        + pet.getTrait().getColor() + pet.getTrait().getDisplayName());
                 double traitValue = pet.getTrait().getValueForRarity(pet.getTraitRarity());
                 lore.add(ChatColor.GRAY + pet.getTrait().getDescription() + ": "
-                        + ChatColor.YELLOW + "+" + ChatColor.YELLOW + traitValue + "%");
+                        + pet.getTrait().getColor() + "+" + traitValue + "%");
                 if (pet.equals(active)) {
                     lore.add(ChatColor.GREEN + "Currently Active");
                 }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetTrait.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetTrait.java
@@ -1,28 +1,37 @@
 package goat.minecraft.minecraftnew.subsystems.pets;
 
+import org.bukkit.ChatColor;
+
 /**
  * Standard pet traits. Each trait defines a description of its
  * effect and an array of stat values for each {@link TraitRarity}.
  * The array order matches the enum order of TraitRarity.
  */
-public enum PetTrait {
-    HEALTHY("Health Increase", new double[]{2,4,6,8,10,12,15}),
-    FAST("Speed Increase", new double[]{2,3,4,5,6,7,8}),
-    STRONG("Damage Increase", new double[]{2,4,6,8,10,12,15}),
-    RESILIENT("Damage Reduction", new double[]{1,2,3,4,5,6,8}),
-    NAUTICAL("Sea Creature Chance", new double[]{1,2,3,4,5,6,8}),
-    HAUNTED("Spirit Chance", new double[]{1,2,3,4,5,6,8}),
-    PRECISE("Arrow Damage Increase", new double[]{1,2,3,4,5,6,8}),
-    FINANCIAL("Discount", new double[]{1,2,3,4,5,6,8}),
-    EVASIVE("Dodge Chance", new double[]{1,2,3,4,5,6,8}),
-    TREASURED("Treasure Chance", new double[]{1,2,3,4,5,6,8});
 
+public enum PetTrait {
+    HEALTHY(ChatColor.RED, "Health Increase", new double[]{2,4,6,8,10,12,15}),
+    FAST(ChatColor.YELLOW, "Speed Increase", new double[]{2,3,4,5,6,7,8}),
+    STRONG(ChatColor.RED, "Damage Increase", new double[]{2,4,6,8,10,12,15}),
+    RESILIENT(ChatColor.DARK_GRAY, "Damage Reduction", new double[]{1,2,3,4,5,6,8}),
+    NAUTICAL(ChatColor.AQUA, "Sea Creature Chance", new double[]{1,2,3,4,5,6,8}),
+    HAUNTED(ChatColor.AQUA, "Spirit Chance", new double[]{1,2,3,4,5,6,8}),
+    PRECISE(ChatColor.RED, "Arrow Damage Increase", new double[]{1,2,3,4,5,6,8}),
+    FINANCIAL(ChatColor.YELLOW, "Discount", new double[]{1,2,3,4,5,6,8}),
+    EVASIVE(ChatColor.LIGHT_PURPLE, "Dodge Chance", new double[]{1,2,3,4,5,6,8}),
+    TREASURED(ChatColor.GOLD, "Treasure Chance", new double[]{1,2,3,4,5,6,8});
+
+    private final ChatColor color;
     private final String description;
     private final double[] values;
 
-    PetTrait(String description, double[] values) {
+    PetTrait(ChatColor color, String description, double[] values) {
+        this.color = color;
         this.description = description;
         this.values = values;
+    }
+
+    public ChatColor getColor() {
+        return color;
     }
 
     public String getDescription() {


### PR DESCRIPTION
## Summary
- give each `PetTrait` a `ChatColor`
- show trait names and values in their color in the pet GUI

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686a361de68c8332998dfc9944fa1e21