### PR TITLE
Fix corpse scaling and grave digging

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -92,6 +92,10 @@ import org.bukkit.*;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
+import net.citizensnpcs.api.CitizensAPI;
+import net.citizensnpcs.api.npc.NPC;
+
+import goat.minecraft.minecraftnew.subsystems.corpses.CorpseTrait;
 
 import java.util.Objects;
 
@@ -789,6 +793,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         if (doubleEnderchest != null) {
             doubleEnderchest.saveAllInventories();
         }
+        removeAllCorpseNPCs();
         System.out.println("[MinecraftNew] Plugin disabled.");//
     }
     public static MinecraftNew getInstance() {
@@ -800,4 +805,14 @@ public class MinecraftNew extends JavaPlugin implements Listener {
     }
     public ForestryPetManager getForestryManager() {
         return forestryPetManager;
-    }}
+    }
+
+    private void removeAllCorpseNPCs() {
+        for (NPC npc : CitizensAPI.getNPCRegistry()) {
+            if (npc.hasTrait(CorpseTrait.class) ||
+                    (npc.getEntity() != null && npc.getEntity().hasMetadata("CORPSE"))) {
+                npc.destroy();
+            }
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseTrait.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseTrait.java
@@ -42,12 +42,19 @@ public class CorpseTrait extends Trait {
 
     private void applyAttributes(NPC npc) {
         if (!(npc.getEntity() instanceof LivingEntity entity)) return;
-        double healthMultiplier = level <= 10 ? 0.1 + 0.1 * (level - 1) : 1 + ((level - 10) * 0.1);
+        double healthMultiplier = level <= 10 ? 0.1 + 0.1 * (level - 1)
+                : 1 + ((level - 10) * 0.1);
         double armorValue = Math.min(healthMultiplier * 20, 100);
         if (entity.getAttribute(Attribute.GENERIC_ARMOR) != null) {
             entity.getAttribute(Attribute.GENERIC_ARMOR).setBaseValue(armorValue);
         }
-        entity.setHealth(entity.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue());
+
+        if (entity.getAttribute(Attribute.GENERIC_MAX_HEALTH) != null) {
+            double base = entity.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue();
+            double scaled = base * healthMultiplier;
+            entity.getAttribute(Attribute.GENERIC_MAX_HEALTH).setBaseValue(scaled);
+            entity.setHealth(scaled);
+        }
         entity.setCustomNameVisible(true);
         entity.setMetadata("mobLevel", new org.bukkit.metadata.FixedMetadataValue(plugin, level));
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
@@ -15,6 +15,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.player.PlayerToggleSneakEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
 
@@ -83,6 +84,19 @@ public class Gravedigging implements Listener {
         event.setCancelled(true);
         stand.remove();
         triggerEvent(player, stand.getLocation());
+    }
+
+    @EventHandler
+    public void onSneakDig(PlayerToggleSneakEvent event) {
+        if (!event.isSneaking()) return;
+        Player player = event.getPlayer();
+        for (org.bukkit.entity.Entity ent : player.getNearbyEntities(4, 4, 4)) {
+            if (ent instanceof ArmorStand stand && stand.hasMetadata("grave")) {
+                Location loc = stand.getLocation();
+                stand.remove();
+                triggerEvent(player, loc);
+            }
+        }
     }
 
     private void triggerEvent(Player player, Location loc) {


### PR DESCRIPTION
## Summary
- properly scale max health for corpse NPCs
- shift digs graves within 4 blocks
- destroy all corpse NPCs on shutdown

## Testing
- `javac -d /tmp/out $(git ls-files 'src/main/java/**/*.java')` *(fails: package org.bukkit... does not exist)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870996c07ac8332a46124f8c83a6a79