### PR TITLE
Add sea creature NPC manager

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreature.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreature.java
@@ -19,9 +19,10 @@ public class SeaCreature {
     private int level; // Level based on rarity
     private String skullName; // Holds the base64 URL string
     private Random random = new Random();
+    private boolean npc;
 
     public SeaCreature(String displayName, Rarity rarity, EntityType entityType, List<DropItem> dropItems,
-                       Color armorColor, String skullName, int level) {
+                       Color armorColor, String skullName, int level, boolean npc) {
         this.displayName = displayName;
         this.rarity = rarity;
         this.entityType = entityType;
@@ -29,6 +30,7 @@ public class SeaCreature {
         this.armorColor = armorColor;
         this.level = level;
         this.skullName = skullName;
+        this.npc = npc;
     }
 
     // Add a getter for the texture
@@ -75,6 +77,10 @@ public class SeaCreature {
 
     public int getLevel() {
         return level;
+    }
+
+    public boolean isNPC() {
+        return npc;
     }
 
     public static ItemStack createDyedLeatherArmor(Material material, Color color) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureRegistry.java
@@ -49,7 +49,8 @@ public class SeaCreatureRegistry implements Listener {
                 turtleDrops, // Drops for the cod fish
                 Color.fromRGB(162, 162, 162), // Light gray color to represent a cod fish
                 "Fish", // Unique texture for this creature
-                RARITY_LEVELS.get(Rarity.COMMON) // Rarity level for common creatures
+                RARITY_LEVELS.get(Rarity.COMMON), // Rarity level for common creatures
+                false
         ));
         List<SeaCreature.DropItem> codFishDrops = new ArrayList<>();
         codFishDrops.add(new SeaCreature.DropItem(ItemRegistry.getFishBone(), 1, 1, 4)); // Common drop for a cod fish
@@ -61,7 +62,8 @@ public class SeaCreatureRegistry implements Listener {
                 codFishDrops, // Drops for the cod fish
                 Color.fromRGB(162, 162, 162), // Light gray color to represent a cod fish
                 "Fish", // Unique texture for this creature
-                RARITY_LEVELS.get(Rarity.COMMON) // Rarity level for common creatures
+                RARITY_LEVELS.get(Rarity.COMMON), // Rarity level for common creatures
+                false
         ));
         List<SeaCreature.DropItem> salmonDrops = new ArrayList<>();
         salmonDrops.add(new SeaCreature.DropItem(ItemRegistry.getFishBone(), 1, 1, 4)); // Common drop for a salmon
@@ -73,7 +75,8 @@ public class SeaCreatureRegistry implements Listener {
                 salmonDrops, // Drops for the salmon
                 Color.fromRGB(255, 105, 180), // Pink color to represent a salmon
                 "Salmon", // Unique texture for this creature
-                RARITY_LEVELS.get(Rarity.COMMON) // Rarity level for common creatures
+                RARITY_LEVELS.get(Rarity.COMMON), // Rarity level for common creatures
+                false
         ));
         List<SeaCreature.DropItem> pufferfishDrops = new ArrayList<>();
         pufferfishDrops.add(new SeaCreature.DropItem(ItemRegistry.getFishBone(), 1, 1, 4)); // Common drop for a pufferfish
@@ -85,7 +88,8 @@ public class SeaCreatureRegistry implements Listener {
                 pufferfishDrops, // Drops for the pufferfish
                 Color.fromRGB(255, 165, 0), // Orange color to represent a pufferfish
                 "Pufferfish", // Unique texture for this creature
-                RARITY_LEVELS.get(Rarity.COMMON) // Rarity level for common creatures
+                RARITY_LEVELS.get(Rarity.COMMON), // Rarity level for common creatures
+                false
         ));
         List<SeaCreature.DropItem> tropicalFishDrops = new ArrayList<>();
         tropicalFishDrops.add(new SeaCreature.DropItem(ItemRegistry.getFishBone(), 1, 1, 1)); // Common drop for a tropical fish
@@ -97,7 +101,8 @@ public class SeaCreatureRegistry implements Listener {
                 tropicalFishDrops, // Drops for the tropical fish
                 Color.fromRGB(255, 215, 0), // Gold color to represent a tropical fish
                 "Tropical_Fish", // Unique texture for this creature
-                RARITY_LEVELS.get(Rarity.COMMON) // Rarity level for common creatures
+                RARITY_LEVELS.get(Rarity.COMMON), // Rarity level for common creatures
+                false
         ));
 
         //UNCOMMON
