### PR TITLE
Add debugplayer command

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -324,6 +324,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getCommand("previewflow").setExecutor(new PreviewFlowCommand(this));
         FlowManager.getInstance(this);
         getCommand("flowdebug").setExecutor(new FlowDebugCommand(flowManager));
+        getCommand("debugplayer").setExecutor(new DebugPlayerCommand(this));
         auraManager = new AuraManager(this);
         getCommand("previewauratemplate").setExecutor(new PreviewAuraTemplateCommand(auraManager));
         getCommand("aura").setExecutor(new AuraCommand(auraManager));

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/DebugPlayerCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/DebugPlayerCommand.java
@@ -1,0 +1,41 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import net.citizensnpcs.api.CitizensAPI;
+import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.api.npc.NPCRegistry;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Command to spawn a hostile player NPC for debugging purposes.
+ */
+public class DebugPlayerCommand implements CommandExecutor {
+
+    private final JavaPlugin plugin;
+
+    public DebugPlayerCommand(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        NPCRegistry registry = CitizensAPI.getNPCRegistry();
+        NPC npc = registry.createNPC(EntityType.PLAYER, "HostileDebug");
+        npc.setProtected(false);
+        npc.spawn(player.getLocation().add(1, 0, 1));
+        npc.addTrait(new HostilePlayerTrait(plugin, player.getUniqueId()));
+
+        sender.sendMessage(ChatColor.GREEN + "Hostile player spawned.");
+        return true;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/HostilePlayerTrait.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/HostilePlayerTrait.java
@@ -1,0 +1,66 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.api.trait.Trait;
+import net.citizensnpcs.api.util.DataKey;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.UUID;
+
+/**
+ * Trait that makes an NPC chase and melee attack a player target.
+ */
+public class HostilePlayerTrait extends Trait {
+
+    private final JavaPlugin plugin;
+    private final UUID targetId;
+    private int taskId = -1;
+
+    private static final double ATTACK_RANGE = 2.5;
+    private static final double DAMAGE = 2.0;
+
+    public HostilePlayerTrait(JavaPlugin plugin, UUID targetId) {
+        super("hostileplayertrait");
+        this.plugin = plugin;
+        this.targetId = targetId;
+    }
+
+    @Override
+    public void onAttach() {
+        npc.setProtected(false); // allow the NPC to take damage
+        start();
+    }
+
+    private void start() {
+        taskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, () -> {
+            Player target = Bukkit.getPlayer(targetId);
+            if (target == null || !npc.isSpawned()) {
+                if (npc.isSpawned()) npc.destroy();
+                Bukkit.getScheduler().cancelTask(taskId);
+                return;
+            }
+
+            npc.getNavigator().setTarget(target, true);
+            Entity entity = npc.getEntity();
+            if (entity.getLocation().distanceSquared(target.getLocation()) <= ATTACK_RANGE * ATTACK_RANGE) {
+                target.damage(DAMAGE, entity);
+            }
+        }, 0L, 10L);
+    }
+
+    @Override
+    public void onRemove() {
+        if (taskId != -1) {
+            Bukkit.getScheduler().cancelTask(taskId);
+        }
+    }
+
+    @Override
+    public void load(DataKey key) {}
+
+    @Override
+    public void save(DataKey key) {}
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -13,9 +13,9 @@ permissions:
     description: "Grants admin access to Continuity"
     default: op     # op = only given to server operators (OPs) by default
 commands:
-  spawnhostile:
-    description: Spawns a hostile player NPC that attacks nearby players
-    usage: /<command>
+  debugplayer:
+    description: Spawns a hostile player NPC that attacks the sender
+    usage: /debugplayer
   getculinaryrecipe:
     description: Gives you the crafted output for a culinary recipe.
     usage: /getculinaryrecipe <recipe name>


### PR DESCRIPTION
## Summary
- add `debugplayer` command using Citizens API
- implement `HostilePlayerTrait` so the spawned NPC hunts and damages the player
- hook command registration in `MinecraftNew`
- update `plugin.yml`

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7235427883329cf8c28910bfce53