### PR TITLE
Update corpse skin handling

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/Corpse.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/Corpse.java
@@ -22,21 +22,21 @@ public class Corpse {
     private final Material weaponMaterial;
     private final boolean usesBow;
     private final List<DropItem> dropItems;
-    private final String skinName;
+    private final String skinTexture;
 
     private final Random random = new Random();
 
     public Corpse(String displayName, Rarity rarity, int level,
                   Material weaponMaterial,
                   boolean usesBow, List<DropItem> dropItems,
-                  String skinName) {
+                  String skinTexture) {
         this.displayName = displayName;
         this.rarity = rarity;
         this.level = level;
         this.weaponMaterial = weaponMaterial;
         this.usesBow = usesBow;
         this.dropItems = dropItems;
-        this.skinName = skinName;
+        this.skinTexture = skinTexture;
     }
 
     public String getDisplayName() {
@@ -61,7 +61,7 @@ public class Corpse {
     public int getLevel() { return level; }
     public Material getWeaponMaterial() { return weaponMaterial; }
     public boolean usesBow() { return usesBow; }
-    public String getSkinName() { return skinName; }
+    public String getSkinTexture() { return skinTexture; }
 
     public List<ItemStack> getDrops() {
         List<ItemStack> drops = new ArrayList<>();

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseEvent.java
@@ -60,8 +60,8 @@ public class CorpseEvent {
         npc.spawn(spawnLoc);
 
         if (npc.getEntity() instanceof SkinnableEntity skinnable) {
-            skinnable.setSkinName(corpse.getSkinName());
-            
+            skinnable.setSkinPersistent("corpse-" + npc.getId(), "", corpse.getSkinTexture());
+
         }
 
         if (npc.getEntity() instanceof org.bukkit.entity.LivingEntity le) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/corpses/CorpseRegistry.java
@@ -14,6 +14,7 @@ public class CorpseRegistry implements Listener {
     private static final List<Corpse> CORPSES = new ArrayList<>();
     private static final Map<Rarity, Double> RARITY_WEIGHTS = new LinkedHashMap<>();
     private static final Random RANDOM = new Random();
+    private static final String DEFAULT_TEXTURE = "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTU4NzNmMDg2NTk1YWQ2OTQyODc4NTM1ZjgxMmFhYjUzNzg1OTQ3MTVmNjk1Yjc3MGMxNzM4YzFmZDNlZTRmZCJ9fX0=";
 
     static {
         RARITY_WEIGHTS.put(Rarity.COMMON, 0.50);
@@ -24,43 +25,43 @@ public class CorpseRegistry implements Listener {
 
         // COMMON
         CORPSES.add(new Corpse("Farmer Corpse", Rarity.COMMON, 30,
-                Material.IRON_HOE, false, new ArrayList<>(), "Notch"));
+                Material.IRON_HOE, false, new ArrayList<>(), DEFAULT_TEXTURE));
         CORPSES.add(new Corpse("Guard Corpse", Rarity.COMMON, 35,
-                Material.IRON_SWORD, false, new ArrayList<>(), "Notch"));
+                Material.IRON_SWORD, false, new ArrayList<>(), DEFAULT_TEXTURE));
         CORPSES.add(new Corpse("Archer Corpse", Rarity.COMMON, 40,
-                Material.BOW, true, new ArrayList<>(), "Notch"));
+                Material.BOW, true, new ArrayList<>(), DEFAULT_TEXTURE));
 
         // UNCOMMON
         CORPSES.add(new Corpse("Diver Corpse", Rarity.UNCOMMON, 50,
-                Material.AIR, false, new ArrayList<>(), "Notch"));
+                Material.AIR, false, new ArrayList<>(), DEFAULT_TEXTURE));
         CORPSES.add(new Corpse("Fisherman Corpse", Rarity.UNCOMMON, 55,
-                Material.FISHING_ROD, false, new ArrayList<>(), "Notch"));
+                Material.FISHING_ROD, false, new ArrayList<>(), DEFAULT_TEXTURE));
         CORPSES.add(new Corpse("Lumberjack Corpse", Rarity.UNCOMMON, 60,
-                Material.IRON_AXE, false, new ArrayList<>(), "Notch"));
+                Material.IRON_AXE, false, new ArrayList<>(), DEFAULT_TEXTURE));
 
         // RARE
         CORPSES.add(new Corpse("Adventurer Corpse", Rarity.RARE, 70,
-                Material.MAP, false, new ArrayList<>(), "Notch"));
+                Material.MAP, false, new ArrayList<>(), DEFAULT_TEXTURE));
         CORPSES.add(new Corpse("Pirates Corpse", Rarity.RARE, 75,
-                Material.IRON_SWORD, false, new ArrayList<>(), "Notch"));
+                Material.IRON_SWORD, false, new ArrayList<>(), DEFAULT_TEXTURE));
         CORPSES.add(new Corpse("Sculk Infected", Rarity.RARE, 80,
-                Material.AIR, false, new ArrayList<>(), "Notch"));
+                Material.AIR, false, new ArrayList<>(), DEFAULT_TEXTURE));
 
         // EPIC
         CORPSES.add(new Corpse("Necromancer Corpse", Rarity.EPIC, 90,
-                Material.SKELETON_SKULL, false, new ArrayList<>(), "Notch"));
+                Material.SKELETON_SKULL, false, new ArrayList<>(), DEFAULT_TEXTURE));
         CORPSES.add(new Corpse("Gladiator Corpse", Rarity.EPIC, 100,
-                Material.DIAMOND_SWORD, false, new ArrayList<>(), "Notch"));
+                Material.DIAMOND_SWORD, false, new ArrayList<>(), DEFAULT_TEXTURE));
         CORPSES.add(new Corpse("Duskblood", Rarity.EPIC, 110,
-                Material.AIR, false, new ArrayList<>(), "Notch"));
+                Material.AIR, false, new ArrayList<>(), DEFAULT_TEXTURE));
 
         // LEGENDARY
         CORPSES.add(new Corpse("Trauma", Rarity.LEGENDARY, 120,
-                Material.DIAMOND_AXE, false, new ArrayList<>(), "Notch"));
+                Material.DIAMOND_AXE, false, new ArrayList<>(), DEFAULT_TEXTURE));
         CORPSES.add(new Corpse("Cryptic", Rarity.LEGENDARY, 140,
-                Material.BOW, true, new ArrayList<>(), "Notch"));
+                Material.BOW, true, new ArrayList<>(), DEFAULT_TEXTURE));
         CORPSES.add(new Corpse("Dreadnaught", Rarity.LEGENDARY, 150,
-                Material.NETHERITE_SWORD, false, new ArrayList<>(), "Notch"));
+                Material.NETHERITE_SWORD, false, new ArrayList<>(), DEFAULT_TEXTURE));
     }
 
     public static Optional<Corpse> getCorpseByName(String name) {


### PR DESCRIPTION
## Summary
- introduce `skinTexture` field in `Corpse`
- apply base64 skin data during corpse spawning
- store a default test texture for all corpses

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin resolution failed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6871c92865388332b3db2798368b6e3a