@@ -110,7 +115,8 @@ public class SeaCreatureRegistry implements Listener {
                 turdleDrops, // Drops for the cod fish
                 Color.fromRGB(162, 162, 162), // Light gray color to represent a cod fish
                 "Fish", // Unique texture for this creature
-                RARITY_LEVELS.get(Rarity.UNCOMMON) // Rarity level for common creatures
+                RARITY_LEVELS.get(Rarity.UNCOMMON), // Rarity level for common creatures
+                false
         ));
         List<SeaCreature.DropItem> luminescentDrownedDrops = new ArrayList<>();
         luminescentDrownedDrops.add(new SeaCreature.DropItem(ItemRegistry.getFishBone(), 1, 1, 2)); // Common drop for a luminescent drowned
@@ -123,7 +129,8 @@ public class SeaCreatureRegistry implements Listener {
                 luminescentDrownedDrops, // Drops for the luminescent drowned
                 Color.fromRGB(50, 150, 255), // Light blue color to represent a luminescent drowned
                 "Luminescent_Drowned", // Unique texture for this creature
-                RARITY_LEVELS.get(Rarity.UNCOMMON) // Rarity level for uncommon creatures
+                RARITY_LEVELS.get(Rarity.UNCOMMON), // Rarity level for uncommon creatures
+                false
         ));
         List<SeaCreature.DropItem> squidDrops = new ArrayList<>();
         squidDrops.add(new SeaCreature.DropItem(ItemRegistry.getSeaSalt(), 1, 1, 1)); // Luminescent Ink drop
@@ -135,7 +142,8 @@ public class SeaCreatureRegistry implements Listener {
                 squidDrops, // Drops for the luminescent drowned
                 Color.fromRGB(50, 150, 255), // Light blue color to represent a luminescent drowned
                 "Luminescent_Drowned", // Unique texture for this creature
-                RARITY_LEVELS.get(Rarity.UNCOMMON) // Rarity level for uncommon creatures
+                RARITY_LEVELS.get(Rarity.UNCOMMON), // Rarity level for uncommon creatures
+                false
         ));
 
         //RARE
@@ -148,7 +156,8 @@ public class SeaCreatureRegistry implements Listener {
                 deepTurtleDrops, // Drops for the cod fish
                 Color.fromRGB(162, 162, 162), // Light gray color to represent a cod fish
                 "Fish", // Unique texture for this creature
-                RARITY_LEVELS.get(Rarity.RARE) // Rarity level for common creatures
+                RARITY_LEVELS.get(Rarity.RARE), // Rarity level for common creatures
+                false
         ));
         List<SeaCreature.DropItem> poseidonDrops = new ArrayList<>();
         poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getSeaSalt(), 6, 1, 3));
@@ -164,7 +173,8 @@ public class SeaCreatureRegistry implements Listener {
                 poseidonDrops,
                 Color.fromRGB(0, 0, 255),
                 "Poseidon",  // unique texture for this creature
-                RARITY_LEVELS.get(Rarity.RARE)
+                RARITY_LEVELS.get(Rarity.RARE),
+                true
         ));
         List<SeaCreature.DropItem> sharkDrops = new ArrayList<>();
         sharkDrops.add(new SeaCreature.DropItem(ItemRegistry.getTooth(), 12, 1, 5));
@@ -178,7 +188,8 @@ public class SeaCreatureRegistry implements Listener {
                 sharkDrops,
                 Color.fromRGB(47, 47, 47),
                 "Shark",  // unique texture for this creature
-                RARITY_LEVELS.get(Rarity.RARE)
+                RARITY_LEVELS.get(Rarity.RARE),
+                false
         ));
         List<SeaCreature.DropItem> pirateDrops = new ArrayList<>();
         pirateDrops.add(new SeaCreature.DropItem(ItemRegistry.getTooth(), 6, 1, 5));
@@ -193,7 +204,8 @@ public class SeaCreatureRegistry implements Listener {
                 null,
                 Color.fromRGB(0, 0, 0),
                 "Pirate",  // unique texture for this creature
-                RARITY_LEVELS.get(Rarity.RARE)
+                RARITY_LEVELS.get(Rarity.RARE),
+                true
         ));
 
 
