### PR TITLE
Apply trait buffs on pet summon

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
@@ -301,6 +301,8 @@ public class PetManager implements Listener {
                     spawnPetParticle(player, pet);
                 }
 
+                goat.minecraft.minecraftnew.subsystems.pets.traits.PetTraitEffects.getInstance().applyTraits(player);
+
                 if ("Ghost".equalsIgnoreCase(pet.getName())) {
                     ghostPreloc.put(player.getUniqueId(), player.getLocation());
                     player.setGameMode(GameMode.SPECTATOR);
@@ -397,6 +399,7 @@ public class PetManager implements Listener {
             }
             player.sendMessage(ChatColor.YELLOW + "Your pet '" + pet.getName() + "' has been despawned.");
             removePetParticle(player);
+            goat.minecraft.minecraftnew.subsystems.pets.traits.PetTraitEffects.getInstance().removeTraits(player);
         }
     }
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/traits/PetTraitEffects.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/traits/PetTraitEffects.java
@@ -11,8 +11,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.HashMap;
@@ -24,13 +22,19 @@ import java.util.UUID;
  */
 public class PetTraitEffects implements Listener {
 
+    private static PetTraitEffects instance;
     private final PetManager petManager;
 
     private final Map<UUID, Double> baseHealth = new HashMap<>();
     private final Map<UUID, Float> baseSpeed = new HashMap<>();
 
     public PetTraitEffects(JavaPlugin plugin) {
+        instance = this;
         this.petManager = PetManager.getInstance(plugin);
+    }
+
+    public static PetTraitEffects getInstance() {
+        return instance;
     }
 
     // ===== Attribute Helpers =====
@@ -86,20 +90,18 @@ public class PetTraitEffects implements Listener {
         baseSpeed.remove(id);
     }
 
-    // ===== Event Hooks =====
-    @EventHandler
-    public void onPlayerMove(PlayerMoveEvent event) {
-        Player player = event.getPlayer();
+    // ===== Application Methods =====
+    public void applyTraits(Player player) {
         applyHealthTrait(player);
         applySpeedTrait(player);
     }
 
-    @EventHandler
-    public void onPlayerJoin(PlayerJoinEvent event) {
-        Player player = event.getPlayer();
-        applyHealthTrait(player);
-        applySpeedTrait(player);
+    public void removeTraits(Player player) {
+        removeHealthTrait(player);
+        removeSpeedTrait(player);
     }
+
+    // ===== Event Hooks =====
 
     @EventHandler
     public void onMeleeDamage(EntityDamageByEntityEvent event) {


### PR DESCRIPTION
## Summary
- move trait bonus application from movement/join events to pet summoning
- expose trait application methods via `PetTraitEffects`
- call these methods when pets are summoned or despawned

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d8613d43c8332bd71aa731761cfb1