### PR TITLE
Add skinName to Corpse definitions

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/Corpse.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/Corpse.java
@@ -22,18 +22,21 @@ public class Corpse {
     private final Material weaponMaterial;
     private final boolean usesBow;
     private final List<DropItem> dropItems;
+    private final String skinName;
 
     private final Random random = new Random();
 
     public Corpse(String displayName, Rarity rarity, int level,
                   Material weaponMaterial,
-                  boolean usesBow, List<DropItem> dropItems) {
+                  boolean usesBow, List<DropItem> dropItems,
+                  String skinName) {
         this.displayName = displayName;
         this.rarity = rarity;
         this.level = level;
         this.weaponMaterial = weaponMaterial;
         this.usesBow = usesBow;
         this.dropItems = dropItems;
+        this.skinName = skinName;
     }
 
     public String getDisplayName() {
@@ -58,6 +61,7 @@ public class Corpse {
     public int getLevel() { return level; }
     public Material getWeaponMaterial() { return weaponMaterial; }
     public boolean usesBow() { return usesBow; }
+    public String getSkinName() { return skinName; }
 
     public List<ItemStack> getDrops() {
         List<ItemStack> drops = new ArrayList<>();

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseEvent.java
@@ -59,6 +59,10 @@ public class CorpseEvent {
         Location spawnLoc = loc.clone().subtract(0, 1, 0);
         npc.spawn(spawnLoc);
 
+        if (npc.getEntity() instanceof SkinnableEntity skinnable) {
+            skinnable.setSkinName(corpse.getSkinName());
+        }
+
         if (npc.getEntity() instanceof org.bukkit.entity.LivingEntity le) {
             EntityEquipment eq = le.getEquipment();
             if (eq != null && corpse.getWeaponMaterial() != null && corpse.getWeaponMaterial() != Material.AIR) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseRegistry.java
@@ -24,43 +24,43 @@ public class CorpseRegistry implements Listener {
 
         // COMMON
         CORPSES.add(new Corpse("Farmer Corpse", Rarity.COMMON, 30,
-                Material.IRON_HOE, false, new ArrayList<>()));
+                Material.IRON_HOE, false, new ArrayList<>(), "Notch"));
         CORPSES.add(new Corpse("Guard Corpse", Rarity.COMMON, 35,
-                Material.IRON_SWORD, false, new ArrayList<>()));
+                Material.IRON_SWORD, false, new ArrayList<>(), "Notch"));
         CORPSES.add(new Corpse("Archer Corpse", Rarity.COMMON, 40,
-                Material.BOW, true, new ArrayList<>()));
+                Material.BOW, true, new ArrayList<>(), "Notch"));
 
         // UNCOMMON
         CORPSES.add(new Corpse("Diver Corpse", Rarity.UNCOMMON, 50,
-                Material.AIR, false, new ArrayList<>()));
+                Material.AIR, false, new ArrayList<>(), "Notch"));
         CORPSES.add(new Corpse("Fisherman Corpse", Rarity.UNCOMMON, 55,
-                Material.FISHING_ROD, false, new ArrayList<>()));
+                Material.FISHING_ROD, false, new ArrayList<>(), "Notch"));
         CORPSES.add(new Corpse("Lumberjack Corpse", Rarity.UNCOMMON, 60,
-                Material.IRON_AXE, false, new ArrayList<>()));
+                Material.IRON_AXE, false, new ArrayList<>(), "Notch"));
 
         // RARE
         CORPSES.add(new Corpse("Adventurer Corpse", Rarity.RARE, 70,
-                Material.MAP, false, new ArrayList<>()));
+                Material.MAP, false, new ArrayList<>(), "Notch"));
         CORPSES.add(new Corpse("Pirates Corpse", Rarity.RARE, 75,
-                Material.IRON_SWORD, false, new ArrayList<>()));
+                Material.IRON_SWORD, false, new ArrayList<>(), "Notch"));
         CORPSES.add(new Corpse("Sculk Infected", Rarity.RARE, 80,
-                Material.AIR, false, new ArrayList<>()));
+                Material.AIR, false, new ArrayList<>(), "Notch"));
 
         // EPIC
         CORPSES.add(new Corpse("Necromancer Corpse", Rarity.EPIC, 90,
-                Material.SKELETON_SKULL, false, new ArrayList<>()));
+                Material.SKELETON_SKULL, false, new ArrayList<>(), "Notch"));
         CORPSES.add(new Corpse("Gladiator Corpse", Rarity.EPIC, 100,
-                Material.DIAMOND_SWORD, false, new ArrayList<>()));
+                Material.DIAMOND_SWORD, false, new ArrayList<>(), "Notch"));
         CORPSES.add(new Corpse("Duskblood", Rarity.EPIC, 110,
-                Material.AIR, false, new ArrayList<>()));
+                Material.AIR, false, new ArrayList<>(), "Notch"));
 
         // LEGENDARY
         CORPSES.add(new Corpse("Trauma", Rarity.LEGENDARY, 120,
-                Material.DIAMOND_AXE, false, new ArrayList<>()));
+                Material.DIAMOND_AXE, false, new ArrayList<>(), "Notch"));
         CORPSES.add(new Corpse("Cryptic", Rarity.LEGENDARY, 140,
-                Material.BOW, true, new ArrayList<>()));
+                Material.BOW, true, new ArrayList<>(), "Notch"));
         CORPSES.add(new Corpse("Dreadnaught", Rarity.LEGENDARY, 150,
-                Material.NETHERITE_SWORD, false, new ArrayList<>()));
+                Material.NETHERITE_SWORD, false, new ArrayList<>(), "Notch"));
     }
 
     public static Optional<Corpse> getCorpseByName(String name) {


### PR DESCRIPTION
## Summary
- allow corpses to hold a player skin name
- spawn corpses with the given skin
- update registry definitions to pass "Notch" for testing

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6871bb9e33708332beab105addfda79a