### PR TITLE
Add audio feedback for trait rolls

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
@@ -859,6 +859,7 @@ public class PetManager implements Listener {
                             player.sendMessage(ChatColor.GREEN + "Your pet " + pet.getName() + " gained the "
                                     + rarity.getColor() + "[" + rarity.getDisplayName() + "] "
                                     + uTrait.getDisplayName() + ChatColor.GREEN + " trait!");
+                            player.playSound(player.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1.0f, 1.1f);
                             openPetGUI(player, currentPage);
                         } else {
                             PetTrait trait = getRandomTraitForRarity(rarity);
@@ -867,6 +868,7 @@ public class PetManager implements Listener {
                             player.sendMessage(ChatColor.GREEN + "Your pet " + pet.getName() + " gained the "
                                     + rarity.getColor() + "[" + rarity.getDisplayName() + "] "
                                     + trait.getDisplayName() + ChatColor.GREEN + " trait!");
+                            player.playSound(player.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.0f);
                             openPetGUI(player, currentPage);
                         }
                     } else {


### PR DESCRIPTION
## Summary
- play a soft level-up chime when rolling a unique trait
- play an orb pickup sound when rolling a regular trait

## Testing
- `mvn -q -DskipTests package` *(fails: Could not download maven plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686a4223e1d0833290466b798cc7afd2