### PR TITLE
Move Verdant relic seeds to grave treasure

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/FireDamageHandler.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/FireDamageHandler.java
@@ -137,9 +137,6 @@ public class FireDamageHandler implements Listener {
                 double damage = level / 2.0;
                 double newHealth = Math.max(0.0, entity.getHealth() - damage);
                 entity.setHealth(newHealth);
-                if(newHealth <= 0.0 && entity.getWorld() != null) {
-                    entity.getWorld().dropItemNaturally(entity.getLocation(), ItemRegistry.getVerdantRelicSunflareSeed());
-                }
                 if (entity.getWorld() != null) {
                     entity.getWorld().playSound(entity.getLocation(), Sound.ENTITY_BLAZE_HURT, 1.0f, 1.0f);
                 }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SpawnMonsters.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SpawnMonsters.java
@@ -676,7 +676,7 @@ public class SpawnMonsters implements Listener {
                     int currentOxygen = oxygenManager.getPlayerOxygen(killer);
                     oxygenManager.setPlayerOxygenLevel(killer, currentOxygen + 100);
                     event.setDroppedExp(100);
-                    drowned.getLocation().getWorld().dropItem(drowned.getLocation(), ItemRegistry.getVerdantRelicEntionPlastSeed());
+                    // Relic seed drops moved to gravedigging treasure rewards
                 }
             }
         }
@@ -699,7 +699,7 @@ public class SpawnMonsters implements Listener {
                 event.setDroppedExp(100);
                 if(random.nextDouble() < 0.125) {
                     killer.sendMessage(ChatColor.AQUA + "You found a " + ChatColor.GOLD + "Verdant Relic: Entropy!");
-                    Objects.requireNonNull(monster.getLocation().getWorld()).dropItem(monster.getLocation(), ItemRegistry.getVerdantRelicEntropySeed());
+                    // Relic seed drops moved to gravedigging treasure rewards
                 }
             }
         }
@@ -749,8 +749,8 @@ public class SpawnMonsters implements Listener {
 
         Player killer = spider.getKiller();
         if (killer != null) {
-            spider.getWorld().dropItemNaturally(spider.getLocation(), ItemRegistry.getVerdantRelicStarlightSeed());
             killer.sendMessage(ChatColor.AQUA + "You found a " + ChatColor.GOLD + "Verdant Relic: Starlight!");
+            // Relic seed drops moved to gravedigging treasure rewards
         }
     }
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureRegistry.java
@@ -156,7 +156,6 @@ public class SeaCreatureRegistry implements Listener {
         poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getRiptide(), 1, 1, 3));
         poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getChanneling(), 1, 1, 6));
         poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getLoyaltyContract(), 1, 1, 5));
-        poseidonDrops.add(new SeaCreature.DropItem(ItemRegistry.getVerdantRelicTideSeed(), 1, 1, 5));
         SEA_CREATURES.add(new SeaCreature(
                 "Poseidon",
                 Rarity.RARE,

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
@@ -13,6 +13,7 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.Bukkit;
@@ -152,9 +153,11 @@ public class Gravedigging implements Listener {
         }
         else {
             // --- TREASURE EVENT ---
-            world.dropItemNaturally(center, new ItemStack(Material.GOLD_BLOCK));
+            ItemStack seed = ItemRegistry.getRandomVerdantRelicSeed();
+            world.dropItemNaturally(center, seed);
             world.playSound(center, Sound.ENTITY_ITEM_PICKUP, 1.0f, 0.8f);
-            player.sendMessage(ChatColor.AQUA + "You uncover a treasure! (Gold Block)");
+            String name = seed.getItemMeta() != null ? seed.getItemMeta().getDisplayName() : "Verdant Relic Seed";
+            player.sendMessage(ChatColor.AQUA + "You uncover a treasure! (" + name + ChatColor.AQUA + ")");
         }
 
         // common dust + gravel sound for breaking the grave

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/mining/Mining.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/mining/Mining.java
@@ -293,13 +293,13 @@ public class Mining implements Listener {
             Material type = block.getType();
             if (type == Material.EMERALD_ORE || type == Material.DEEPSLATE_EMERALD_ORE) {
                 if (random.nextInt(100) < 5) { // 5% chance
-                    block.getWorld().dropItemNaturally(block.getLocation(), ItemRegistry.getVerdantRelicShinyEmeraldSeed());
+                    // Relic seed drops moved to gravedigging treasure rewards
                 }
             } else if (type == Material.DIAMOND_ORE || type == Material.DEEPSLATE_DIAMOND_ORE ||
                     type == Material.LAPIS_ORE || type == Material.DEEPSLATE_LAPIS_ORE ||
                     type == Material.REDSTONE_ORE || type == Material.DEEPSLATE_REDSTONE_ORE) {
                 if (random.nextInt(100) < 1) { // 1% chance
-                    block.getWorld().dropItemNaturally(block.getLocation(), ItemRegistry.getVerdantRelicShinyEmeraldSeed());
+                    // Relic seed drops moved to gravedigging treasure rewards
                 }
             }
         }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -1061,8 +1061,6 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getVindicatorDrop();
             case "WITCH_DROP":
                 return ItemRegistry.getWitchDrop();
-            case "VERDANT_RELIC_TIDE_SEED":
-                return ItemRegistry.getVerdantRelicTideSeed();
             case "VERDANT_RELIC_TREASURY":
                 return ItemRegistry.getVerdantRelicTreasury();
             case "RESPIRATION":

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -577,6 +577,22 @@ public class ItemRegistry {
         );
     }
 
+    /**
+     * Returns a random Verdant Relic seed.
+     */
+    public static ItemStack getRandomVerdantRelicSeed() {
+        Random random = new Random();
+        List<ItemStack> seeds = Arrays.asList(
+                getVerdantRelicEntionPlastSeed(),
+                getVerdantRelicEntropySeed(),
+                getVerdantRelicSunflareSeed(),
+                getVerdantRelicStarlightSeed(),
+                getVerdantRelicTideSeed(),
+                getVerdantRelicShinyEmeraldSeed()
+        );
+        return seeds.get(random.nextInt(seeds.size()));
+    }
+
     // ------------------------------------------------------------------
     // Ghost Relic
     // ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- randomize Verdant relic seeds in `ItemRegistry`
- reward treasure graves with a random Verdant relic seed
- remove old seed drop logic from combat, mining, fishing, and villagers

## Testing
- `mvn -q -DskipTests package` *(fails: Could not download maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6871f751f49c8332baee3cce36e16f96