@@ -210,7 +222,8 @@ public class SeaCreatureRegistry implements Listener {
                 abyssalTurtleDrops, // Drops for the cod fish
                 Color.fromRGB(162, 162, 162), // Light gray color to represent a cod fish
                 "Fish", // Unique texture for this creature
-                RARITY_LEVELS.get(Rarity.EPIC) // Rarity level for common creatures
+                RARITY_LEVELS.get(Rarity.EPIC), // Rarity level for common creatures
+                false
         ));
         List<SeaCreature.DropItem> waterSpiderDrops = new ArrayList<>();
         waterSpiderDrops.add(new SeaCreature.DropItem(ItemRegistry.getFishBone(), 14, 1, 5));
@@ -222,7 +235,8 @@ public class SeaCreatureRegistry implements Listener {
                 waterSpiderDrops,
                 Color.fromRGB(0, 51, 102),
                 "waterspider",  // unique texture for this creature
-                RARITY_LEVELS.get(Rarity.EPIC)
+                RARITY_LEVELS.get(Rarity.EPIC),
+                false
         ));
         List<SeaCreature.DropItem> greatWhiteSharkDrops = new ArrayList<>();
         greatWhiteSharkDrops.add(new SeaCreature.DropItem(ItemRegistry.getFishBone(), 14, 1, 5));
@@ -237,7 +251,8 @@ public class SeaCreatureRegistry implements Listener {
                 greatWhiteSharkDrops,
                 Color.fromRGB(0, 51, 102),
                 "Great_White_Shark",  // unique texture for this creature
-                RARITY_LEVELS.get(Rarity.EPIC)
+                RARITY_LEVELS.get(Rarity.EPIC),
+                false
         ));
         List<SeaCreature.DropItem> leviathanDrops = new ArrayList<>();
         leviathanDrops.add(new SeaCreature.DropItem(ItemRegistry.getTooth(), 30, 1, 4));
@@ -251,7 +266,8 @@ public class SeaCreatureRegistry implements Listener {
                 leviathanDrops,
                 Color.fromRGB(0, 100, 100), // Dark aqua color
                 "Leviathan", // Unique texture for this creature
-                RARITY_LEVELS.get(Rarity.EPIC)
+                RARITY_LEVELS.get(Rarity.EPIC),
+                false
         ));
         List<SeaCreature.DropItem> yetiDrops = new ArrayList<>();
         yetiDrops.add(new SeaCreature.DropItem(ItemRegistry.getTooth(), 20, 1, 3)); // Example drop
@@ -264,7 +280,8 @@ public class SeaCreatureRegistry implements Listener {
                 yetiDrops, // Drops for the Yeti
                 Color.fromRGB(255, 255, 255), // White color to represent a Yeti
                 "Yeti", // Unique texture for this creature
-                RARITY_LEVELS.get(Rarity.EPIC) // Rarity level for epic creatures
+                RARITY_LEVELS.get(Rarity.EPIC), // Rarity level for epic creatures
+                false
         ));
 
 
@@ -282,7 +299,8 @@ public class SeaCreatureRegistry implements Listener {
                 bioluminescentGuardianDrops,
                 Color.fromRGB(211, 211, 211),
                 "Megalodon",  // unique texture for this creature
-                RARITY_LEVELS.get(Rarity.LEGENDARY)
+                RARITY_LEVELS.get(Rarity.LEGENDARY),
+                false
         ));
         List<SeaCreature.DropItem> megalodonDrops = new ArrayList<>();
         megalodonDrops.add(new SeaCreature.DropItem(ItemRegistry.getTooth(), 30, 1, 4));
@@ -295,7 +313,8 @@ public class SeaCreatureRegistry implements Listener {
                 megalodonDrops,
                 Color.fromRGB(211, 211, 211),
                 "Megalodon",  // unique texture for this creature
-                RARITY_LEVELS.get(Rarity.LEGENDARY)
+                RARITY_LEVELS.get(Rarity.LEGENDARY),
+                false
         ));
         List<SeaCreature.DropItem> abominationDrops = new ArrayList<>();
         abominationDrops.add(new SeaCreature.DropItem(ItemRegistry.getTooth(), 64, 1, 4));
