### PR TITLE
Add Corpse NPC system

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -390,6 +390,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
             getDataFolder().mkdirs();
         }
         this.getCommand("spawnseacreature").setExecutor(new SpawnSeaCreatureCommand());
+        this.getCommand("spawncorpse").setExecutor(new goat.minecraft.minecraftnew.subsystems.corpses.SpawnCorpseCommand(this));
         getCommand("seacreaturechance").setExecutor(new SeaCreatureChanceCommand(this, xpManager));
         getCommand("treasurechance").setExecutor(new TreasureChanceCommand(this));
         getCommand("spiritchance").setExecutor(new SpiritChanceCommand(this, xpManager));
@@ -557,6 +558,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
 
         getServer().getPluginManager().registerEvents(new FarmingEvent(), MinecraftNew.getInstance());
         getServer().getPluginManager().registerEvents(new SeaCreatureDeathEvent(), MinecraftNew.getInstance());
+        getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.corpses.CorpseDeathEvent(), this);
         //getServer().getPluginManager().registerEvents(new CancelBrewing(MinecraftNew.getInstance()), MinecraftNew.getInstance());
         getServer().getPluginManager().registerEvents(new RightClickArtifacts(this), this);
         getServer().getPluginManager().registerEvents(new BlessingArtifactGUI(this), this);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/Corpse.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/Corpse.java
