### PR TITLE
Add corpse NPC spawning system

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -30,6 +30,7 @@ import goat.minecraft.minecraftnew.subsystems.farming.FarmingEvent;
 import goat.minecraft.minecraftnew.subsystems.fishing.FishingEvent;
 import goat.minecraft.minecraftnew.subsystems.fishing.SeaCreatureRegistry;
 import goat.minecraft.minecraftnew.subsystems.fishing.SpawnSeaCreatureCommand;
+import goat.minecraft.minecraftnew.subsystems.corpses.SpawnCorpseCommand;
 import goat.minecraft.minecraftnew.subsystems.fishing.SeaCreatureChanceCommand;
 import goat.minecraft.minecraftnew.subsystems.fishing.TreasureChanceCommand;
 import goat.minecraft.minecraftnew.subsystems.forestry.ForestSpiritManager;
@@ -390,6 +391,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
             getDataFolder().mkdirs();
         }
         this.getCommand("spawnseacreature").setExecutor(new SpawnSeaCreatureCommand());
+        this.getCommand("spawncorpse").setExecutor(new SpawnCorpseCommand());
         getCommand("seacreaturechance").setExecutor(new SeaCreatureChanceCommand(this, xpManager));
         getCommand("treasurechance").setExecutor(new TreasureChanceCommand(this));
         getCommand("spiritchance").setExecutor(new SpiritChanceCommand(this, xpManager));

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/Corpse.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/Corpse.java
@@ -1,0 +1,75 @@
+package goat.minecraft.minecraftnew.subsystems.corpses;
+
+import goat.minecraft.minecraftnew.subsystems.fishing.Rarity;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+public class Corpse {
+    private final String name;
+    private final Rarity rarity;
+    private final int level;
+    private final ItemStack weapon;
+    private final boolean ranged;
+    private final String skinUrl;
+    private final List<DropItem> dropItems;
+    private final Random random = new Random();
+
+    public Corpse(String name, Rarity rarity, int level, Material weaponType, boolean ranged, String skinUrl, List<DropItem> drops) {
+        this.name = name;
+        this.rarity = rarity;
+        this.level = level;
+        this.weapon = weaponType == null ? null : new ItemStack(weaponType);
+        this.ranged = ranged;
+        this.skinUrl = skinUrl;
+        this.dropItems = drops;
+    }
+
+    public String getName() { return name; }
+    public Rarity getRarity() { return rarity; }
+    public int getLevel() { return level; }
+    public ItemStack getWeapon() { return weapon == null ? null : weapon.clone(); }
+    public boolean isRanged() { return ranged; }
+    public String getSkinUrl() { return skinUrl; }
+
+    public List<ItemStack> getDrops() {
+        List<ItemStack> drops = new ArrayList<>();
+        if (dropItems == null) return drops;
+        for (DropItem drop : dropItems) {
+            int qty = 0;
+            for (int i = 0; i < drop.getRollCount(); i++) {
+                if (random.nextInt(drop.getRollDenominator()) < drop.getRollNumerator()) {
+                    qty++;
+                }
+            }
+            if (qty > 0) {
+                ItemStack item = drop.getItemStack().clone();
+                item.setAmount(qty);
+                drops.add(item);
+            }
+        }
+        return drops;
+    }
+
+    public static class DropItem {
+        private final ItemStack itemStack;
+        private final int rollCount;
+        private final int rollNumerator;
+        private final int rollDenominator;
+
+        public DropItem(ItemStack itemStack, int rollCount, int rollNumerator, int rollDenominator) {
+            this.itemStack = itemStack;
+            this.rollCount = rollCount;
+            this.rollNumerator = rollNumerator;
+            this.rollDenominator = rollDenominator;
+        }
+
+        public ItemStack getItemStack() { return itemStack; }
+        public int getRollCount() { return rollCount; }
+        public int getRollNumerator() { return rollNumerator; }
+        public int getRollDenominator() { return rollDenominator; }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseRegistry.java
@@ -1,0 +1,73 @@
+package goat.minecraft.minecraftnew.subsystems.corpses;
+
+import goat.minecraft.minecraftnew.subsystems.fishing.Rarity;
+import org.bukkit.Material;
+
+import java.util.*;
+
+public class CorpseRegistry {
+    private static final List<Corpse> CORPSES = new ArrayList<>();
+    private static final Map<Rarity, Double> RARITY_WEIGHTS = new LinkedHashMap<>();
+    private static final Random RANDOM = new Random();
+
+    static {
+        RARITY_WEIGHTS.put(Rarity.COMMON, 0.50);
+        RARITY_WEIGHTS.put(Rarity.UNCOMMON, 0.30);
+        RARITY_WEIGHTS.put(Rarity.RARE, 0.12);
+        RARITY_WEIGHTS.put(Rarity.EPIC, 0.06);
+        RARITY_WEIGHTS.put(Rarity.LEGENDARY, 0.02);
+
+        // Common corpses
+        CORPSES.add(new Corpse("Farmer Corpse", Rarity.COMMON, 30, Material.IRON_HOE, false, "", Collections.emptyList()));
+        CORPSES.add(new Corpse("Guard Corpse", Rarity.COMMON, 35, Material.IRON_SWORD, false, "", Collections.emptyList()));
+        CORPSES.add(new Corpse("Archer Corpse", Rarity.COMMON, 40, Material.BOW, true, "", Collections.emptyList()));
+
+        // Uncommon corpses
+        CORPSES.add(new Corpse("Diver Corpse", Rarity.UNCOMMON, 50, Material.TRIDENT, false, "", Collections.emptyList()));
+        CORPSES.add(new Corpse("Fisherman Corpse", Rarity.UNCOMMON, 55, Material.FISHING_ROD, true, "", Collections.emptyList()));
+        CORPSES.add(new Corpse("Lumberjack Corpse", Rarity.UNCOMMON, 60, Material.IRON_AXE, false, "", Collections.emptyList()));
+
+        // Rare corpses
+        CORPSES.add(new Corpse("Adventurer Corpse", Rarity.RARE, 70, Material.MAP, false, "", Collections.emptyList()));
+        CORPSES.add(new Corpse("Pirate Corpse", Rarity.RARE, 75, Material.IRON_SWORD, false, "", Collections.emptyList()));
+        CORPSES.add(new Corpse("Sculk Infected", Rarity.RARE, 80, Material.STONE, false, "", Collections.emptyList()));
+
+        // Epic corpses
+        CORPSES.add(new Corpse("Necromancer Corpse", Rarity.EPIC, 90, Material.SKELETON_SKULL, false, "", Collections.emptyList()));
+        CORPSES.add(new Corpse("Gladiator Corpse", Rarity.EPIC, 100, Material.DIAMOND_SWORD, false, "", Collections.emptyList()));
+        CORPSES.add(new Corpse("Duskblood", Rarity.EPIC, 110, Material.AIR, false, "", Collections.emptyList()));
+
+        // Legendary corpses
+        CORPSES.add(new Corpse("Trauma", Rarity.LEGENDARY, 120, Material.DIAMOND_AXE, false, "", Collections.emptyList()));
+        CORPSES.add(new Corpse("Cryptic", Rarity.LEGENDARY, 140, Material.BOW, true, "", Collections.emptyList()));
+        CORPSES.add(new Corpse("Dreadnaught", Rarity.LEGENDARY, 150, Material.NETHERITE_SWORD, false, "", Collections.emptyList()));
+    }
+
+    public static Optional<Corpse> getCorpseByName(String name) {
+        return CORPSES.stream().filter(c -> c.getName().equalsIgnoreCase(name)).findFirst();
+    }
+
+    public static Optional<Corpse> getRandomCorpse() {
+        if (CORPSES.isEmpty()) return Optional.empty();
+
+        double rand = RANDOM.nextDouble();
+        double cumulative = 0.0;
+        Rarity selected = Rarity.COMMON;
+        for (Map.Entry<Rarity, Double> e : RARITY_WEIGHTS.entrySet()) {
+            cumulative += e.getValue();
+            if (rand <= cumulative) {
+                selected = e.getKey();
+                break;
+            }
+        }
+
+        List<Corpse> filtered = new ArrayList<>();
+        for (Corpse c : CORPSES) {
+            if (c.getRarity() == selected) {
+                filtered.add(c);
+            }
+        }
+        if (filtered.isEmpty()) return Optional.of(CORPSES.get(RANDOM.nextInt(CORPSES.size())));
+        return Optional.of(filtered.get(RANDOM.nextInt(filtered.size())));
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseTrait.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseTrait.java
@@ -1,0 +1,87 @@
+package goat.minecraft.minecraftnew.subsystems.corpses;
+
+import net.citizensnpcs.api.trait.Trait;
+import net.citizensnpcs.api.util.DataKey;
+import net.citizensnpcs.api.npc.NPC;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Arrow;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.UUID;
+
+public class CorpseTrait extends Trait {
+    private final JavaPlugin plugin;
+    private final Corpse corpse;
+    private int taskId = -1;
+    private long lastShot = 0L;
+
+    public CorpseTrait(JavaPlugin plugin, Corpse corpse) {
+        super("corpse_trait");
+        this.plugin = plugin;
+        this.corpse = corpse;
+    }
+
+    @Override
+    public void onAttach() {
+        npc.setProtected(false);
+        start();
+    }
+
+    private Player findNearestPlayer(Location loc) {
+        Player nearest = null;
+        double dist = Double.MAX_VALUE;
+        for (Player p : Bukkit.getOnlinePlayers()) {
+            double d = p.getLocation().distanceSquared(loc);
+            if (d < dist) {
+                dist = d;
+                nearest = p;
+            }
+        }
+        return nearest;
+    }
+
+    private double getDamage() {
+        double base = 2.0;
+        double perLevel = 0.06;
+        return base * (1.0 + corpse.getLevel() * perLevel);
+    }
+
+    private void start() {
+        taskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, () -> {
+            if (!npc.isSpawned()) return;
+            Player target = findNearestPlayer(npc.getEntity().getLocation());
+            if (target == null) return;
+
+            npc.getNavigator().setTarget(target, true);
+            Entity ent = npc.getEntity();
+            if (!(ent instanceof LivingEntity living)) return;
+
+            if (corpse.isRanged()) {
+                if (System.currentTimeMillis() - lastShot > 2000) {
+                    Arrow arrow = living.launchProjectile(Arrow.class);
+                    arrow.setDamage(getDamage());
+                    lastShot = System.currentTimeMillis();
+                }
+            } else {
+                if (ent.getLocation().distanceSquared(target.getLocation()) <= 2.5 * 2.5) {
+                    target.damage(getDamage(), ent);
+                }
+            }
+        }, 0L, 20L);
+    }
+
+    @Override
+    public void onRemove() {
+        if (taskId != -1) Bukkit.getScheduler().cancelTask(taskId);
+    }
+
+    @Override
+    public void load(DataKey key) {}
+
+    @Override
+    public void save(DataKey key) {}
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/SpawnCorpseCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/SpawnCorpseCommand.java
@@ -1,0 +1,69 @@
+package goat.minecraft.minecraftnew.subsystems.corpses;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import net.citizensnpcs.api.CitizensAPI;
+import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.api.npc.NPCRegistry;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.metadata.FixedMetadataValue;
+
+import java.util.Optional;
+
+public class SpawnCorpseCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command!");
+            return true;
+        }
+        Player player = (Player) sender;
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You do not have permission to use this command!");
+            return true;
+        }
+
+        Corpse corpse;
+        if (args.length == 0 || args[0].equalsIgnoreCase("random")) {
+            Optional<Corpse> opt = CorpseRegistry.getRandomCorpse();
+            if (!opt.isPresent()) {
+                player.sendMessage(ChatColor.RED + "No corpse found.");
+                return true;
+            }
+            corpse = opt.get();
+        } else {
+            String name = args[0].replace("_", " ");
+            Optional<Corpse> opt = CorpseRegistry.getCorpseByName(name);
+            if (!opt.isPresent()) {
+                player.sendMessage(ChatColor.RED + "Corpse with name '" + name + "' not found!");
+                return true;
+            }
+            corpse = opt.get();
+        }
+
+        NPCRegistry registry = CitizensAPI.getNPCRegistry();
+        NPC npc = registry.createNPC(EntityType.PLAYER, corpse.getName());
+        npc.spawn(player.getLocation());
+        npc.addTrait(new CorpseTrait(MinecraftNew.getInstance(), corpse));
+
+        if (npc.getEntity() instanceof org.bukkit.entity.LivingEntity living) {
+            EntityEquipment eq = living.getEquipment();
+            if (eq != null && corpse.getWeapon() != null) {
+                eq.setItemInMainHand(corpse.getWeapon());
+                eq.setItemInMainHandDropChance(0);
+            }
+            living.setCustomName(ChatColor.RED + corpse.getName());
+            living.setCustomNameVisible(true);
+            living.setMetadata("CORPSE", new FixedMetadataValue(MinecraftNew.getInstance(), corpse.getName()));
+            living.setMetadata("CORPSE_LEVEL", new FixedMetadataValue(MinecraftNew.getInstance(), corpse.getLevel()));
+        }
+
+        player.sendMessage(ChatColor.GREEN + "Spawned corpse: " + corpse.getName());
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -90,6 +90,9 @@ commands:
   spawnseacreature:
     description: Spawns a sea creature by name.
     permission: continuity.admin
+  spawncorpse:
+    description: Spawns a corpse by name.
+    permission: continuity.admin
   givecustomitem:
     description: Gives a predefined custom item to the player.
     usage: /givecustomitem <customitem>


### PR DESCRIPTION
## Summary
- implement `Corpse` data class and registry of different corpse types
- provide trait for hostile Citizens NPC behaviour
- add `/spawncorpse` command and wire it in main plugin and plugin.yml

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f87f47cc08332ae406e316f657728