### PR TITLE
Implement corpse event logic and cleanup

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -160,6 +160,9 @@ public class MinecraftNew extends JavaPlugin implements Listener {
     public void onEnable() {
         instance = this;
 
+        removeAllCorpseNPCs();
+        removeAllCitizenEntities();
+
         HealthManager.getInstance(this).startup();
 
         ArmorStandCommand armorStandCommand = new ArmorStandCommand(this);
@@ -517,7 +520,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new KillMonster(), MinecraftNew.getInstance());
         getServer().getPluginManager().registerEvents(new Mining(), MinecraftNew.getInstance());
         getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.terraforming.Terraforming(), MinecraftNew.getInstance());
-        getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.gravedigging.Gravedigging(), MinecraftNew.getInstance());
+        getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.gravedigging.Gravedigging(this), this);
         getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.mining.GemstoneApplicationSystem(this), this);
         getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.forestry.EffigyApplicationSystem(this), this);
         getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.fishing.BaitApplicationSystem(this), this);
@@ -794,6 +797,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
             doubleEnderchest.saveAllInventories();
         }
         removeAllCorpseNPCs();
+        removeAllCitizenEntities();
         System.out.println("[MinecraftNew] Plugin disabled.");//
     }
     public static MinecraftNew getInstance() {
@@ -813,6 +817,14 @@ public class MinecraftNew extends JavaPlugin implements Listener {
                     (npc.getEntity() != null && npc.getEntity().hasMetadata("CORPSE"))) {
                 npc.destroy();
             }
+        }
+    }
+
+    private void removeAllCitizenEntities() {
+        for (org.bukkit.World world : Bukkit.getWorlds()) {
+            world.getEntities().stream()
+                    .filter(e -> e.hasMetadata("NPC"))
+                    .forEach(org.bukkit.entity.Entity::remove);
         }
     }
 }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseDeathEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseDeathEvent.java
@@ -1,6 +1,9 @@
 package goat.minecraft.minecraftnew.subsystems.corpses;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.fishing.Rarity;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
@@ -34,6 +37,37 @@ public class CorpseDeathEvent implements Listener {
         if (!opt.isPresent()) return;
 
         event.getDrops().clear();
+        playDeathEffects(entity, opt.get().getRarity());
         // Future drop logic using opt.get().getDrops()
+    }
+
+    private void playDeathEffects(Entity entity, Rarity rarity) {
+        if (entity.getWorld() == null) return;
+        Sound sound;
+        Particle particle = Particle.SMOKE_NORMAL;
+        float volume = 1.0f;
+        float pitch = 1.0f;
+        switch (rarity) {
+            case UNCOMMON -> sound = Sound.ENTITY_SKELETON_DEATH;
+            case RARE -> {
+                sound = Sound.ENTITY_ZOMBIE_VILLAGER_DEATH;
+                particle = Particle.CRIT;
+            }
+            case EPIC -> {
+                sound = Sound.ENTITY_WITHER_DEATH;
+                particle = Particle.EXPLOSION_LARGE;
+                volume = 1.5f;
+                pitch = 0.8f;
+            }
+            case LEGENDARY -> {
+                sound = Sound.ENTITY_ENDER_DRAGON_DEATH;
+                particle = Particle.EXPLOSION_HUGE;
+                volume = 2.0f;
+                pitch = 0.6f;
+            }
+            default -> sound = Sound.ENTITY_ZOMBIE_DEATH;
+        }
+        entity.getWorld().playSound(entity.getLocation(), sound, volume, pitch);
+        entity.getWorld().spawnParticle(particle, entity.getLocation(), 25, 0.5, 0.5, 0.5, 0.1);
     }
 }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseEvent.java
