### PR TITLE
Centralize health management

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -95,8 +95,7 @@ import goat.minecraft.minecraftnew.subsystems.music.PigStepArena;
 import goat.minecraft.minecraftnew.subsystems.realms.Tropic;
 import goat.minecraft.minecraftnew.subsystems.realms.Frozen;
 import org.bukkit.*;
-import org.bukkit.attribute.Attribute;
-import org.bukkit.attribute.AttributeInstance;
+import goat.minecraft.minecraftnew.subsystems.health.HealthManager;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -168,16 +167,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
     public void onEnable() {
         instance = this;
 
-        // Reset player max health to default on startup to avoid stacked buffs
-        for (Player online : Bukkit.getOnlinePlayers()) {
-            AttributeInstance attr = online.getAttribute(Attribute.GENERIC_MAX_HEALTH);
-            if (attr != null) {
-                attr.setBaseValue(20.0);
-                if (online.getHealth() > 20.0) {
-                    online.setHealth(20.0);
-                }
-            }
-        }
+
 
         ArmorStandCommand armorStandCommand = new ArmorStandCommand(this);
         armorStandCommand.removeInvisibleArmorStands();
@@ -356,6 +346,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
 
         xpManager = new XPManager(this);
         PetManager.getInstance(this).setXPManager(xpManager);
+        HealthManager.getInstance(this, xpManager).startup();
 
         // Initialize the new combat subsystem (replaces old combat event registrations)
         try {
@@ -753,6 +744,8 @@ public class MinecraftNew extends JavaPlugin implements Listener {
             combatSubsystemManager.shutdown();
         }
 
+        HealthManager.getInstance(this, xpManager).shutdown();
+
         if (beaconPassiveEffects != null) {
             beaconPassiveEffects.removeAllPassiveEffects();
         }
@@ -821,7 +814,10 @@ public class MinecraftNew extends JavaPlugin implements Listener {
 
         return instance; // Provide a static method to get the instance
     }
+
+    public XPManager getXpManager() {
+        return xpManager;
+    }
     public ForestryPetManager getForestryManager() {
         return forestryPetManager;
-    }
-}
+    }}