@@ -309,7 +328,8 @@ public class SeaCreatureRegistry implements Listener {
                 abominationDrops,
                 Color.fromRGB(250, 10, 20),
                 "Abomination",  // unique texture for this creature
-                RARITY_LEVELS.get(Rarity.LEGENDARY)
+                RARITY_LEVELS.get(Rarity.LEGENDARY),
+                false
         ));
         List<SeaCreature.DropItem> midasDrops = new ArrayList<>();
         midasDrops.add(new SeaCreature.DropItem(ItemRegistry.getVerdantRelicTreasury(), 1, 1, 1));
@@ -321,7 +341,8 @@ public class SeaCreatureRegistry implements Listener {
                 midasDrops,
                 Color.fromRGB(212, 175, 55),  // A gold-like color.
                 "Midas",  // Unique texture for this creature (ensure your texture key/method is set up accordingly).
-                RARITY_LEVELS.get(Rarity.LEGENDARY)
+                RARITY_LEVELS.get(Rarity.LEGENDARY),
+                true
         ));
 
         //MYTHIC

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SpawnSeaCreatureCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SpawnSeaCreatureCommand.java
@@ -2,6 +2,7 @@ package goat.minecraft.minecraftnew.subsystems.fishing;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
+import goat.minecraft.minecraftnew.subsystems.fishing.npc.SeaCreatureNPCManager;
 import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
 import goat.minecraft.minecraftnew.subsystems.combat.SpawnMonsters;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
