### PR TITLE
Implement unique trait perks

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/mining/PlayerOxygenManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/mining/PlayerOxygenManager.java
@@ -243,7 +243,8 @@ public class PlayerOxygenManager implements Listener {
 
         int y = location.getBlockY();
         PetManager.Pet activePet = PetManager.getInstance(plugin).getActivePet(player);
-        boolean hasBlacklung = activePet != null && activePet.hasPerk(PetManager.PetPerk.BLACKLUNG);
+        boolean hasBlacklung = activePet != null && (activePet.hasPerk(PetManager.PetPerk.BLACKLUNG)
+                || activePet.hasUniqueTraitPerk(PetManager.PetPerk.BLACKLUNG));
         Random random = new Random();
 
         if (world.getEnvironment() == World.Environment.NETHER) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/UniqueTrait.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/UniqueTrait.java
@@ -1,0 +1,29 @@
+package goat.minecraft.minecraftnew.subsystems.pets;
+
+public enum UniqueTrait {
+    NIGHT_VISION("Night Vision", PetManager.PetPerk.ECHOLOCATION),
+    STRONG_SWIMMER("Strong Swimmer", PetManager.PetPerk.STRONG_SWIMMER),
+    QUICK_DRAW("QuickDraw", PetManager.PetPerk.QUICK_DRAW),
+    COLLECTOR("Collector", PetManager.PetPerk.COLLECTOR),
+    BLACKLUNG("Blacklung", PetManager.PetPerk.BLACKLUNG),
+    FETCH("Fetch", PetManager.PetPerk.FETCH),
+    LULLABY("Lullaby", PetManager.PetPerk.LULLABY),
+    GREEN_THUMB("Green Thumb", PetManager.PetPerk.GREEN_THUMB),
+    WATERLOGGED("Waterlogged", PetManager.PetPerk.WATERLOGGED);
+
+    private final String displayName;
+    private final PetManager.PetPerk perk;
+
+    UniqueTrait(String displayName, PetManager.PetPerk perk) {
+        this.displayName = displayName;
+        this.perk = perk;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public PetManager.PetPerk getPerk() {
+        return perk;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/Collector.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/Collector.java
@@ -31,8 +31,9 @@ public class Collector implements Listener {
         Player player = event.getPlayer();
         PetManager.Pet activePet = petManager.getActivePet(player);
 
-        // Check if the player has the COLLECTOR perk
-        if (activePet != null && activePet.hasPerk(PetManager.PetPerk.COLLECTOR)) {
+        // Check if the player has the COLLECTOR perk or unique trait
+        if (activePet != null && (activePet.hasPerk(PetManager.PetPerk.COLLECTOR)
+                || activePet.hasUniqueTraitPerk(PetManager.PetPerk.COLLECTOR))) {
             // Define the collection radius based on pet level:
             // start at 15 and increase by 1 per level, capped at 50
             int petLevel = activePet.getLevel();

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/Echolocation.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/Echolocation.java
@@ -25,8 +25,9 @@ public class Echolocation implements Listener {
         // Get the player's active pet
         PetManager.Pet activePet = petManager.getActivePet(player);
 
-        // Check if the player has the ECHOLOCATION perk
-        if (activePet != null && activePet.hasPerk(PetManager.PetPerk.ECHOLOCATION)) {
+        // Check if the player has the ECHOLOCATION perk or unique trait
+        if (activePet != null && (activePet.hasPerk(PetManager.PetPerk.ECHOLOCATION)
+                || activePet.hasUniqueTraitPerk(PetManager.PetPerk.ECHOLOCATION))) {
             int petLevel = activePet.getLevel();
 
             // Calculate effect duration (e.g., 5 seconds + 1 second per pet level)

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/Fetch.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/Fetch.java
@@ -34,7 +34,8 @@ public class Fetch implements Listener {
         }
 
         PetManager.Pet activePet = petManager.getActivePet(player);
-        if (activePet == null || !activePet.hasPerk(PetManager.PetPerk.FETCH)) {
+        if (activePet == null || !(activePet.hasPerk(PetManager.PetPerk.FETCH)
+                || activePet.hasUniqueTraitPerk(PetManager.PetPerk.FETCH))) {
             return;
         }
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/GreenThumb.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/GreenThumb.java
@@ -46,9 +46,10 @@ public class GreenThumb implements Listener {
             return; // Growth cooldown hasn't passed
         }
 
-        // Check if player has the Green Thumb perk
+        // Check if player has the Green Thumb perk or unique trait
         PetManager.Pet activePet = petManager.getActivePet(player);
-        if (activePet != null && activePet.hasPerk(PetManager.PetPerk.GREEN_THUMB)) {
+        if (activePet != null && (activePet.hasPerk(PetManager.PetPerk.GREEN_THUMB)
+                || activePet.hasUniqueTraitPerk(PetManager.PetPerk.GREEN_THUMB))) {
             int radius = 10 + activePet.getLevel();
             growCropsAroundPlayer(player, radius);
             player.sendMessage(ChatColor.YELLOW + "Your pet naturally grows nearby crops!");

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/Lullaby.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/Lullaby.java
@@ -32,7 +32,8 @@ public class Lullaby implements Listener {
         for (Player player : world.getPlayers()) {
             // Get the player's active pet
             PetManager.Pet activePet = petManager.getActivePet(player);
-            if (activePet == null || !activePet.hasPerk(PetManager.PetPerk.LULLABY)) {
+            if (activePet == null || !(activePet.hasPerk(PetManager.PetPerk.LULLABY)
+                    || activePet.hasUniqueTraitPerk(PetManager.PetPerk.LULLABY))) {
                 continue;
             }
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/QuickDraw.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/QuickDraw.java
@@ -50,8 +50,9 @@ public class QuickDraw implements Listener {
         // Get the player's active pet
         PetManager.Pet activePet = petManager.getActivePet(player);
 
-        // Check if the player has the Quick Draw perk
-        if (activePet == null || !activePet.hasPerk(PetManager.PetPerk.QUICK_DRAW)) {
+        // Check if the player has the Quick Draw perk or unique trait
+        if (activePet == null || !(activePet.hasPerk(PetManager.PetPerk.QUICK_DRAW)
+                || activePet.hasUniqueTraitPerk(PetManager.PetPerk.QUICK_DRAW))) {
             return;
         }
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/StrongSwimmer.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/StrongSwimmer.java
@@ -30,8 +30,9 @@ public class StrongSwimmer implements Listener {
         PetManager petManager = PetManager.getInstance(plugin);
         PetManager.Pet activePet = petManager.getActivePet(player);
 
-        // Check if the player has the STRONG_SWIMMER perk
-        if (activePet != null && activePet.hasPerk(PetManager.PetPerk.STRONG_SWIMMER)) {
+        // Check if the player has the STRONG_SWIMMER perk or unique trait
+        if (activePet != null && (activePet.hasPerk(PetManager.PetPerk.STRONG_SWIMMER)
+                || activePet.hasUniqueTraitPerk(PetManager.PetPerk.STRONG_SWIMMER))) {
             // Apply Dolphin's Grace effect
             player.addPotionEffect(new PotionEffect(PotionEffectType.DOLPHINS_GRACE, 200, 1));
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/WaterLogged.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/WaterLogged.java
@@ -25,8 +25,9 @@ public class WaterLogged implements Listener {
         PetManager petManager = PetManager.getInstance(plugin);
         PetManager.Pet activePet = petManager.getActivePet(player);
 
-        // Check if the player has the WATER_LOGGED perk
-        if (activePet != null && activePet.hasPerk(PetManager.PetPerk.WATERLOGGED)) {
+        // Check if the player has the WATER_LOGGED perk or unique trait
+        if (activePet != null && (activePet.hasPerk(PetManager.PetPerk.WATERLOGGED)
+                || activePet.hasUniqueTraitPerk(PetManager.PetPerk.WATERLOGGED))) {
             if (player.isSwimming()) {
                 int petLevel = activePet.getLevel();
 


### PR DESCRIPTION
## Summary
- add new `UniqueTrait` enum for rolling unique traits
- store unique trait data in `PetManager`
- allow unique trait perk usage in perk listeners
- update GUI and roll logic for unique traits

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a3a212e748332a8100005bede8dc8