### PR TITLE
Refactor health system via HealthManager

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -74,6 +74,7 @@ import goat.minecraft.minecraftnew.other.trinkets.TrinketManager;
 import goat.minecraft.minecraftnew.subsystems.auras.AuraManager;
 import goat.minecraft.minecraftnew.subsystems.armorsets.FlowManager;
 import goat.minecraft.minecraftnew.subsystems.armorsets.MonolithSetBonus;
+import goat.minecraft.minecraftnew.subsystems.health.HealthManager;
 import goat.minecraft.minecraftnew.subsystems.armorsets.DuskbloodSetBonus;
 import goat.minecraft.minecraftnew.subsystems.armorsets.DwellerSetBonus;
 import goat.minecraft.minecraftnew.subsystems.armorsets.FathmicIronSetBonus;
@@ -168,16 +169,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
     public void onEnable() {
         instance = this;
 
-        // Reset player max health to default on startup to avoid stacked buffs
-        for (Player online : Bukkit.getOnlinePlayers()) {
-            AttributeInstance attr = online.getAttribute(Attribute.GENERIC_MAX_HEALTH);
-            if (attr != null) {
-                attr.setBaseValue(20.0);
-                if (online.getHealth() > 20.0) {
-                    online.setHealth(20.0);
-                }
-            }
-        }
+        HealthManager.getInstance(this).startup();
 
         ArmorStandCommand armorStandCommand = new ArmorStandCommand(this);
         armorStandCommand.removeInvisibleArmorStands();
@@ -714,6 +706,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
 
     @Override
     public void onDisable() {
+        HealthManager.getInstance(this).shutdown();
         if (shelfManager != null) {
             shelfManager.onDisable();
         }
@@ -821,7 +814,9 @@ public class MinecraftNew extends JavaPlugin implements Listener {
 
         return instance; // Provide a static method to get the instance
     }
+    public XPManager getXPManager() {
+        return xpManager;
+    }
     public ForestryPetManager getForestryManager() {
         return forestryPetManager;
-    }
-}
+    }}

--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/PlayerLevel.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/PlayerLevel.java
@@ -2,8 +2,7 @@ package goat.minecraft.minecraftnew.other.additionalfunctionality;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
-import org.bukkit.attribute.Attribute;
-import org.bukkit.attribute.AttributeInstance;
+import goat.minecraft.minecraftnew.subsystems.health.HealthManager;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -22,26 +21,7 @@ public class PlayerLevel implements Listener {
 
     // Method to apply attribute bonuses to a player
     public void applyPlayerAttributes(Player player) {
-        int level = xpManager.getPlayerLevel(player, "Player");
-
-        // Cap level at 100
-        level = Math.min(level, 100);
-
-        // Calculate health multiplier (max double health at level 50)
-        double healthMultiplier = 1 + ((Math.min(level, 100) * 0.01)); // 2% per level up to level 50
-
-        // Apply health (max double)
-        AttributeInstance healthAttribute = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
-        if (healthAttribute != null) {
-            double baseHealth = 20.0; // Default player health
-            double newHealth = baseHealth * healthMultiplier;
-            healthAttribute.setBaseValue(newHealth);
-
-            // Ensure current health does not exceed max health
-            if (player.getHealth() > newHealth) {
-                player.setHealth(newHealth);
-            }
-        }
+        HealthManager.getInstance(plugin).applyAndFill(player);
     }
 
     // Event handlers to apply attributes when necessary

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/armorsets/MonolithSetBonus.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/armorsets/MonolithSetBonus.java
@@ -2,8 +2,7 @@ package goat.minecraft.minecraftnew.subsystems.armorsets;
 
 import goat.minecraft.minecraftnew.other.additionalfunctionality.BlessingUtils;
 import org.bukkit.Bukkit;
-import org.bukkit.attribute.Attribute;
-import org.bukkit.attribute.AttributeInstance;
+import goat.minecraft.minecraftnew.subsystems.health.HealthManager;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -29,7 +28,6 @@ public class MonolithSetBonus implements Listener {
 
     private final JavaPlugin plugin;
     private final Map<UUID, Boolean> applied = new HashMap<>();
-    private final Map<UUID, Double> baseHealth = new HashMap<>();
 
     public MonolithSetBonus(JavaPlugin plugin) {
         this.plugin = plugin;
@@ -90,16 +88,7 @@ public class MonolithSetBonus implements Listener {
             return;
         }
         player.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, Integer.MAX_VALUE, 0, false, false));
-        AttributeInstance attr = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
-        if (attr != null) {
-            double current = attr.getBaseValue();
-            baseHealth.put(id, current);
-            double newMax = current + 20.0;
-            attr.setBaseValue(newMax);
-            if (player.getHealth() > newMax) {
-                player.setHealth(newMax);
-            }
-        }
+        HealthManager.getInstance(plugin).updateHealth(player);
         applied.put(id, true);
     }
 
