### PR TITLE
Add treasure chance command

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -37,6 +37,7 @@ import goat.minecraft.minecraftnew.subsystems.fishing.FishingEvent;
 import goat.minecraft.minecraftnew.subsystems.fishing.SeaCreatureRegistry;
 import goat.minecraft.minecraftnew.subsystems.fishing.SpawnSeaCreatureCommand;
 import goat.minecraft.minecraftnew.subsystems.fishing.SeaCreatureChanceCommand;
+import goat.minecraft.minecraftnew.subsystems.fishing.TreasureChanceCommand;
 import goat.minecraft.minecraftnew.subsystems.forestry.ForestSpiritManager;
 import goat.minecraft.minecraftnew.subsystems.forestry.SpiritChanceCommand;
 import goat.minecraft.minecraftnew.subsystems.mining.PlayerOxygenManager;
@@ -406,6 +407,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         }
         this.getCommand("spawnseacreature").setExecutor(new SpawnSeaCreatureCommand());
         getCommand("seacreaturechance").setExecutor(new SeaCreatureChanceCommand(this, xpManager));
+        getCommand("treasurechance").setExecutor(new TreasureChanceCommand(this));
         getCommand("spiritchance").setExecutor(new SpiritChanceCommand(this, xpManager));
         new SpeedBoost(petManager);
         // Register trait-based stat modifications

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/TreasureChanceCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/TreasureChanceCommand.java
@@ -1,0 +1,54 @@
+package goat.minecraft.minecraftnew.subsystems.fishing;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
+import goat.minecraft.minecraftnew.subsystems.enchanting.CustomEnchantmentManager;
+import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+public class TreasureChanceCommand implements CommandExecutor {
+    private final MinecraftNew plugin;
+
+    public TreasureChanceCommand(MinecraftNew plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        double chance = calculateTreasureChance(player);
+        player.sendMessage(ChatColor.GOLD + "Treasure Chance: " + ChatColor.YELLOW + String.format("%.2f", chance * 100) + "%");
+        return true;
+    }
+
+    private double calculateTreasureChance(Player player) {
+        double treasureChance = 0.05; // Base 5%
+        ItemStack rod = player.getInventory().getItemInMainHand();
+        int upgradeLevel = FishingUpgradeSystem.getUpgradeLevel(rod, FishingUpgradeSystem.UpgradeType.TREASURE_HUNTER);
+        treasureChance += upgradeLevel / 100.0;
+
+        PetManager petManager = PetManager.getInstance(plugin);
+        PetManager.Pet activePet = petManager.getActivePet(player);
+        if (activePet != null && activePet.hasPerk(PetManager.PetPerk.TREASURE_HUNTER)) {
+            treasureChance += activePet.getLevel() * 0.0010;
+        }
+
+        if (PotionManager.isActive("Potion of Liquid Luck", player)) {
+            treasureChance += 0.2;
+        }
+
+        int piracyLevel = CustomEnchantmentManager.getEnchantmentLevel(player.getInventory().getItemInMainHand(), "Piracy");
+        treasureChance += piracyLevel / 100.0;
+
+        return treasureChance;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -202,6 +202,10 @@ commands:
     description: Displays your total Sea Creature Chance
     usage: /seacreaturechance
     default: true
+  treasurechance:
+    description: Displays your total Treasure Chance
+    usage: /treasurechance
+    default: true
   spiritchance:
     description: Displays your total Spirit Chance
     usage: /spiritchance


### PR DESCRIPTION
## Summary
- implement `TreasureChanceCommand` to show player treasure chance
- register the command in `MinecraftNew`
- wire `/treasurechance` in plugin.yml

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d98605f488332afb0ef17cc0f4df1