@@ -1,0 +1,110 @@
+package goat.minecraft.minecraftnew.subsystems.corpses;
+
+import net.citizensnpcs.api.CitizensAPI;
+import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.api.npc.NPCRegistry;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.event.player.PlayerTeleportEvent;
+
+import java.util.Optional;
+
+/**
+ * Spawns a random Corpse from the registry with an emergence animation.
+ */
+public class CorpseEvent {
+    private final JavaPlugin plugin;
+
+    public CorpseEvent(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Spawns a random corpse at the given location rising from the ground.
+     */
+    public void trigger(Location location) {
+        Optional<Corpse> optional = CorpseRegistry.getRandomCorpse();
+        if (!optional.isPresent()) {
+            return;
+        }
+        spawnCorpse(optional.get(), location);
+    }
+
+    private void spawnCorpse(Corpse corpse, Location loc) {
+        NPCRegistry registry = CitizensAPI.getNPCRegistry();
+        NPC npc = registry.createNPC(EntityType.PLAYER, corpse.getDisplayName());
+        Location spawnLoc = loc.clone().subtract(0, 1, 0);
+        npc.spawn(spawnLoc);
+
+        if (npc.getEntity() instanceof org.bukkit.entity.LivingEntity le) {
+            EntityEquipment eq = le.getEquipment();
+            if (eq != null && corpse.getWeaponMaterial() != null && corpse.getWeaponMaterial() != Material.AIR) {
+                eq.setItemInMainHand(new ItemStack(corpse.getWeaponMaterial()));
+            }
+        }
+        npc.data().setPersistent(NPC.DEFAULT_PROTECTED_METADATA, false);
+        npc.addTrait(new CorpseTrait(plugin, corpse.getLevel(), corpse.usesBow(),
+                corpse.getDisplayName().equalsIgnoreCase("Duskblood") ? 100 : 0));
+        ChatColor color = SpawnCorpseCommand.getColorForRarityStatic(corpse.getRarity());
+        npc.getEntity().setCustomName(ChatColor.GRAY + "[Lvl " + corpse.getLevel() + "] " + color + corpse.getDisplayName());
+        npc.getEntity().setCustomNameVisible(true);
+        npc.getEntity().setMetadata("CORPSE", new FixedMetadataValue(plugin, corpse.getDisplayName()));
+
+        playSpawnSound(loc, corpse.getRarity());
+
+        // Raise the corpse over 20 ticks with block crack particles
+        new BukkitRunnable() {
+            int ticks = 0;
+            @Override
+            public void run() {
+                if (ticks >= 20 || !npc.isSpawned()) {
+                    cancel();
+                    return;
+                }
+                Location current = npc.getEntity().getLocation();
+                npc.teleport(current.add(0, 0.05, 0), PlayerTeleportEvent.TeleportCause.PLUGIN);
+                current.getWorld().spawnParticle(Particle.BLOCK_CRACK, current, 5, 0.2, 0.1, 0.2, current.getBlock().getBlockData());
+                ticks++;
+            }
+        }.runTaskTimer(plugin, 1L, 1L);
+    }
+
+    private void playSpawnSound(Location loc, Rarity rarity) {
+        Sound sound;
+        float volume = 1.0f;
+        float pitch = 1.0f;
+        switch (rarity) {
+            case UNCOMMON:
+                sound = Sound.ENTITY_ZOMBIE_AMBIENT;
+                break;
+            case RARE:
+                sound = Sound.ENTITY_WITHER_SPAWN;
+                volume = 1.2f;
+                pitch = 0.9f;
+                break;
+            case EPIC:
+                sound = Sound.ENTITY_WITHER_SPAWN;
+                volume = 1.5f;
+                pitch = 0.8f;
+                break;
+            case LEGENDARY:
+                sound = Sound.ENTITY_ENDER_DRAGON_GROWL;
+                volume = 2.0f;
+                pitch = 0.7f;
+                break;
+            default:
+                sound = Sound.BLOCK_GRAVEL_BREAK;
+                break;
+        }
+        loc.getWorld().playSound(loc, sound, volume, pitch);
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/SpawnCorpseCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/SpawnCorpseCommand.java
@@ -65,13 +65,13 @@ public class SpawnCorpseCommand implements CommandExecutor {
         npc.data().setPersistent(NPC.DEFAULT_PROTECTED_METADATA, false);
         npc.addTrait(new CorpseTrait(plugin, corpse.getLevel(), corpse.usesBow(),
                 corpse.getDisplayName().equalsIgnoreCase("Duskblood") ? 100 : 0));
-        ChatColor color = getColorForRarity(corpse.getRarity());
-        npc.getEntity().setCustomName(ChatColor.GRAY + "[Lv: " + corpse.getLevel() + "] " + color + corpse.getDisplayName());
+        ChatColor color = getColorForRarityStatic(corpse.getRarity());
+        npc.getEntity().setCustomName(ChatColor.GRAY + "[Lvl " + corpse.getLevel() + "] " + color + corpse.getDisplayName());
         npc.getEntity().setCustomNameVisible(true);
         npc.getEntity().setMetadata("CORPSE", new FixedMetadataValue(plugin, corpse.getDisplayName()));
     }
 
-    private ChatColor getColorForRarity(Rarity rarity) {
+    public static ChatColor getColorForRarityStatic(Rarity rarity) {
         return switch (rarity) {
             case COMMON -> ChatColor.WHITE;
             case UNCOMMON -> ChatColor.GREEN;

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
@@ -8,7 +8,9 @@ import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.World;
 import org.bukkit.block.Block;
+import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.entity.Player;
+import goat.minecraft.minecraftnew.subsystems.corpses.CorpseEvent;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
@@ -28,6 +30,11 @@ public class Gravedigging implements Listener {
     private static final double BASE_CHANCE = 1.0; // 100% for testing
     private final Random random = new Random();
     private final Map<Location, BukkitTask> graves = new HashMap<>();
+    private final JavaPlugin plugin;
+
+    public Gravedigging(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     private boolean isNight(World world) {
         long time = world.getTime();
@@ -82,7 +89,7 @@ public class Gravedigging implements Listener {
         World world = loc.getWorld();
         if (world == null) return;
         Location effectLoc = loc.clone().add(0.5, 1, 0.5);
-        BukkitTask task = Bukkit.getScheduler().runTaskTimer(MinecraftNew.getInstance(), () -> {
+        BukkitTask task = Bukkit.getScheduler().runTaskTimer(plugin, () -> {
             world.spawnParticle(Particle.SOUL, effectLoc, 3, 0.1, 0.1, 0.1, 0);
         }, 0L, 20L);
         graves.put(loc, task);
@@ -92,7 +99,7 @@ public class Gravedigging implements Listener {
     private void triggerEvent(Player player, Location loc) {
         double roll = random.nextDouble();
         if (roll < 0.5) {
-            player.sendMessage(ChatColor.DARK_RED + "A Corpse stirs... (CorpseEvent)");
+            new CorpseEvent(plugin).trigger(loc);
         } else if (roll < 0.85) {
             player.sendMessage(ChatColor.GOLD + "You find something... (LootEvent)");
         } else {


### PR DESCRIPTION
## Summary
- remove lingering corpses and citizen NPCs on startup/shutdown
- add randomized corpse event with spawn animation
- add rarity-based sounds for corpse death and spawn
- update gravedigging to trigger corpse events
- adjust corpse naming logic

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6870a64e99208332bd787029143c58a4