@@ -109,16 +98,8 @@ public class MonolithSetBonus implements Listener {
             return;
         }
         player.removePotionEffect(PotionEffectType.DAMAGE_RESISTANCE);
-        AttributeInstance attr = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
-        if (attr != null) {
-            double base = baseHealth.getOrDefault(id, attr.getBaseValue() - 20.0);
-            attr.setBaseValue(base);
-            if (player.getHealth() > base) {
-                player.setHealth(base);
-            }
-        }
+        HealthManager.getInstance(plugin).updateHealth(player);
         applied.put(id, false);
-        baseHealth.remove(id);
     }
 
     /**
@@ -129,6 +110,5 @@ public class MonolithSetBonus implements Listener {
             removeBonus(player);
         }
         applied.clear();
-        baseHealth.clear();
     }
 }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/health/HealthManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/health/HealthManager.java
@@ -1,0 +1,114 @@
+package goat.minecraft.minecraftnew.subsystems.health;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.other.additionalfunctionality.BlessingUtils;
+import goat.minecraft.minecraftnew.subsystems.beacon.BeaconPassivesGUI;
+import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
+import goat.minecraft.minecraftnew.subsystems.pets.PetTrait;
+import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class HealthManager {
+
+    private static HealthManager instance;
+    private final JavaPlugin plugin;
+
+    private HealthManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public static synchronized HealthManager getInstance(JavaPlugin plugin) {
+        if (instance == null) {
+            instance = new HealthManager(plugin);
+        }
+        return instance;
+    }
+
+    public static HealthManager getInstance() {
+        return instance;
+    }
+
+    /**
+     * Compute the maximum health for a player based on all bonuses.
+     */
+    public double computeMaxHealth(Player player) {
+        double health = 20.0;
+
+        XPManager xp = MinecraftNew.getInstance().getXPManager();
+        if (xp != null) {
+            int level = xp.getPlayerLevel(player, "Player");
+            health += (level / 10) * 2; // +2 health every 10 levels
+        }
+
+        if (BeaconPassivesGUI.hasBeaconPassives(player) &&
+                BeaconPassivesGUI.hasPassiveEnabled(player, "mending")) {
+            health += 20.0;
+        }
+
+        if (BlessingUtils.hasFullSetBonus(player, "Monolith")) {
+            health += 20.0;
+        }
+
+        PetManager.Pet active = PetManager.getInstance(plugin).getActivePet(player);
+        if (active != null && active.getTrait() == PetTrait.HEALTHY) {
+            double percent = active.getTrait().getValueForRarity(active.getTraitRarity());
+            double bonus = Math.floor((health * percent / 100.0) / 2) * 2; // round down to full hearts
+            health += bonus;
+        }
+
+        return health;
+    }
+
+    /**
+     * Apply computed max health to the player, keeping current health within bounds.
+     */
+    public void updateHealth(Player player) {
+        double max = computeMaxHealth(player);
+        AttributeInstance attr = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+        if (attr != null) {
+            attr.setBaseValue(max);
+            if (player.getHealth() > max) {
+                player.setHealth(max);
+            }
+        }
+    }
+
+    /**
+     * Apply computed max health and fully heal the player.
+     */
+    public void applyAndFill(Player player) {
+        double max = computeMaxHealth(player);
+        AttributeInstance attr = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+        if (attr != null) {
+            attr.setBaseValue(max);
+            player.setHealth(max);
+        }
+    }
+
+    /**
+     * Recalculate and fill health for all online players on startup.
+     */
+    public void startup() {
+        for (Player player : plugin.getServer().getOnlinePlayers()) {
+            applyAndFill(player);
+        }
+    }
+
+    /**
+     * Reset all player health to the default 20 before shutdown to avoid stacking.
+     */
+    public void shutdown() {
+        for (Player player : plugin.getServer().getOnlinePlayers()) {
+            AttributeInstance attr = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+            if (attr != null) {
+                attr.setBaseValue(20.0);
+                if (player.getHealth() > 20.0) {
+                    player.setHealth(20.0);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/traits/PetTraitEffects.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/traits/PetTraitEffects.java
@@ -3,8 +3,7 @@ package goat.minecraft.minecraftnew.subsystems.pets.traits;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
 import goat.minecraft.minecraftnew.subsystems.pets.PetTrait;
 import org.bukkit.Sound;
-import org.bukkit.attribute.Attribute;
-import org.bukkit.attribute.AttributeInstance;
+import goat.minecraft.minecraftnew.subsystems.health.HealthManager;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -25,7 +24,6 @@ public class PetTraitEffects implements Listener {
     private static PetTraitEffects instance;
     private final PetManager petManager;
 
-    private final Map<UUID, Double> baseHealth = new HashMap<>();
     private final Map<UUID, Float> baseSpeed = new HashMap<>();
 
     public PetTraitEffects(JavaPlugin plugin) {
@@ -39,35 +37,11 @@ public class PetTraitEffects implements Listener {
 
     // ===== Attribute Helpers =====
     private void applyHealthTrait(Player player) {
-        PetManager.Pet active = petManager.getActivePet(player);
-        if (active != null && active.getTrait() == PetTrait.HEALTHY) {
-            double bonusPercent = active.getTrait().getValueForRarity(active.getTraitRarity());
-            AttributeInstance attr = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
-            if (attr == null) return;
-            UUID id = player.getUniqueId();
-            double base = baseHealth.computeIfAbsent(id, k -> attr.getBaseValue());
-            double newBase = base * (1.0 + bonusPercent / 100.0);
-            attr.setBaseValue(newBase);
-            if (player.getHealth() > newBase) {
-                player.setHealth(newBase);
-            }
-            return;
-        }
-        removeHealthTrait(player);
+        HealthManager.getInstance(petManager.getPlugin()).updateHealth(player);
     }
 
     private void removeHealthTrait(Player player) {
-        UUID id = player.getUniqueId();
-        if (!baseHealth.containsKey(id)) return;
-        AttributeInstance attr = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
-        if (attr != null) {
-            double base = baseHealth.get(id);
-            attr.setBaseValue(base);
-            if (player.getHealth() > base) {
-                player.setHealth(base);
-            }
-        }
-        baseHealth.remove(id);
+        HealthManager.getInstance(petManager.getPlugin()).updateHealth(player);
     }
 
     private void applySpeedTrait(Player player) {
@@ -94,11 +68,13 @@ public class PetTraitEffects implements Listener {
     public void applyTraits(Player player) {
         applyHealthTrait(player);
         applySpeedTrait(player);
+        HealthManager.getInstance(petManager.getPlugin()).updateHealth(player);
     }
 
     public void removeTraits(Player player) {
         removeHealthTrait(player);
         removeSpeedTrait(player);
+        HealthManager.getInstance(petManager.getPlugin()).updateHealth(player);
     }
 
     // ===== Event Hooks =====

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/XPManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/XPManager.java
@@ -22,6 +22,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
+import goat.minecraft.minecraftnew.subsystems.health.HealthManager;
 
 public class XPManager implements CommandExecutor {
 
@@ -456,10 +457,7 @@ public class XPManager implements CommandExecutor {
             player.addPotionEffect(new PotionEffect(PotionEffectType.ABSORPTION, 1200, 0));
             player.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, 600, 0));
 
-            // Adjust max health
-            double healthMultiplier = 1 + (Math.min(newLevel, 100) * 0.01);
-            double newMaxHealth = 20.0 * healthMultiplier;
-            player.getAttribute(Attribute.GENERIC_MAX_HEALTH).setBaseValue(newMaxHealth);
+            HealthManager.getInstance(plugin).applyAndFill(player);
         }
 
         //==========================
@@ -478,9 +476,8 @@ public class XPManager implements CommandExecutor {
         // Then skill-specific details
         switch (skill.toLowerCase()) {
             case "player":
-                double healthMultiplier = 1 + (Math.min(newLevel, 100) * 0.01);
-                double newMaxHealth = 20.0 * healthMultiplier;
-                int displayHealth = (int)newMaxHealth + 1;  // add 1 to match the actual health
+                double newMaxHealth = HealthManager.getInstance(plugin).computeMaxHealth(player);
+                int displayHealth = (int) newMaxHealth;
                 body.append(ChatColor.WHITE).append("Your ")
                         .append(ChatColor.GREEN).append("Max Health ")
                         .append(ChatColor.WHITE).append("is now ")


### PR DESCRIPTION
## Summary
- introduce `HealthManager` singleton to handle all player health bonuses
- route player join and respawn health through `HealthManager`
- update Player skill level-ups to recalc health
- centralize Monolith, Beacon and pet trait health effects
- reset health on shutdown and reapply on startup

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dabb9ec648332b054c7de5ca811d2