### PR TITLE
Add Composter enchantment

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -616,6 +616,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new Preservation(), this);
         getServer().getPluginManager().registerEvents(new WaterAspect(), this);
         getServer().getPluginManager().registerEvents(new Accelerate(), this);
+        getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.other.enchanting.enchantingeffects.Composter(), this);
         getServer().getPluginManager().registerEvents(new FortuneRemover(), this);
         getServer().getPluginManager().registerEvents(new Defenestration(), this);
         getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.other.enchanting.enchantingeffects.Velocity(), this);
@@ -627,6 +628,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         CustomEnchantmentManager.registerEnchantment("Savant", 1, true);
         CustomEnchantmentManager.registerEnchantment("Ventilation", 4, true);
         CustomEnchantmentManager.registerEnchantment("Forge", 5, true);
+        CustomEnchantmentManager.registerEnchantment("Composter", 5, true);
         CustomEnchantmentManager.registerEnchantment("Piracy", 5, true);
         CustomEnchantmentManager.registerEnchantment("Shear", 5, true);
         CustomEnchantmentManager.registerEnchantment("Physical Protection", 4, true);

--- a/src/main/java/goat/minecraft/minecraftnew/other/enchanting/enchantingeffects/Composter.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/enchanting/enchantingeffects/Composter.java
@@ -1,0 +1,107 @@
+package goat.minecraft.minecraftnew.other.enchanting.enchantingeffects;
+
+import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentManager;
+import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.EnumSet;
+import java.util.Random;
+import java.util.Set;
+
+public class Composter implements Listener {
+
+    private static final Set<Material> ELIGIBLE_MATERIALS = EnumSet.of(
+            Material.DIRT,
+            Material.GRAVEL,
+            Material.SAND,
+            Material.WHEAT_SEEDS,
+            Material.BEETROOT_SEEDS,
+            Material.MELON_SEEDS,
+            Material.PUMPKIN_SEEDS,
+            Material.DANDELION,
+            Material.POPPY,
+            Material.BLUE_ORCHID,
+            Material.ALLIUM,
+            Material.AZURE_BLUET,
+            Material.RED_TULIP,
+            Material.ORANGE_TULIP,
+            Material.WHITE_TULIP,
+            Material.PINK_TULIP,
+            Material.OXEYE_DAISY,
+            Material.CORNFLOWER,
+            Material.LILY_OF_THE_VALLEY,
+            Material.WITHER_ROSE,
+            Material.SUNFLOWER,
+            Material.LILAC,
+            Material.ROSE_BUSH,
+            Material.PEONY
+    );
+
+    private final Random random = new Random();
+
+    @EventHandler
+    public void onBlockBreak(BlockBreakEvent event) {
+        Player player = event.getPlayer();
+        ItemStack tool = player.getInventory().getItemInMainHand();
+        if (!CustomEnchantmentManager.hasEnchantment(tool, "Composter")) {
+            return;
+        }
+        int level = CustomEnchantmentManager.getEnchantmentLevel(tool, "Composter");
+        if (level <= 0) return;
+
+        double chance = 0.04 * level; // 4% per level
+        if (random.nextDouble() > chance) {
+            return;
+        }
+
+        Location dropLoc = event.getBlock().getLocation();
+        autoCompost(player, dropLoc);
+    }
+
+    private void autoCompost(Player player, Location dropLoc) {
+        for (Material mat : ELIGIBLE_MATERIALS) {
+            int count = countItem(player, mat);
+            if (count >= 64) {
+                removeItem(player, mat, 64);
+                dropLoc.getWorld().dropItemNaturally(dropLoc, ItemRegistry.getOrganicSoil());
+                return;
+            }
+        }
+    }
+
+    private int countItem(Player player, Material mat) {
+        int total = 0;
+        for (ItemStack item : player.getInventory().getContents()) {
+            if (item == null || item.getType() != mat) continue;
+            if (item.hasItemMeta() && (item.getItemMeta().hasDisplayName() || !item.getEnchantments().isEmpty())) {
+                continue; // skip custom named or enchanted items
+            }
+            total += item.getAmount();
+        }
+        return total;
+    }
+
+    private void removeItem(Player player, Material mat, int amount) {
+        ItemStack[] contents = player.getInventory().getContents();
+        for (int i = 0; i < contents.length && amount > 0; i++) {
+            ItemStack item = contents[i];
+            if (item == null || item.getType() != mat) continue;
+            if (item.hasItemMeta() && (item.getItemMeta().hasDisplayName() || !item.getEnchantments().isEmpty())) {
+                continue;
+            }
+            int take = Math.min(item.getAmount(), amount);
+            item.setAmount(item.getAmount() - take);
+            if (item.getAmount() <= 0) {
+                contents[i] = null;
+            }
+            amount -= take;
+        }
+        player.getInventory().setContents(contents);
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -445,6 +445,7 @@ public class VillagerTradeManager implements Listener {
         toolsmithPurchases.add(createTradeMap("POWER_CRYSTAL", 1, 512, 5)); // Custom Item
         toolsmithPurchases.add(createTradeMap("REDSTONE_GEMSTONE", 1, 128, 5)); // Custom Item
         toolsmithPurchases.add(createTradeMap("JACKHAMMER", 1, 32, 3)); // Custom Item
+        toolsmithPurchases.add(createTradeMap("COMPOSTER_ENCHANT", 1, 32, 3)); // Custom Item
 
         defaultConfig.set("TOOLSMITH.purchases", toolsmithPurchases);
 
@@ -849,6 +850,8 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getToolsmithEnchant();
             case "TOOLSMITH_ENCHANT_TWO":
                 return ItemRegistry.getToolsmithEnchantTwo();
+            case "COMPOSTER_ENCHANT":
+                return ItemRegistry.getComposterEnchant();
             case "LEGENDARY_TOOL_REFORGE":
                 return ItemRegistry.getLegendaryToolReforge();
             case "MERIT_ITEM":

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -998,6 +998,15 @@ public class ItemRegistry {
         ), 1, false, true);
     }
 
+    public static ItemStack getComposterEnchant() {
+        return createCustomItem(Material.COMPOSTER, ChatColor.YELLOW +
+                "Composter", Arrays.asList(
+                ChatColor.GRAY + "Max level of V",
+                ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Adds 1 Level of Composter to items.",
+                ChatColor.DARK_PURPLE + "Smithing Item"
+        ), 1, false, true);
+    }
+
     public static ItemStack getShepherdArtifact() {
         return createCustomItem(Material.BRUSH, ChatColor.YELLOW +
                 "Creative Mind", Arrays.asList(


### PR DESCRIPTION
## Summary
- add `Composter` custom enchantment
- register new `Composter` enchant and event listener
- create `Composter` smithing item and trade entry
- whitelist the trade for Toolsmith villagers

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871821c4c7883328ca62d8ef02a4c48