### PR TITLE
Add Terraforming durability preservation

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -587,6 +587,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new ReforgeArmorToughness(), this);
         getServer().getPluginManager().registerEvents(new ReforgeArmor(), this);
         getServer().getPluginManager().registerEvents(new ReforgeDurability(), this);
+        getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.terraforming.TerraformingDurability(), this);
         getServer().getPluginManager().registerEvents(new ReforgeSwiftBlade(), this);
         getServer().getPluginManager().registerEvents(new WaterLogged(this), this);
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/terraforming/TerraformingDurability.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/terraforming/TerraformingDurability.java
@@ -1,0 +1,26 @@
+package goat.minecraft.minecraftnew.subsystems.terraforming;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerItemDamageEvent;
+
+/**
+ * Grants a chance to prevent durability loss based on the player's Terraforming level.
+ */
+public class TerraformingDurability implements Listener {
+    private final XPManager xpManager = new XPManager(MinecraftNew.getInstance());
+
+    @EventHandler
+    public void onItemDamage(PlayerItemDamageEvent event) {
+        Player player = event.getPlayer();
+        int level = xpManager.getPlayerLevel(player, "Terraforming");
+        double chance = level * 0.0025; // (0.25 * level)% chance
+
+        if (Math.random() < chance) {
+            event.setCancelled(true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `TerraformingDurability` listener giving a (0.25 * level)% chance to negate durability loss
- register the listener in `MinecraftNew`

## Testing
- `mvn -q -DskipTests package` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f85705bcc8332aa6d5081942f3d6c