### PR TITLE
Update grave mechanics and corpse visuals

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseTrait.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseTrait.java
@@ -73,7 +73,7 @@ public class CorpseTrait extends Trait {
                 self.teleport(target.getLocation());
             }
 
-            double damageMultiplier = 1.0 + level * 0.06;
+            double damageMultiplier = getLevelMultiplier(level);
             double damage = BASE_DAMAGE * damageMultiplier;
 
             if (ranged) {
@@ -89,6 +89,13 @@ public class CorpseTrait extends Trait {
                 }
             }
         }, 20L, 20L);
+    }
+
+    private double getLevelMultiplier(int lvl) {
+        if (lvl <= 10) {
+            return 0.1 + 0.1 * (lvl - 1);
+        }
+        return 1 + ((lvl - 10) * 0.1);
     }
 
     private Player getNearestPlayer(Location loc) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/SpawnCorpseCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/SpawnCorpseCommand.java
@@ -3,6 +3,7 @@ package goat.minecraft.minecraftnew.subsystems.corpses;
 import net.citizensnpcs.api.CitizensAPI;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.api.npc.NPCRegistry;
+import goat.minecraft.minecraftnew.subsystems.fishing.Rarity;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -64,8 +65,19 @@ public class SpawnCorpseCommand implements CommandExecutor {
         npc.data().setPersistent(NPC.DEFAULT_PROTECTED_METADATA, false);
         npc.addTrait(new CorpseTrait(plugin, corpse.getLevel(), corpse.usesBow(),
                 corpse.getDisplayName().equalsIgnoreCase("Duskblood") ? 100 : 0));
-        npc.getEntity().setCustomName(ChatColor.GRAY + "[Lv: " + corpse.getLevel() + "] " + corpse.getDisplayName());
+        ChatColor color = getColorForRarity(corpse.getRarity());
+        npc.getEntity().setCustomName(ChatColor.GRAY + "[Lv: " + corpse.getLevel() + "] " + color + corpse.getDisplayName());
         npc.getEntity().setCustomNameVisible(true);
         npc.getEntity().setMetadata("CORPSE", new FixedMetadataValue(plugin, corpse.getDisplayName()));
+    }
+
+    private ChatColor getColorForRarity(Rarity rarity) {
+        return switch (rarity) {
+            case COMMON -> ChatColor.WHITE;
+            case UNCOMMON -> ChatColor.GREEN;
+            case RARE -> ChatColor.BLUE;
+            case EPIC -> ChatColor.DARK_PURPLE;
+            case LEGENDARY, MYTHIC -> ChatColor.GOLD;
+        };
     }
 }


### PR DESCRIPTION
## Summary
- redesign graves to use particles at random nearby blocks
- show corpse rarity color and level in their names
- scale corpse damage with level correctly

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:2.6)*

------
https://chatgpt.com/codex/tasks/task_e_68709e6617bc833284ae9152e1e2ebee