### PR TITLE
Add terraforming XP for corpse kills

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/corpses/CorpseDeathEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/corpses/CorpseDeathEvent.java
@@ -1,6 +1,8 @@
 package goat.minecraft.minecraftnew.subsystems.gravedigging.corpses;
 
+import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.fishing.Rarity;
+import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import net.citizensnpcs.api.npc.NPC;
 import org.bukkit.Bukkit;
 import org.bukkit.Particle;
@@ -18,6 +20,7 @@ import java.util.Optional;
  * Handles drops and cleanup when a Corpse NPC dies.
  */
 public class CorpseDeathEvent implements Listener {
+    private final XPManager xpManager = new XPManager(MinecraftNew.getInstance());
     @EventHandler
     public void onCorpseDeath(EntityDeathEvent event) {
         Entity entity = event.getEntity();
@@ -33,11 +36,25 @@ public class CorpseDeathEvent implements Listener {
         // 3) Clear any item drops (we handle loot ourselves)
         event.getDrops().clear();
 
-        // 4) Fetch your Corpse data by name
+        // 4) Fetch your Corpse data by name and handle XP/visuals
         String corpseName = meta.get(0).asString();
         Optional<Corpse> corpseOpt = CorpseRegistry.getCorpseByName(corpseName);
         corpseOpt.ifPresent(corpse -> {
             playDeathEffects(entity, corpse.getRarity());
+
+            // Award Terraforming XP to the killer based on corpse rarity
+            var killer = event.getEntity().getKiller();
+            if (killer != null) {
+                int tier = switch (corpse.getRarity()) {
+                    case UNCOMMON -> 2;
+                    case RARE -> 3;
+                    case EPIC -> 4;
+                    case LEGENDARY -> 5;
+                    default -> 1; // COMMON or unknown
+                };
+                int terraXP = 200 * tier;
+                xpManager.addXP(killer, "Terraforming", terraXP);
+            }
         });
 
         // 5) Destroy the NPC so it won’t re-spawn on reload


### PR DESCRIPTION
## Summary
- reward players with Terraforming XP when they kill corpse NPCs

## Testing
- `mvn -q -DskipTests package` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6871f86e3e448332ba3a11c1e27c8612