@@ -1,0 +1,82 @@
+package goat.minecraft.minecraftnew.subsystems.corpses;
+
+import goat.minecraft.minecraftnew.subsystems.fishing.Rarity;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Represents a hostile Corpse NPC definition.
+ */
+public class Corpse {
+    private final String displayName;
+    private final Rarity rarity;
+    private final int level;
+    private final Material weaponMaterial;
+    private final String skinUrl;
+    private final boolean usesBow;
+    private final List<DropItem> dropItems;
+
+    private final Random random = new Random();
+
+    public Corpse(String displayName, Rarity rarity, int level,
+                  Material weaponMaterial, String skinUrl,
+                  boolean usesBow, List<DropItem> dropItems) {
+        this.displayName = displayName;
+        this.rarity = rarity;
+        this.level = level;
+        this.weaponMaterial = weaponMaterial;
+        this.skinUrl = skinUrl;
+        this.usesBow = usesBow;
+        this.dropItems = dropItems;
+    }
+
+    public String getDisplayName() { return displayName; }
+    public Rarity getRarity() { return rarity; }
+    public int getLevel() { return level; }
+    public Material getWeaponMaterial() { return weaponMaterial; }
+    public String getSkinUrl() { return skinUrl; }
+    public boolean usesBow() { return usesBow; }
+
+    public List<ItemStack> getDrops() {
+        List<ItemStack> drops = new ArrayList<>();
+        if (dropItems == null) return drops;
+        for (DropItem drop : dropItems) {
+            int qty = 0;
+            for (int i = 0; i < drop.getRollCount(); i++) {
+                if (random.nextInt(drop.getRollDenominator()) < drop.getRollNumerator()) {
+                    qty++;
+                }
+            }
+            if (qty > 0) {
+                ItemStack item = drop.getItemStack().clone();
+                item.setAmount(qty);
+                drops.add(item);
+            }
+        }
+        return drops;
+    }
+
+    /** Represents an item drop with roll chance information. */
+    public static class DropItem {
+        private final ItemStack itemStack;
+        private final int rollCount;
+        private final int rollNumerator;
+        private final int rollDenominator;
+
+        public DropItem(ItemStack itemStack, int rollCount, int rollNumerator, int rollDenominator) {
+            this.itemStack = itemStack;
+            this.rollCount = rollCount;
+            this.rollNumerator = rollNumerator;
+            this.rollDenominator = rollDenominator;
+        }
+
+        public ItemStack getItemStack() { return itemStack; }
+        public int getRollCount() { return rollCount; }
+        public int getRollNumerator() { return rollNumerator; }
+        public int getRollDenominator() { return rollDenominator; }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseDeathEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseDeathEvent.java
@@ -1,0 +1,39 @@
+package goat.minecraft.minecraftnew.subsystems.corpses;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.metadata.MetadataValue;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Handles drops and cleanup when a Corpse NPC dies.
+ */
+public class CorpseDeathEvent implements Listener {
+    @EventHandler
+    public void onCorpseDeath(EntityDeathEvent event) {
+        Entity entity = event.getEntity();
+        List<MetadataValue> data = entity.getMetadata("CORPSE");
+        if (data == null || data.isEmpty()) {
+            return;
+        }
+        if (entity instanceof LivingEntity) {
+            EntityEquipment eq = ((LivingEntity) entity).getEquipment();
+            if (eq != null) {
+                eq.setItemInMainHandDropChance(0);
+            }
+        }
+        String name = data.get(0).asString();
+        Optional<Corpse> opt = CorpseRegistry.getCorpseByName(name);
+        if (!opt.isPresent()) return;
+
+        event.getDrops().clear();
+        // Future drop logic using opt.get().getDrops()
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseRegistry.java
@@ -1,0 +1,95 @@
+package goat.minecraft.minecraftnew.subsystems.corpses;
+
+import goat.minecraft.minecraftnew.subsystems.fishing.Rarity;
+import org.bukkit.Material;
+import org.bukkit.event.Listener;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Registry for all Corpse definitions and weighted random selection.
+ */
+public class CorpseRegistry implements Listener {
+    private static final List<Corpse> CORPSES = new ArrayList<>();
+    private static final Map<Rarity, Double> RARITY_WEIGHTS = new LinkedHashMap<>();
+    private static final Random RANDOM = new Random();
+
+    static {
+        RARITY_WEIGHTS.put(Rarity.COMMON, 0.50);
+        RARITY_WEIGHTS.put(Rarity.UNCOMMON, 0.30);
+        RARITY_WEIGHTS.put(Rarity.RARE, 0.12);
+        RARITY_WEIGHTS.put(Rarity.EPIC, 0.06);
+        RARITY_WEIGHTS.put(Rarity.LEGENDARY, 0.02);
+
+        // COMMON
+        CORPSES.add(new Corpse("Farmer Corpse", Rarity.COMMON, 30,
+                Material.IRON_HOE, "", false, new ArrayList<>()));
+        CORPSES.add(new Corpse("Guard Corpse", Rarity.COMMON, 35,
+                Material.IRON_SWORD, "", false, new ArrayList<>()));
+        CORPSES.add(new Corpse("Archer Corpse", Rarity.COMMON, 40,
+                Material.BOW, "", true, new ArrayList<>()));
+
+        // UNCOMMON
+        CORPSES.add(new Corpse("Diver Corpse", Rarity.UNCOMMON, 50,
+                Material.AIR, "", false, new ArrayList<>()));
+        CORPSES.add(new Corpse("Fisherman Corpse", Rarity.UNCOMMON, 55,
+                Material.FISHING_ROD, "", false, new ArrayList<>()));
+        CORPSES.add(new Corpse("Lumberjack Corpse", Rarity.UNCOMMON, 60,
+                Material.IRON_AXE, "", false, new ArrayList<>()));
+
+        // RARE
+        CORPSES.add(new Corpse("Adventurer Corpse", Rarity.RARE, 70,
+                Material.MAP, "", false, new ArrayList<>()));
+        CORPSES.add(new Corpse("Pirates Corpse", Rarity.RARE, 75,
+                Material.IRON_SWORD, "", false, new ArrayList<>()));
+        CORPSES.add(new Corpse("Sculk Infected", Rarity.RARE, 80,
+                Material.AIR, "", false, new ArrayList<>()));
+
+        // EPIC
+        CORPSES.add(new Corpse("Necromancer Corpse", Rarity.EPIC, 90,
+                Material.SKELETON_SKULL, "", false, new ArrayList<>()));
+        CORPSES.add(new Corpse("Gladiator Corpse", Rarity.EPIC, 100,
+                Material.DIAMOND_SWORD, "", false, new ArrayList<>()));
+        CORPSES.add(new Corpse("Duskblood", Rarity.EPIC, 110,
+                Material.AIR, "", false, new ArrayList<>()));
+
+        // LEGENDARY
+        CORPSES.add(new Corpse("Trauma", Rarity.LEGENDARY, 120,
+                Material.DIAMOND_AXE, "", false, new ArrayList<>()));
+        CORPSES.add(new Corpse("Cryptic", Rarity.LEGENDARY, 140,
+                Material.BOW, "", true, new ArrayList<>()));
+        CORPSES.add(new Corpse("Dreadnaught", Rarity.LEGENDARY, 150,
+                Material.NETHERITE_SWORD, "", false, new ArrayList<>()));
+    }
+
+    public static Optional<Corpse> getCorpseByName(String name) {
+        return CORPSES.stream()
+                .filter(c -> c.getDisplayName().equalsIgnoreCase(name))
+                .findFirst();
+    }
+
+    public static Optional<Corpse> getRandomCorpse() {
+        if (CORPSES.isEmpty()) return Optional.empty();
+
+        double rand = RANDOM.nextDouble();
+        double cumulative = 0.0;
+        Rarity selected = Rarity.COMMON;
+        for (Map.Entry<Rarity, Double> entry : RARITY_WEIGHTS.entrySet()) {
+            cumulative += entry.getValue();
+            if (rand <= cumulative) {
+                selected = entry.getKey();
+                break;
+            }
+        }
+        List<Corpse> filtered = CORPSES.stream()
+                .filter(c -> c.getRarity() == selected)
+                .collect(Collectors.toList());
+        if (filtered.isEmpty()) return Optional.empty();
+        return Optional.of(filtered.get(RANDOM.nextInt(filtered.size())));
+    }
+
+    public static List<Corpse> getCorpses() {
+        return Collections.unmodifiableList(CORPSES);
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseTrait.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseTrait.java
@@ -1,0 +1,109 @@
+package goat.minecraft.minecraftnew.subsystems.corpses;
+
+import net.citizensnpcs.api.trait.Trait;
+import net.citizensnpcs.api.util.DataKey;
+import net.citizensnpcs.api.npc.NPC;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.entity.Arrow;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.util.Vector;
+
+/**
+ * Trait giving a Corpse hostile behaviour and stats.
+ */
+public class CorpseTrait extends Trait {
+    private final JavaPlugin plugin;
+    private final int level;
+    private final boolean ranged;
+    private final int teleportInterval;
+    private int taskId = -1;
+    private int tickCounter = 0;
+
+    private static final double BASE_DAMAGE = 2.0;
+
+    public CorpseTrait(JavaPlugin plugin, int level, boolean ranged, int teleportInterval) {
+        super("corpse_trait");
+        this.plugin = plugin;
+        this.level = level;
+        this.ranged = ranged;
+        this.teleportInterval = teleportInterval;
+    }
+
+    @Override
+    public void onAttach() {
+        npc.setProtected(false);
+        applyAttributes(npc);
+        start();
+    }
+
+    private void applyAttributes(NPC npc) {
+        if (!(npc.getEntity() instanceof LivingEntity entity)) return;
+        double healthMultiplier = level <= 10 ? 0.1 + 0.1 * (level - 1) : 1 + ((level - 10) * 0.1);
+        double armorValue = Math.min(healthMultiplier * 20, 100);
+        if (entity.getAttribute(Attribute.GENERIC_ARMOR) != null) {
+            entity.getAttribute(Attribute.GENERIC_ARMOR).setBaseValue(armorValue);
+        }
+        entity.setHealth(entity.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue());
+        entity.setCustomNameVisible(true);
+        entity.setMetadata("mobLevel", new org.bukkit.metadata.FixedMetadataValue(plugin, level));
+    }
+
+    private void start() {
+        taskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, () -> {
+            if (!npc.isSpawned()) return;
+            LivingEntity self = (LivingEntity) npc.getEntity();
+            Player target = getNearestPlayer(self.getLocation());
+            if (target == null) return;
+            npc.getNavigator().setTarget(target, true);
+
+            tickCounter += 20;
+            if (teleportInterval > 0 && tickCounter >= teleportInterval) {
+                tickCounter = 0;
+                self.teleport(target.getLocation());
+            }
+
+            double damageMultiplier = 1.0 + level * 0.06;
+            double damage = BASE_DAMAGE * damageMultiplier;
+
+            if (ranged) {
+                if (self.getLocation().distanceSquared(target.getLocation()) <= 20 * 20) {
+                    Arrow arrow = self.launchProjectile(Arrow.class);
+                    Vector vel = target.getLocation().toVector().subtract(self.getLocation().toVector()).normalize().multiply(1.2);
+                    arrow.setVelocity(vel);
+                    arrow.setDamage(damage);
+                }
+            } else {
+                if (self.getLocation().distanceSquared(target.getLocation()) <= 3 * 3) {
+                    target.damage(damage, self);
+                }
+            }
+        }, 20L, 20L);
+    }
+
+    private Player getNearestPlayer(Location loc) {
+        double best = Double.MAX_VALUE;
+        Player closest = null;
+        for (Player p : Bukkit.getOnlinePlayers()) {
+            double d = p.getLocation().distanceSquared(loc);
+            if (d < best) {
+                best = d;
+                closest = p;
+            }
+        }
+        return closest;
+    }
+
+    @Override
+    public void onRemove() {
+        if (taskId != -1) {
+            Bukkit.getScheduler().cancelTask(taskId);
+        }
+    }
+
+    @Override public void load(DataKey key) {}
+    @Override public void save(DataKey key) {}
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/SpawnCorpseCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/SpawnCorpseCommand.java
@@ -1,0 +1,71 @@
+package goat.minecraft.minecraftnew.subsystems.corpses;
+
+import net.citizensnpcs.api.CitizensAPI;
+import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.api.npc.NPCRegistry;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.Optional;
+
+/**
+ * Developer command to spawn a Corpse NPC by name.
+ */
+public class SpawnCorpseCommand implements CommandExecutor {
+    private final JavaPlugin plugin;
+
+    public SpawnCorpseCommand(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players may use this command.");
+            return true;
+        }
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You do not have permission to use this command!");
+            return true;
+        }
+        if (args.length != 1) {
+            player.sendMessage(ChatColor.RED + "Usage: /spawncorpse <name>");
+            return true;
+        }
+        String name = args[0].replace("_", " ");
+        Optional<Corpse> optional = CorpseRegistry.getCorpseByName(name);
+        if (!optional.isPresent()) {
+            player.sendMessage(ChatColor.RED + "Corpse " + name + " not found.");
+            return true;
+        }
+        spawnCorpse(optional.get(), player);
+        return true;
+    }
+
+    private void spawnCorpse(Corpse corpse, Player player) {
+        NPCRegistry registry = CitizensAPI.getNPCRegistry();
+        NPC npc = registry.createNPC(EntityType.PLAYER, corpse.getDisplayName());
+        npc.spawn(player.getLocation());
+
+        if (npc.getEntity() instanceof org.bukkit.entity.LivingEntity le) {
+            EntityEquipment eq = le.getEquipment();
+            if (eq != null && corpse.getWeaponMaterial() != null && corpse.getWeaponMaterial() != org.bukkit.Material.AIR) {
+                eq.setItemInMainHand(new ItemStack(corpse.getWeaponMaterial()));
+            }
+        }
+        npc.data().setPersistent(NPC.DEFAULT_PROTECTED_METADATA, false);
+        npc.addTrait(new CorpseTrait(plugin, corpse.getLevel(), corpse.usesBow(),
+                corpse.getDisplayName().equalsIgnoreCase("Duskblood") ? 100 : 0));
+        npc.getEntity().setCustomName(ChatColor.GRAY + "[Lv: " + corpse.getLevel() + "] " + corpse.getDisplayName());
+        npc.getEntity().setCustomNameVisible(true);
+        npc.getEntity().setMetadata("CORPSE", new FixedMetadataValue(plugin, corpse.getDisplayName()));
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -90,6 +90,9 @@ commands:
   spawnseacreature:
     description: Spawns a sea creature by name.
     permission: continuity.admin
+  spawncorpse:
+    description: Spawns a corpse by name.
+    permission: continuity.admin
   givecustomitem:
     description: Gives a predefined custom item to the player.
     usage: /givecustomitem <customitem>


### PR DESCRIPTION
## Summary
- add Corpses subsystem with registry, trait and spawn command
- register spawncorpse dev command and death listener
- add placeholder entries for each corpse type

## Testing
- `mvn --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f87f47cc08332ae406e316f657728