### PR TITLE
Add basic corpse NPC system

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -390,6 +390,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
             getDataFolder().mkdirs();
         }
         this.getCommand("spawnseacreature").setExecutor(new SpawnSeaCreatureCommand());
+        this.getCommand("spawncorpse").setExecutor(new goat.minecraft.minecraftnew.subsystems.corpses.SpawnCorpseCommand());
         getCommand("seacreaturechance").setExecutor(new SeaCreatureChanceCommand(this, xpManager));
         getCommand("treasurechance").setExecutor(new TreasureChanceCommand(this));
         getCommand("spiritchance").setExecutor(new SpiritChanceCommand(this, xpManager));

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/Corpse.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/Corpse.java
@@ -1,0 +1,85 @@
+package goat.minecraft.minecraftnew.subsystems.corpses;
+
+import goat.minecraft.minecraftnew.subsystems.fishing.Rarity;
+import org.bukkit.Material;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+public class Corpse {
+    private final String name;
+    private final Rarity rarity;
+    private final int level;
+    private final Material weapon;
+    private final boolean bow;
+    private final String skinUrl;
+    private final List<DropItem> dropItems;
+    private final Random random = new Random();
+
+    public Corpse(String name, Rarity rarity, int level, Material weapon, boolean bow, String skinUrl, List<DropItem> dropItems) {
+        this.name = name;
+        this.rarity = rarity;
+        this.level = level;
+        this.weapon = weapon;
+        this.bow = bow;
+        this.skinUrl = skinUrl;
+        this.dropItems = dropItems == null ? new ArrayList<>() : dropItems;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Rarity getRarity() {
+        return rarity;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public Material getWeapon() {
+        return weapon;
+    }
+
+    public boolean usesBow() {
+        return bow;
+    }
+
+    public String getSkinUrl() {
+        return skinUrl;
+    }
+
+    public List<org.bukkit.inventory.ItemStack> getDrops() {
+        List<org.bukkit.inventory.ItemStack> drops = new ArrayList<>();
+        for (DropItem di : dropItems) {
+            int qty = 0;
+            for (int i = 0; i < di.rollCount; i++) {
+                if (random.nextInt(di.rollDenominator) < di.rollNumerator) {
+                    qty++;
+                }
+            }
+            if (qty > 0) {
+                org.bukkit.inventory.ItemStack item = di.item.clone();
+                item.setAmount(qty);
+                drops.add(item);
+            }
+        }
+        return drops;
+    }
+
+    public static class DropItem {
+        private final org.bukkit.inventory.ItemStack item;
+        private final int rollCount;
+        private final int rollNumerator;
+        private final int rollDenominator;
+
+        public DropItem(org.bukkit.inventory.ItemStack item, int rollCount, int rollNumerator, int rollDenominator) {
+            this.item = item;
+            this.rollCount = rollCount;
+            this.rollNumerator = rollNumerator;
+            this.rollDenominator = rollDenominator;
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseRegistry.java
@@ -1,0 +1,72 @@
+package goat.minecraft.minecraftnew.subsystems.corpses;
+
+import goat.minecraft.minecraftnew.subsystems.fishing.Rarity;
+import org.bukkit.Color;
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
+
+import java.util.*;
+
+public class CorpseRegistry {
+    private static final List<Corpse> CORPSES = new ArrayList<>();
+    private static final Map<Rarity, Double> RARITY_WEIGHTS = new HashMap<>();
+    private static final Random RANDOM = new Random();
+
+    static {
+        RARITY_WEIGHTS.put(Rarity.COMMON, 0.50);
+        RARITY_WEIGHTS.put(Rarity.UNCOMMON, 0.30);
+        RARITY_WEIGHTS.put(Rarity.RARE, 0.12);
+        RARITY_WEIGHTS.put(Rarity.EPIC, 0.06);
+        RARITY_WEIGHTS.put(Rarity.LEGENDARY, 0.02);
+
+        // COMMON
+        CORPSES.add(new Corpse("Farmer Corpse", Rarity.COMMON, 30, Material.IRON_HOE, false, "", null));
+        CORPSES.add(new Corpse("Guard Corpse", Rarity.COMMON, 35, Material.IRON_SWORD, false, "", null));
+        CORPSES.add(new Corpse("Archer Corpse", Rarity.COMMON, 40, Material.BOW, true, "", null));
+
+        // UNCOMMON
+        CORPSES.add(new Corpse("Diver Corpse", Rarity.UNCOMMON, 50, Material.TRIDENT, false, "", null));
+        CORPSES.add(new Corpse("Fisherman Corpse", Rarity.UNCOMMON, 55, Material.FISHING_ROD, false, "", null));
+        CORPSES.add(new Corpse("Lumberjack Corpse", Rarity.UNCOMMON, 60, Material.IRON_AXE, false, "", null));
+
+        // RARE
+        CORPSES.add(new Corpse("Adventurer Corpse", Rarity.RARE, 70, Material.MAP, false, "", null));
+        CORPSES.add(new Corpse("Pirate Corpse", Rarity.RARE, 75, Material.IRON_SWORD, false, "", null));
+        CORPSES.add(new Corpse("Sculk Infected", Rarity.RARE, 80, Material.STONE_SWORD, false, "", null));
+
+        // EPIC
+        CORPSES.add(new Corpse("Necromancer Corpse", Rarity.EPIC, 90, Material.SKELETON_SKULL, false, "", null));
+        CORPSES.add(new Corpse("Gladiator Corpse", Rarity.EPIC, 100, Material.DIAMOND_SWORD, false, "", null));
+        CORPSES.add(new Corpse("Duskblood", Rarity.EPIC, 110, Material.AIR, false, "", null));
+
+        // LEGENDARY
+        CORPSES.add(new Corpse("Trauma", Rarity.LEGENDARY, 120, Material.DIAMOND_AXE, false, "", null));
+        CORPSES.add(new Corpse("Cryptic", Rarity.LEGENDARY, 140, Material.BOW, true, "", null));
+        CORPSES.add(new Corpse("Dreadnaught", Rarity.LEGENDARY, 150, Material.NETHERITE_SWORD, false, "", null));
+    }
+
+    public static Optional<Corpse> getCorpseByName(String name) {
+        return CORPSES.stream().filter(c -> c.getName().equalsIgnoreCase(name)).findFirst();
+    }
+
+    public static Optional<Corpse> getRandomCorpse() {
+        double rand = RANDOM.nextDouble();
+        double cumulative = 0.0;
+        Rarity selected = Rarity.COMMON;
+        for (Map.Entry<Rarity, Double> e : RARITY_WEIGHTS.entrySet()) {
+            cumulative += e.getValue();
+            if (rand <= cumulative) {
+                selected = e.getKey();
+                break;
+            }
+        }
+        List<Corpse> filtered = new ArrayList<>();
+        for (Corpse c : CORPSES) {
+            if (c.getRarity() == selected) {
+                filtered.add(c);
+            }
+        }
+        if (filtered.isEmpty()) return Optional.empty();
+        return Optional.of(filtered.get(RANDOM.nextInt(filtered.size())));
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseTrait.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseTrait.java
@@ -1,0 +1,92 @@
+package goat.minecraft.minecraftnew.subsystems.corpses;
+
+import goat.minecraft.minecraftnew.subsystems.combat.config.CombatConfiguration;
+import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.api.trait.Trait;
+import net.citizensnpcs.api.util.DataKey;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Arrow;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.util.Vector;
+
+import java.util.UUID;
+
+public class CorpseTrait extends Trait {
+    private final JavaPlugin plugin;
+    private final Corpse corpse;
+    private int taskId = -1;
+
+    private static final double MELEE_RANGE = 2.5;
+    private static final double BOW_RANGE = 16.0;
+    private static final double BASE_DAMAGE = 5.0;
+
+    public CorpseTrait(JavaPlugin plugin, Corpse corpse) {
+        super("corpse_trait");
+        this.plugin = plugin;
+        this.corpse = corpse;
+    }
+
+    @Override
+    public void onAttach() {
+        npc.setProtected(false);
+        start();
+    }
+
+    private void start() {
+        taskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, () -> {
+            if (!npc.isSpawned()) {
+                Bukkit.getScheduler().cancelTask(taskId);
+                return;
+            }
+            Player nearest = getNearestPlayer();
+            if (nearest == null) return;
+
+            npc.getNavigator().setTarget(nearest, true);
+            Entity entity = npc.getEntity();
+            double damage = BASE_DAMAGE * (1 + corpse.getLevel() * CombatConfiguration.getInstance().getDamageConfig().getMonsterPerLevel());
+            double distSq = entity.getLocation().distanceSquared(nearest.getLocation());
+
+            if (corpse.usesBow()) {
+                if (distSq <= BOW_RANGE * BOW_RANGE) {
+                    Arrow arrow = ((Player) entity).launchProjectile(Arrow.class);
+                    Vector dir = nearest.getLocation().add(0,1.5,0).toVector().subtract(entity.getLocation().add(0,1.5,0).toVector()).normalize();
+                    arrow.setVelocity(dir.multiply(1.6));
+                    arrow.setDamage(damage);
+                    arrow.setShooter((Player) entity);
+                }
+            } else {
+                if (distSq <= MELEE_RANGE * MELEE_RANGE) {
+                    nearest.damage(damage, entity);
+                }
+            }
+        }, 0L, 20L);
+    }
+
+    private Player getNearestPlayer() {
+        double nearest = Double.MAX_VALUE;
+        Player result = null;
+        for (Player p : Bukkit.getOnlinePlayers()) {
+            double d = npc.getEntity().getLocation().distanceSquared(p.getLocation());
+            if (d < nearest) {
+                nearest = d;
+                result = p;
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void onRemove() {
+        if (taskId != -1) {
+            Bukkit.getScheduler().cancelTask(taskId);
+        }
+    }
+
+    @Override
+    public void load(DataKey key) {}
+
+    @Override
+    public void save(DataKey key) {}
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/SpawnCorpseCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/SpawnCorpseCommand.java
@@ -1,0 +1,62 @@
+package goat.minecraft.minecraftnew.subsystems.corpses;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.combat.SpawnMonsters;
+import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import net.citizensnpcs.api.CitizensAPI;
+import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.api.npc.NPCRegistry;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.metadata.FixedMetadataValue;
+
+import java.util.Optional;
+
+public class SpawnCorpseCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command!");
+            return true;
+        }
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You do not have permission to use this command!");
+            return true;
+        }
+        if (args.length != 1) {
+            player.sendMessage(ChatColor.RED + "Usage: /spawncorpse <name>");
+            return true;
+        }
+        String corpseName = args[0].replace("_", " ");
+        Optional<Corpse> optionalCorpse = CorpseRegistry.getCorpseByName(corpseName);
+        if (optionalCorpse.isEmpty()) {
+            player.sendMessage(ChatColor.RED + "Corpse with name '" + corpseName + "' not found!");
+            return true;
+        }
+        Corpse corpse = optionalCorpse.get();
+        NPCRegistry registry = CitizensAPI.getNPCRegistry();
+        NPC npc = registry.createNPC(org.bukkit.entity.EntityType.PLAYER, corpse.getName());
+        npc.spawn(player.getLocation());
+        npc.setProtected(false);
+        npc.setName(ChatColor.GRAY + "[Lvl " + corpse.getLevel() + "] " + corpse.getName());
+        npc.data().setPersistent(false);
+        npc.addTrait(new CorpseTrait(MinecraftNew.getInstance(), corpse));
+
+        EntityEquipment eq = ((Player) npc.getEntity()).getEquipment();
+        if (eq != null && corpse.getWeapon() != Material.AIR) {
+            eq.setItemInMainHand(new ItemStack(corpse.getWeapon()));
+        }
+
+        npc.getEntity().setMetadata("CORPSE", new FixedMetadataValue(MinecraftNew.getInstance(), corpse.getName()));
+
+        SpawnMonsters.getInstance(new XPManager(MinecraftNew.getInstance())).applyMobAttributes((Player) npc.getEntity(), corpse.getLevel());
+        player.sendMessage(ChatColor.GREEN + "Spawned " + corpse.getName());
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -90,6 +90,9 @@ commands:
   spawnseacreature:
     description: Spawns a sea creature by name.
     permission: continuity.admin
+  spawncorpse:
+    description: Spawns a corpse by name.
+    permission: continuity.admin
   givecustomitem:
     description: Gives a predefined custom item to the player.
     usage: /givecustomitem <customitem>


### PR DESCRIPTION
## Summary
- implement corpse NPCs with registry and spawn command
- add CorpseTrait to attack players
- integrate spawn command in main plugin and plugin.yml

## Testing
- `javac` *(fails: package org.bukkit does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_686f87f47cc08332ae406e316f657728