### PR TITLE
Add sea creature and spirit chance commands

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -36,7 +36,9 @@ import goat.minecraft.minecraftnew.subsystems.farming.FarmingEvent;
 import goat.minecraft.minecraftnew.subsystems.fishing.FishingEvent;
 import goat.minecraft.minecraftnew.subsystems.fishing.SeaCreatureRegistry;
 import goat.minecraft.minecraftnew.subsystems.fishing.SpawnSeaCreatureCommand;
+import goat.minecraft.minecraftnew.subsystems.fishing.SeaCreatureChanceCommand;
 import goat.minecraft.minecraftnew.subsystems.forestry.ForestSpiritManager;
+import goat.minecraft.minecraftnew.subsystems.forestry.SpiritChanceCommand;
 import goat.minecraft.minecraftnew.subsystems.mining.PlayerOxygenManager;
 import goat.minecraft.minecraftnew.subsystems.mining.FortuneRemover;
 import goat.minecraft.minecraftnew.subsystems.music.MusicDiscManager;
@@ -403,6 +405,8 @@ public class MinecraftNew extends JavaPlugin implements Listener {
             getDataFolder().mkdirs();
         }
         this.getCommand("spawnseacreature").setExecutor(new SpawnSeaCreatureCommand());
+        getCommand("seacreaturechance").setExecutor(new SeaCreatureChanceCommand(this, xpManager));
+        getCommand("spiritchance").setExecutor(new SpiritChanceCommand(this, xpManager));
         new SpeedBoost(petManager);
         // Register trait-based stat modifications
         getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.pets.traits.PetTraitEffects(this), this);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureChanceCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureChanceCommand.java