@@ -52,18 +53,19 @@ public class SpawnSeaCreatureCommand implements CommandExecutor {
         SeaCreature seaCreature = optionalSeaCreature.get();
 
         // Spawn the sea creature at the player's location
-
-        Entity spawnedEntity = player.getWorld().spawnEntity(player.getLocation(), seaCreature.getEntityType());
-        if (spawnedEntity instanceof org.bukkit.entity.LivingEntity) {
-            org.bukkit.entity.LivingEntity livingEntity = (org.bukkit.entity.LivingEntity) spawnedEntity;
-            applySeaCreatureEquipment(livingEntity, seaCreature);
-            SpawnMonsters spawnMonsters = SpawnMonsters.getInstance(new XPManager(MinecraftNew.getInstance()));
-            spawnMonsters.applyMobAttributes(livingEntity, seaCreature.getLevel());
+        if (seaCreature.isNPC()) {
+            SeaCreatureNPCManager.getInstance(MinecraftNew.getInstance()).spawnSeaCreatureNPC(player, player.getLocation(), seaCreature, seaCreature.getLevel());
+        } else {
+            Entity spawnedEntity = player.getWorld().spawnEntity(player.getLocation(), seaCreature.getEntityType());
+            if (spawnedEntity instanceof org.bukkit.entity.LivingEntity livingEntity) {
+                applySeaCreatureEquipment(livingEntity, seaCreature);
+                SpawnMonsters spawnMonsters = SpawnMonsters.getInstance(new XPManager(MinecraftNew.getInstance()));
+                spawnMonsters.applyMobAttributes(livingEntity, seaCreature.getLevel());
+            }
+            spawnedEntity.setCustomName(ChatColor.AQUA + "[Lvl " + seaCreature.getLevel() + "] " + seaCreature.getColoredDisplayName());
+            spawnedEntity.setCustomNameVisible(true);
+            spawnedEntity.setMetadata("SEA_CREATURE", new FixedMetadataValue(Bukkit.getPluginManager().getPlugin("MinecraftNew"), seaCreature.getDisplayName()));
         }
-
-        spawnedEntity.setCustomName(ChatColor.AQUA + "[Lvl " + seaCreature.getLevel() + "] " + seaCreature.getColoredDisplayName());
-        spawnedEntity.setCustomNameVisible(true);
-        spawnedEntity.setMetadata("SEA_CREATURE", new FixedMetadataValue(Bukkit.getPluginManager().getPlugin("MinecraftNew"), seaCreature.getDisplayName()));
 
         // Apply attributes and equipment
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/npc/RangedAttackTrait.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/npc/RangedAttackTrait.java
@@ -1,0 +1,56 @@
+package goat.minecraft.minecraftnew.subsystems.fishing.npc;
+
+import net.citizensnpcs.api.trait.Trait;
+import net.citizensnpcs.api.util.DataKey;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Arrow;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.util.Vector;
+
+import java.util.UUID;
+
+public class RangedAttackTrait extends Trait {
+    private final JavaPlugin plugin;
+    private final UUID targetId;
+    private int taskId = -1;
+
+    public RangedAttackTrait(JavaPlugin plugin, UUID targetId) {
+        super("seacreatureranged");
+        this.plugin = plugin;
+        this.targetId = targetId;
+    }
+
+    @Override
+    public void onAttach() {
+        start();
+    }
+
+    private void start() {
+        taskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, () -> {
+            Player target = Bukkit.getPlayer(targetId);
+            if (target == null || !npc.isSpawned()) {
+                if (npc.isSpawned()) npc.destroy();
+                Bukkit.getScheduler().cancelTask(taskId);
+                return;
+            }
+            LivingEntity entity = (LivingEntity) npc.getEntity();
+            if (entity.getLocation().distanceSquared(target.getLocation()) <= 100) {
+                Arrow arrow = entity.launchProjectile(Arrow.class);
+                Vector v = target.getLocation().toVector().subtract(entity.getLocation().toVector()).normalize();
+                arrow.setVelocity(v.multiply(1.2));
+            }
+        }, 40L, 40L);
+    }
+
+    @Override
+    public void onRemove() {
+        if (taskId != -1) {
+            Bukkit.getScheduler().cancelTask(taskId);
+        }
+    }
+
+    @Override public void load(DataKey key) {}
+    @Override public void save(DataKey key) {}
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/npc/SeaCreatureNPCManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/npc/SeaCreatureNPCManager.java
@@ -1,0 +1,120 @@
+package goat.minecraft.minecraftnew.subsystems.fishing.npc;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.fishing.SeaCreature;
+import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
+import goat.minecraft.minecraftnew.subsystems.combat.SpawnMonsters;
+import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import net.citizensnpcs.api.CitizensAPI;
+import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.api.npc.NPCRegistry;
+import net.citizensnpcs.api.trait.trait.Equipment;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.util.Vector;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class SeaCreatureNPCManager {
+    private static SeaCreatureNPCManager instance;
+    private final MinecraftNew plugin;
+    private final NPCRegistry registry;
+    private final XPManager xpManager;
+    private final Map<UUID, NPC> active = new HashMap<>();
+
+    private SeaCreatureNPCManager(MinecraftNew plugin) {
+        this.plugin = plugin;
+        this.registry = CitizensAPI.getNPCRegistry();
+        this.xpManager = new XPManager(plugin);
+    }
+
+    public static SeaCreatureNPCManager getInstance(MinecraftNew plugin) {
+        if (instance == null) {
+            instance = new SeaCreatureNPCManager(plugin);
+        }
+        return instance;
+    }
+
+    public NPC spawnSeaCreatureNPC(Player target, Location loc, SeaCreature creature, int level) {
+        NPC npc = registry.createNPC(creature.getEntityType(), creature.getDisplayName());
+        npc.setProtected(false);
+        npc.spawn(loc);
+        LivingEntity entity = (LivingEntity) npc.getEntity();
+
+        applyEquipment(entity, creature);
+        SpawnMonsters.getInstance(xpManager).applyMobAttributes(entity, level);
+
+        entity.setCustomName(ChatColor.AQUA + "[Lvl " + level + "] " + creature.getColoredDisplayName());
+        entity.setCustomNameVisible(true);
+        entity.setMetadata("SEA_CREATURE", new FixedMetadataValue(plugin, creature.getDisplayName()));
+
+        npc.addTrait(new SwimmingTrait(plugin, target.getUniqueId()));
+        if (creature.getEntityType() == EntityType.SKELETON) {
+            npc.addTrait(new RangedAttackTrait(plugin, target.getUniqueId()));
+        }
+
+        launchTowards(entity, target.getLocation(), loc);
+        entity.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, Integer.MAX_VALUE, 2, false));
+
+        active.put(npc.getUniqueId(), npc);
+        return npc;
+    }
+
+    private void applyEquipment(LivingEntity living, SeaCreature creature) {
+        PetManager petManager = PetManager.getInstance(plugin);
+        ItemStack helmet = petManager.getSkullForPet(creature.getSkullName());
+        ItemStack chest = SeaCreature.createDyedLeatherArmor(org.bukkit.Material.LEATHER_CHESTPLATE, creature.getArmorColor());
+        ItemStack legs = SeaCreature.createDyedLeatherArmor(org.bukkit.Material.LEATHER_LEGGINGS, creature.getArmorColor());
+        ItemStack boots = SeaCreature.createDyedLeatherArmor(org.bukkit.Material.LEATHER_BOOTS, creature.getArmorColor());
+        Equipment eq = npcEquipment(living);
+        if (eq != null) {
+            eq.set(Equipment.EquipmentSlot.HELMET, helmet);
+            eq.set(Equipment.EquipmentSlot.CHESTPLATE, chest);
+            eq.set(Equipment.EquipmentSlot.LEGGINGS, legs);
+            eq.set(Equipment.EquipmentSlot.BOOTS, boots);
+        } else {
+            living.getEquipment().setHelmet(helmet);
+            living.getEquipment().setChestplate(chest);
+            living.getEquipment().setLeggings(legs);
+            living.getEquipment().setBoots(boots);
+        }
+        living.getEquipment().setHelmetDropChance(0);
+        living.getEquipment().setChestplateDropChance(0);
+        living.getEquipment().setLeggingsDropChance(0);
+        living.getEquipment().setBootsDropChance(0);
+    }
+
+    private Equipment npcEquipment(LivingEntity entity) {
+        if (CitizensAPI.getNPCRegistry().isNPC(entity)) {
+            NPC npc = CitizensAPI.getNPCRegistry().getNPC(entity);
+            return npc.getOrAddTrait(Equipment.class);
+        }
+        return null;
+    }
+
+    private void launchTowards(LivingEntity entity, Location playerLoc, Location bobberLocation) {
+        Vector direction = playerLoc.subtract(bobberLocation).toVector().normalize();
+        double verticalBoost = 0.2;
+        if (entity.getType() == EntityType.SQUID || entity.getType() == EntityType.GLOW_SQUID) {
+            Location above = playerLoc.clone().add(0, 2, 0);
+            entity.teleport(above);
+            return;
+        }
+        double diff = playerLoc.getY() - bobberLocation.getY();
+        if (diff >= 4) {
+            verticalBoost += diff * 0.1;
+        }
+        direction.setY(verticalBoost);
+        direction.multiply(2);
+        entity.setVelocity(direction);
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/npc/SwimmingTrait.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/npc/SwimmingTrait.java
@@ -1,0 +1,50 @@
+package goat.minecraft.minecraftnew.subsystems.fishing.npc;
+
+import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.api.trait.Trait;
+import net.citizensnpcs.api.util.DataKey;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.UUID;
+
+public class SwimmingTrait extends Trait {
+    private final JavaPlugin plugin;
+    private final UUID targetId;
+    private int taskId = -1;
+
+    public SwimmingTrait(JavaPlugin plugin, UUID targetId) {
+        super("seacreatureswim");
+        this.plugin = plugin;
+        this.targetId = targetId;
+    }
+
+    @Override
+    public void onAttach() {
+        npc.setProtected(false);
+        start();
+    }
+
+    private void start() {
+        taskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, () -> {
+            Player target = Bukkit.getPlayer(targetId);
+            if (target == null || !npc.isSpawned()) {
+                if (npc.isSpawned()) npc.destroy();
+                Bukkit.getScheduler().cancelTask(taskId);
+                return;
+            }
+            npc.getNavigator().setTarget(target, true);
+        }, 0L, 10L);
+    }
+
+    @Override
+    public void onRemove() {
+        if (taskId != -1) {
+            Bukkit.getScheduler().cancelTask(taskId);
+        }
+    }
+
+    @Override public void load(DataKey key) {}
+    @Override public void save(DataKey key) {}
+}


### PR DESCRIPTION
## Summary
- allow SeaCreature definitions to mark entries as NPCs
- add `SeaCreatureNPCManager` using Citizens API for spawning
- create `SwimmingTrait` and `RangedAttackTrait`
- support NPC spawning in `FishingEvent` and admin command

## Testing
- `mvn -q test` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686f796231388332815c6bec7b0db481