### PR TITLE
Add Terraforming skill

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -511,6 +511,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(SpawnMonsters.getInstance(xpManager), this);
         getServer().getPluginManager().registerEvents(new KillMonster(), MinecraftNew.getInstance());
         getServer().getPluginManager().registerEvents(new Mining(), MinecraftNew.getInstance());
+        getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.terraforming.Terraforming(), MinecraftNew.getInstance());
         getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.mining.GemstoneApplicationSystem(this), this);
         getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.forestry.EffigyApplicationSystem(this), this);
         getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.fishing.BaitApplicationSystem(this), this);

--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TransfigurationPouchManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TransfigurationPouchManager.java
@@ -29,9 +29,10 @@ public class TransfigurationPouchManager implements Listener {
     private FileConfiguration pouchConfig;
     private final Map<UUID, Integer> pendingXP = new HashMap<>();
 
-    private static final String[] SKILLS = {"Fishing","Farming","Mining","Combat","Player","Taming","Forestry","Bartering","Culinary","Smithing","Brewing"};
+    private static final String[] SKILLS = {"Fishing","Farming","Mining","Terraforming","Combat","Player","Taming","Forestry","Bartering","Culinary","Smithing","Brewing"};
     private static final Material[] SKILL_ICONS = {
             Material.FISHING_ROD, Material.WHEAT, Material.IRON_PICKAXE,
+            Material.GRASS_BLOCK,
             Material.IRON_SWORD, Material.PLAYER_HEAD, Material.LEAD, Material.GOLDEN_AXE,
             Material.EMERALD, Material.FURNACE, Material.DAMAGED_ANVIL,
             Material.BREWING_STAND

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/music/MusicDiscManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/music/MusicDiscManager.java
@@ -1548,7 +1548,7 @@ public class MusicDiscManager implements Listener {
         int totalCycles = durationTicks / intervalTicks;
 
         // List of skills
-        String[] skills = {"Combat", "Fishing", "Forestry", "Mining", "Farming", "Bartering", "Smithing", "Culinary", "Taming"};
+        String[] skills = {"Combat", "Fishing", "Forestry", "Mining", "Terraforming", "Farming", "Bartering", "Smithing", "Culinary", "Taming"};
 
         // Colors for each skill
         Map<String, ChatColor> skillColors = new HashMap<>();
@@ -1556,6 +1556,7 @@ public class MusicDiscManager implements Listener {
         skillColors.put("Fishing", ChatColor.AQUA);
         skillColors.put("Forestry", ChatColor.DARK_GREEN);
         skillColors.put("Mining", ChatColor.GRAY);
+        skillColors.put("Terraforming", ChatColor.GREEN);
         skillColors.put("Farming", ChatColor.YELLOW);
         skillColors.put("Bartering", ChatColor.GREEN);
         skillColors.put("Culinary", ChatColor.YELLOW);
@@ -1786,7 +1787,7 @@ public class MusicDiscManager implements Listener {
                 Arrays.asList(ChatColor.GRAY + "Gain 500-1000 XP in a random skill."),
                 1, false, false);
         list.add(new LotteryReward(xpIcon, p -> {
-            String[] skills = {"Combat","Fishing","Forestry","Mining","Farming","Bartering","Smithing","Culinary","Taming"};
+            String[] skills = {"Combat","Fishing","Forestry","Mining","Terraforming","Farming","Bartering","Smithing","Culinary","Taming"};
             String skill = skills[random.nextInt(skills.length)];
             int xp = 5000 + random.nextInt(10000);
             xpManager.addXP(p, skill, xp);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/terraforming/Terraforming.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/terraforming/Terraforming.java
@@ -1,0 +1,31 @@
+package goat.minecraft.minecraftnew.subsystems.terraforming;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+
+/**
+ * Awards Terraforming XP when players mine blocks that are exposed to the sky.
+ */
+public class Terraforming implements Listener {
+    private final XPManager xpManager = new XPManager(MinecraftNew.getInstance());
+
+    @EventHandler
+    public void onBlockBreak(BlockBreakEvent event) {
+        Player player = event.getPlayer();
+        Block block = event.getBlock();
+        Location loc = block.getLocation();
+        World world = loc.getWorld();
+        if (world == null) return;
+        int highest = world.getHighestBlockYAt(loc);
+        if (loc.getBlockY() >= highest) {
+            xpManager.addXP(player, "Terraforming", 1);
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/SkillsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/SkillsCommand.java
@@ -55,13 +55,14 @@ public class SkillsCommand implements CommandExecutor {
         Inventory skillsInventory = Bukkit.createInventory(null, 27, ChatColor.GOLD + "Your Skills");
 
         // Define the skills to display
-        String[] skills = {"Fishing", "Farming", "Mining", "Combat", "Player", "Taming", "Forestry", "Bartering", "Culinary", "Smithing", "Brewing"};
+        String[] skills = {"Fishing", "Farming", "Mining", "Terraforming", "Combat", "Player", "Taming", "Forestry", "Bartering", "Culinary", "Smithing", "Brewing"};
 
         // Define icons for each skill (customize as desired)
         Material[] icons = {
                 Material.FISHING_ROD,    // Fishing
                 Material.WHEAT,          // Farming
                 Material.IRON_PICKAXE,   // Mining
+                Material.GRASS_BLOCK,    // Terraforming
                 Material.IRON_SWORD,     // Combat
                 Material.PLAYER_HEAD,    // Player
                 Material.LEAD,           // Taming
@@ -159,6 +160,12 @@ public class SkillsCommand implements CommandExecutor {
                         ChatColor.GRAY + "Bonus Oxygen: +" + ChatColor.GREEN + (4 * level) + " seconds",
                         ChatColor.GRAY + "Double Drops Chance: " + ChatColor.GREEN + (level / 2) + "%",
                         ChatColor.GRAY + "Gold Fever: " + ChatColor.GREEN + "Haste " + 1 + " (" + duration / 20 + "s)"
+                ));
+                break;
+            case "Terraforming":
+                lore = new ArrayList<>(Arrays.asList(
+                        ChatColor.GREEN + "Level: " + ChatColor.GREEN + (int) level,
+                        ChatColor.GREEN + "XP from surface blocks" // simple descriptor
                 ));
                 break;
             case "Combat":


### PR DESCRIPTION
## Summary
- introduce a new Terraforming skill that awards XP for breaking blocks exposed to the sky
- show Terraforming in the skills GUI
- include Terraforming in music disc rewards and transfiguration pouch options
- register Terraforming events

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f832ea6c48332ac4dd87087002ab9