@@ -1,0 +1,120 @@
+package goat.minecraft.minecraftnew.subsystems.fishing;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.other.additionalfunctionality.BlessingUtils;
+import goat.minecraft.minecraftnew.subsystems.beacon.Catalyst;
+import goat.minecraft.minecraftnew.subsystems.beacon.CatalystManager;
+import goat.minecraft.minecraftnew.subsystems.beacon.CatalystType;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
+import goat.minecraft.minecraftnew.subsystems.enchanting.CustomEnchantmentManager;
+import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
+import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
+import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class SeaCreatureChanceCommand implements CommandExecutor {
+    private final MinecraftNew plugin;
+    private final XPManager xpManager;
+
+    public SeaCreatureChanceCommand(MinecraftNew plugin, XPManager xpManager) {
+        this.plugin = plugin;
+        this.xpManager = xpManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        double chance = calculateSeaCreatureChance(player) ;
+        player.sendMessage(ChatColor.AQUA + "Sea Creature Chance: " + ChatColor.YELLOW + String.format("%.2f", chance) + "%");
+        return true;
+    }
+
+    private double calculateSeaCreatureChance(Player player) {
+        double seaCreatureChance = 0.0;
+        int fishingLevel = xpManager.getPlayerLevel(player, "Fishing");
+        seaCreatureChance += fishingLevel / 4.0;
+
+        int callOfTheVoidLevel = CustomEnchantmentManager.getEnchantmentLevel(player.getInventory().getItemInMainHand(), "Call of the Void");
+        seaCreatureChance += callOfTheVoidLevel;
+
+        if (PotionManager.isActive("Potion of Fountains", player)) {
+            seaCreatureChance += 10;
+        }
+
+        CatalystManager catalystManager = CatalystManager.getInstance();
+        if (catalystManager != null && catalystManager.isNearCatalyst(player.getLocation(), CatalystType.DEPTH)) {
+            Catalyst nearest = catalystManager.findNearestCatalyst(player.getLocation(), CatalystType.DEPTH);
+            if (nearest != null) {
+                int tier = catalystManager.getCatalystTier(nearest);
+                double bonus = 0.05 + (tier * 0.01);
+                seaCreatureChance += bonus;
+            }
+        }
+
+        if (isReforgedForSeaCreatures(player.getInventory().getItemInMainHand())) {
+            seaCreatureChance += 5;
+        }
+
+        PlayerMeritManager meritManager = PlayerMeritManager.getInstance(plugin);
+        if (meritManager.hasPerk(player.getUniqueId(), "Master Angler")) {
+            seaCreatureChance += 5;
+        }
+
+        if (BlessingUtils.hasFullSetBonus(player, "Fathmic Iron")) {
+            seaCreatureChance -= 20;
+        }
+
+        ItemStack rod = player.getInventory().getItemInMainHand();
+        int sonarLevel = FishingUpgradeSystem.getUpgradeLevel(rod, FishingUpgradeSystem.UpgradeType.SONAR);
+        seaCreatureChance += sonarLevel;
+
+        PetManager petManager = PetManager.getInstance(plugin);
+        PetManager.Pet activePet = petManager.getActivePet(player);
+        if (activePet != null) {
+            if (activePet.hasPerk(PetManager.PetPerk.ANGLER)) {
+                seaCreatureChance += 5;
+            }
+            if (activePet.hasPerk(PetManager.PetPerk.HEART_OF_THE_SEA)) {
+                seaCreatureChance += 10;
+            }
+            if (activePet.hasPerk(PetManager.PetPerk.BUDDY_SYSTEM)) {
+                for (Player other : player.getWorld().getPlayers()) {
+                    if (!other.equals(player) && other.getLocation().distance(player.getLocation()) <= 20) {
+                        seaCreatureChance += 5;
+                        break;
+                    }
+                }
+            }
+            if (activePet.hasPerk(PetManager.PetPerk.BAIT)) {
+                seaCreatureChance += (double) activePet.getLevel() / 10.0;
+            }
+        }
+
+        return seaCreatureChance;
+    }
+
+    private boolean isReforgedForSeaCreatures(ItemStack item) {
+        if (item == null) {
+            return false;
+        }
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null && meta.hasLore()) {
+            for (String lore : meta.getLore()) {
+                if (ChatColor.stripColor(lore).equals("Talisman: Sea Creature Chance")) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/SpiritChanceCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/SpiritChanceCommand.java
@@ -1,0 +1,71 @@
+package goat.minecraft.minecraftnew.subsystems.forestry;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.other.additionalfunctionality.BlessingUtils;
+import goat.minecraft.minecraftnew.subsystems.armorsets.NaturesWrathSetBonus;
+import goat.minecraft.minecraftnew.subsystems.beacon.Catalyst;
+import goat.minecraft.minecraftnew.subsystems.beacon.CatalystManager;
+import goat.minecraft.minecraftnew.subsystems.beacon.CatalystType;
+import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
+import goat.minecraft.minecraftnew.subsystems.forestry.EffigyUpgradeSystem;
+import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+public class SpiritChanceCommand implements CommandExecutor {
+    private final MinecraftNew plugin;
+    private final XPManager xpManager;
+
+    public SpiritChanceCommand(MinecraftNew plugin, XPManager xpManager) {
+        this.plugin = plugin;
+        this.xpManager = xpManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        double chance = calculateSpiritChance(player);
+        player.sendMessage(ChatColor.DARK_AQUA + "Spirit Chance: " + ChatColor.YELLOW + String.format("%.2f", chance * 100) + "%");
+        return true;
+    }
+
+    private double calculateSpiritChance(Player player) {
+        double spiritChance = 0.02;
+        ItemStack axe = player.getInventory().getItemInMainHand();
+        int effigyYield = EffigyUpgradeSystem.getUpgradeLevel(axe, EffigyUpgradeSystem.UpgradeType.EFFIGY_YIELD);
+        spiritChance += effigyYield * 0.005;
+
+        PetManager petManager = PetManager.getInstance(plugin);
+        PetManager.Pet activePet = petManager.getActivePet(player);
+        if (activePet != null) {
+            if (activePet.hasPerk(PetManager.PetPerk.SKEPTICISM)) {
+                spiritChance += 0.02;
+            }
+            if (activePet.hasPerk(PetManager.PetPerk.CHALLENGE)) {
+                spiritChance += 0.05;
+            }
+        }
+
+        spiritChance += NaturesWrathSetBonus.getSpiritChanceBonus(player);
+
+        CatalystManager catalystManager = CatalystManager.getInstance();
+        if (catalystManager != null && catalystManager.isNearCatalyst(player.getLocation(), CatalystType.INSANITY)) {
+            Catalyst nearest = catalystManager.findNearestCatalyst(player.getLocation(), CatalystType.INSANITY);
+            if (nearest != null) {
+                int tier = catalystManager.getCatalystTier(nearest);
+                double bonus = 0.05 + (tier * 0.01);
+                spiritChance += bonus;
+            }
+        }
+
+        return spiritChance;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -198,3 +198,11 @@ commands:
     description: Shows a player's current flow level
     usage: /flowdebug
     permission: continuity.admin
+  seacreaturechance:
+    description: Displays your total Sea Creature Chance
+    usage: /seacreaturechance
+    default: true
+  spiritchance:
+    description: Displays your total Spirit Chance
+    usage: /spiritchance
+    default: true


### PR DESCRIPTION
## Summary
- add `/seacreaturechance` to view sea creature chance
- add `/spiritchance` to view spirit chance
- register the commands in `MinecraftNew`
- document new commands in `plugin.yml`

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d9225b20c8332af2fa194f976d881