--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/PlayerLevel.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/PlayerLevel.java
@@ -2,8 +2,7 @@ package goat.minecraft.minecraftnew.other.additionalfunctionality;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
-import org.bukkit.attribute.Attribute;
-import org.bukkit.attribute.AttributeInstance;
+import goat.minecraft.minecraftnew.subsystems.health.HealthManager;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -22,26 +21,7 @@ public class PlayerLevel implements Listener {
 
     // Method to apply attribute bonuses to a player
     public void applyPlayerAttributes(Player player) {
-        int level = xpManager.getPlayerLevel(player, "Player");
-
-        // Cap level at 100
-        level = Math.min(level, 100);
-
-        // Calculate health multiplier (max double health at level 50)
-        double healthMultiplier = 1 + ((Math.min(level, 100) * 0.01)); // 2% per level up to level 50
-
-        // Apply health (max double)
-        AttributeInstance healthAttribute = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
-        if (healthAttribute != null) {
-            double baseHealth = 20.0; // Default player health
-            double newHealth = baseHealth * healthMultiplier;
-            healthAttribute.setBaseValue(newHealth);
-
-            // Ensure current health does not exceed max health
-            if (player.getHealth() > newHealth) {
-                player.setHealth(newHealth);
-            }
-        }
+        HealthManager.getInstance(plugin, xpManager).recalculate(player);
     }
 
     // Event handlers to apply attributes when necessary

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/armorsets/MonolithSetBonus.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/armorsets/MonolithSetBonus.java
@@ -2,8 +2,8 @@ package goat.minecraft.minecraftnew.subsystems.armorsets;
 
 import goat.minecraft.minecraftnew.other.additionalfunctionality.BlessingUtils;
 import org.bukkit.Bukkit;
-import org.bukkit.attribute.Attribute;
-import org.bukkit.attribute.AttributeInstance;
+import goat.minecraft.minecraftnew.subsystems.health.HealthManager;
+import goat.minecraft.minecraftnew.MinecraftNew;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -29,7 +29,6 @@ public class MonolithSetBonus implements Listener {
 
     private final JavaPlugin plugin;
     private final Map<UUID, Boolean> applied = new HashMap<>();
-    private final Map<UUID, Double> baseHealth = new HashMap<>();
 
     public MonolithSetBonus(JavaPlugin plugin) {
         this.plugin = plugin;
@@ -90,17 +89,8 @@ public class MonolithSetBonus implements Listener {
             return;
         }
         player.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, Integer.MAX_VALUE, 0, false, false));
-        AttributeInstance attr = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
-        if (attr != null) {
-            double current = attr.getBaseValue();
-            baseHealth.put(id, current);
-            double newMax = current + 20.0;
-            attr.setBaseValue(newMax);
-            if (player.getHealth() > newMax) {
-                player.setHealth(newMax);
-            }
-        }
         applied.put(id, true);
+        HealthManager.getInstance(MinecraftNew.getInstance(), MinecraftNew.getInstance().getXpManager()).recalculate(player);
     }
 
     private void removeBonus(Player player) {
@@ -109,16 +99,8 @@ public class MonolithSetBonus implements Listener {
             return;
         }
         player.removePotionEffect(PotionEffectType.DAMAGE_RESISTANCE);
-        AttributeInstance attr = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
-        if (attr != null) {
-            double base = baseHealth.getOrDefault(id, attr.getBaseValue() - 20.0);
-            attr.setBaseValue(base);
-            if (player.getHealth() > base) {
-                player.setHealth(base);
-            }
-        }
         applied.put(id, false);
-        baseHealth.remove(id);
+        HealthManager.getInstance(MinecraftNew.getInstance(), MinecraftNew.getInstance().getXpManager()).recalculate(player);
     }
 
     /**
@@ -129,6 +111,5 @@ public class MonolithSetBonus implements Listener {
             removeBonus(player);
         }
         applied.clear();
-        baseHealth.clear();
     }
 }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/BeaconPassiveEffects.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/beacon/BeaconPassiveEffects.java
@@ -8,10 +8,10 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.attribute.Attribute;
-import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import goat.minecraft.minecraftnew.subsystems.health.HealthManager;
+import goat.minecraft.minecraftnew.MinecraftNew;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -21,7 +21,6 @@ public class BeaconPassiveEffects implements Listener {
 
     private final JavaPlugin plugin;
     private final Map<UUID, Boolean> mendingApplied = new HashMap<>();
-    private final Map<UUID, Double> mendingBaseHealth = new HashMap<>();
     private final Map<UUID, Boolean> swiftApplied = new HashMap<>();
 
     public BeaconPassiveEffects(JavaPlugin plugin) {
@@ -61,32 +60,16 @@ public class BeaconPassiveEffects implements Listener {
     private void applyMendingEffect(Player player) {
         UUID playerId = player.getUniqueId();
         if (!mendingApplied.getOrDefault(playerId, false)) {
-            // Increase max health by 20 (10 hearts)
-            AttributeInstance maxHealth = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
-            if (maxHealth != null) {
-                double currentMax = maxHealth.getBaseValue();
-                mendingBaseHealth.put(playerId, currentMax);
-                double newMax = currentMax + 20.0; // +20 health
-                maxHealth.setBaseValue(newMax);
-                player.setHealth(Math.min(player.getHealth() + 20.0, newMax));
-            }
             mendingApplied.put(playerId, true);
+            HealthManager.getInstance(plugin, MinecraftNew.getInstance().getXpManager()).recalculate(player);
         }
     }
 
     private void removeMendingEffect(Player player) {
         UUID playerId = player.getUniqueId();
         if (mendingApplied.getOrDefault(playerId, false)) {
-            // Remove the 20 health bonus
-            AttributeInstance maxHealth = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
-            if (maxHealth != null) {
-                double originalMax = mendingBaseHealth.getOrDefault(playerId, maxHealth.getBaseValue() - 20.0);
-                double currentHealth = player.getHealth();
-                maxHealth.setBaseValue(originalMax);
-                player.setHealth(Math.min(currentHealth, originalMax));
-            }
             mendingApplied.put(playerId, false);
-            mendingBaseHealth.remove(playerId);
+            HealthManager.getInstance(plugin, MinecraftNew.getInstance().getXpManager()).recalculate(player);
         }
     }
 
@@ -175,7 +158,6 @@ public class BeaconPassiveEffects implements Listener {
         }
         // Clear tracking maps
         mendingApplied.clear();
-        mendingBaseHealth.clear();
         swiftApplied.clear();
     }
 
@@ -187,5 +169,4 @@ public class BeaconPassiveEffects implements Listener {
         for (Player player : plugin.getServer().getOnlinePlayers()) {
             updatePassiveEffects(player);
         }
-    }
-}
+    }}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/health/HealthManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/health/HealthManager.java
@@ -1,0 +1,100 @@
+package goat.minecraft.minecraftnew.subsystems.health;
+
+import goat.minecraft.minecraftnew.other.additionalfunctionality.BlessingUtils;
+import goat.minecraft.minecraftnew.subsystems.beacon.BeaconPassivesGUI;
+import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
+import goat.minecraft.minecraftnew.subsystems.pets.PetTrait;
+import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import org.bukkit.Bukkit;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Central manager for all player max health modifications.
+ */
+public class HealthManager {
+    private static HealthManager instance;
+    private final JavaPlugin plugin;
+    private final XPManager xpManager;
+    private final PetManager petManager;
+
+    private HealthManager(JavaPlugin plugin, XPManager xpManager) {
+        this.plugin = plugin;
+        this.xpManager = xpManager;
+        this.petManager = PetManager.getInstance(plugin);
+    }
+
+    /**
+     * Returns the singleton instance, creating it when first used.
+     */
+    public static synchronized HealthManager getInstance(JavaPlugin plugin, XPManager xpManager) {
+        if (instance == null) {
+            instance = new HealthManager(plugin, xpManager);
+        }
+        return instance;
+    }
+
+    /**
+     * Recalculate and apply max health for the specified player.
+     */
+    public void recalculate(Player player) {
+        double max = 20.0;
+
+        // Player skill bonus: +2 health per 10 levels
+        int level = xpManager.getPlayerLevel(player, "Player");
+        max += (level / 10) * 2.0;
+
+        // Beacon Mending passive
+        if (BeaconPassivesGUI.hasBeaconPassives(player) &&
+                BeaconPassivesGUI.hasPassiveEnabled(player, "mending")) {
+            max += 20.0;
+        }
+
+        // Monolith armor set bonus
+        if (BlessingUtils.hasFullSetBonus(player, "Monolith")) {
+            max += 20.0;
+        }
+
+        // Healthy pet trait bonus (percent, rounded down to full heart)
+        PetManager.Pet pet = petManager.getActivePet(player);
+        if (pet != null && pet.getTrait() == PetTrait.HEALTHY) {
+            double percent = pet.getTrait().getValueForRarity(pet.getTraitRarity());
+            double withMultiplier = max * (1.0 + percent / 100.0);
+            max = Math.floor(withMultiplier / 2.0) * 2.0;
+        }
+
+        AttributeInstance attr = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+        if (attr != null) {
+            attr.setBaseValue(max);
+            if (player.getHealth() > max) {
+                player.setHealth(max);
+            }
+        }
+    }
+
+    /**
+     * Called when the plugin starts. Reapplies max health to online players.
+     */
+    public void startup() {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            recalculate(player);
+        }
+    }
+
+    /**
+     * Called on plugin shutdown to reset all players to default health.
+     */
+    public void shutdown() {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            AttributeInstance attr = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+            if (attr != null) {
+                attr.setBaseValue(20.0);
+                if (player.getHealth() > 20.0) {
+                    player.setHealth(20.0);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/traits/PetTraitEffects.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/traits/PetTraitEffects.java
@@ -3,8 +3,8 @@ package goat.minecraft.minecraftnew.subsystems.pets.traits;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
 import goat.minecraft.minecraftnew.subsystems.pets.PetTrait;
 import org.bukkit.Sound;
-import org.bukkit.attribute.Attribute;
-import org.bukkit.attribute.AttributeInstance;
+import goat.minecraft.minecraftnew.subsystems.health.HealthManager;
+import goat.minecraft.minecraftnew.MinecraftNew;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -25,7 +25,6 @@ public class PetTraitEffects implements Listener {
     private static PetTraitEffects instance;
     private final PetManager petManager;
 
-    private final Map<UUID, Double> baseHealth = new HashMap<>();
     private final Map<UUID, Float> baseSpeed = new HashMap<>();
 
     public PetTraitEffects(JavaPlugin plugin) {
@@ -41,33 +40,14 @@ public class PetTraitEffects implements Listener {
     private void applyHealthTrait(Player player) {
         PetManager.Pet active = petManager.getActivePet(player);
         if (active != null && active.getTrait() == PetTrait.HEALTHY) {
-            double bonusPercent = active.getTrait().getValueForRarity(active.getTraitRarity());
-            AttributeInstance attr = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
-            if (attr == null) return;
-            UUID id = player.getUniqueId();
-            double base = baseHealth.computeIfAbsent(id, k -> attr.getBaseValue());
-            double newBase = base * (1.0 + bonusPercent / 100.0);
-            attr.setBaseValue(newBase);
-            if (player.getHealth() > newBase) {
-                player.setHealth(newBase);
-            }
+            HealthManager.getInstance(MinecraftNew.getInstance(), MinecraftNew.getInstance().getXpManager()).recalculate(player);
             return;
         }
         removeHealthTrait(player);
     }
 
     private void removeHealthTrait(Player player) {
-        UUID id = player.getUniqueId();
-        if (!baseHealth.containsKey(id)) return;
-        AttributeInstance attr = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
-        if (attr != null) {
-            double base = baseHealth.get(id);
-            attr.setBaseValue(base);
-            if (player.getHealth() > base) {
-                player.setHealth(base);
-            }
-        }
-        baseHealth.remove(id);
+        HealthManager.getInstance(MinecraftNew.getInstance(), MinecraftNew.getInstance().getXpManager()).recalculate(player);
     }
 
     private void applySpeedTrait(Player player) {

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/XPManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/XPManager.java
@@ -456,10 +456,9 @@ public class XPManager implements CommandExecutor {
             player.addPotionEffect(new PotionEffect(PotionEffectType.ABSORPTION, 1200, 0));
             player.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, 600, 0));
 
-            // Adjust max health
-            double healthMultiplier = 1 + (Math.min(newLevel, 100) * 0.01);
-            double newMaxHealth = 20.0 * healthMultiplier;
-            player.getAttribute(Attribute.GENERIC_MAX_HEALTH).setBaseValue(newMaxHealth);
+            // Recalculate health using central manager
+            goat.minecraft.minecraftnew.subsystems.health.HealthManager.getInstance(
+                    plugin, this).recalculate(player);
         }
 
         //==========================
@@ -478,9 +477,10 @@ public class XPManager implements CommandExecutor {
         // Then skill-specific details
         switch (skill.toLowerCase()) {
             case "player":
-                double healthMultiplier = 1 + (Math.min(newLevel, 100) * 0.01);
-                double newMaxHealth = 20.0 * healthMultiplier;
-                int displayHealth = (int)newMaxHealth + 1;  // add 1 to match the actual health
+                goat.minecraft.minecraftnew.subsystems.health.HealthManager.getInstance(
+                        plugin, this).recalculate(player);
+                double newMaxHealth = player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue();
+                int displayHealth = (int) newMaxHealth + 1;
                 body.append(ChatColor.WHITE).append("Your ")
                         .append(ChatColor.GREEN).append("Max Health ")
                         .append(ChatColor.WHITE).append("is now ")


### PR DESCRIPTION
## Summary
- add a `HealthManager` singleton for calculating player max health
- hook player level, mending beacon, healthy pets and Monolith set through `HealthManager`
- reset player health on startup/shutdown via the manager
- update XPManager and event handlers to use the new manager

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_686dabb9ec648332b054c7de5ca811d2