### PR TITLE
Fix corpses and improve gravedigging

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -789,6 +789,17 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         if (doubleEnderchest != null) {
             doubleEnderchest.saveAllInventories();
         }
+        // Remove any remaining Corpse NPCs to prevent persistence on reload
+        try {
+            net.citizensnpcs.api.npc.NPCRegistry registry = net.citizensnpcs.api.CitizensAPI.getNPCRegistry();
+            for (net.citizensnpcs.api.npc.NPC npc : registry) {
+                if (npc.isSpawned() && npc.getEntity().hasMetadata("CORPSE")) {
+                    npc.destroy();
+                }
+            }
+        } catch (Exception e) {
+            getLogger().warning("Failed to remove corpses on shutdown: " + e.getMessage());
+        }
         System.out.println("[MinecraftNew] Plugin disabled.");//
     }
     public static MinecraftNew getInstance() {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseTrait.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseTrait.java
@@ -47,7 +47,11 @@ public class CorpseTrait extends Trait {
         if (entity.getAttribute(Attribute.GENERIC_ARMOR) != null) {
             entity.getAttribute(Attribute.GENERIC_ARMOR).setBaseValue(armorValue);
         }
-        entity.setHealth(entity.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue());
+        if (entity.getAttribute(Attribute.GENERIC_MAX_HEALTH) != null) {
+            double baseHealth = entity.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue();
+            entity.getAttribute(Attribute.GENERIC_MAX_HEALTH).setBaseValue(baseHealth * healthMultiplier);
+            entity.setHealth(entity.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue());
+        }
         entity.setCustomNameVisible(true);
         entity.setMetadata("mobLevel", new org.bukkit.metadata.FixedMetadataValue(plugin, level));
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/SpawnCorpseCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/SpawnCorpseCommand.java
@@ -54,6 +54,7 @@ public class SpawnCorpseCommand implements CommandExecutor {
         NPCRegistry registry = CitizensAPI.getNPCRegistry();
         NPC npc = registry.createNPC(EntityType.PLAYER, corpse.getDisplayName());
         npc.spawn(player.getLocation());
+        npc.setPersistent(false); // ensure corpses are not saved between restarts
 
         if (npc.getEntity() instanceof org.bukkit.entity.LivingEntity le) {
             EntityEquipment eq = le.getEquipment();

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
@@ -85,6 +85,22 @@ public class Gravedigging implements Listener {
         triggerEvent(player, stand.getLocation());
     }
 
+    // Sneaking digs up any graves nearby to improve reliability
+    @EventHandler
+    public void onPlayerSneak(org.bukkit.event.player.PlayerToggleSneakEvent event) {
+        if (!event.isSneaking()) return;
+        Player player = event.getPlayer();
+        Location ploc = player.getLocation();
+        World world = ploc.getWorld();
+        if (world == null) return;
+        for (org.bukkit.entity.Entity entity : world.getNearbyEntities(ploc, 4, 4, 4)) {
+            if (entity instanceof ArmorStand stand && stand.hasMetadata("grave")) {
+                stand.remove();
+                triggerEvent(player, stand.getLocation());
+            }
+        }
+    }
+
     private void triggerEvent(Player player, Location loc) {
         double roll = random.nextDouble();
         if (roll < 0.5) {


### PR DESCRIPTION
## Summary
- ensure spawned corpses are not persisted
- scale corpse max health with their level
- clean up all corpse NPCs on shutdown
- allow sneaking to dig nearby graves

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870996c07ac8332a46124f8c83a6a79