### PR TITLE
Add undead pet line and corpse kill progress tracking

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -467,6 +467,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new PhoenixRebirth(this), this);
         getServer().getPluginManager().registerEvents(new FlameTrail(this), this);
         getServer().getPluginManager().registerEvents(new Spectral(this), this);
+        getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.pets.perks.Revenant(this), this);
         getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.other.qol.FastAscend(), this);
 
         this.getCommand("givecustomitem").setExecutor(new GiveCustomItem());

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/CorpseKillManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/CorpseKillManager.java
@@ -1,0 +1,71 @@
+package goat.minecraft.minecraftnew.subsystems.gravedigging;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import org.bukkit.entity.Player;
+
+import java.io.*;
+
+/**
+ * Simple persistence helper for tracking how many corpse mobs a player has killed.
+ */
+public class CorpseKillManager {
+
+    private static final File DATA_FOLDER = new File(MinecraftNew.getInstance().getDataFolder(), "corpseKills");
+
+    private static CorpseKillManager instance;
+
+    static {
+        if (!DATA_FOLDER.exists()) {
+            DATA_FOLDER.mkdirs();
+        }
+    }
+
+    private CorpseKillManager() {}
+
+    public static CorpseKillManager getInstance() {
+        if (instance == null) {
+            instance = new CorpseKillManager();
+        }
+        return instance;
+    }
+
+    /**
+     * Increment the corpse kill count for the given player.
+     */
+    public void incrementCorpseKills(Player player) {
+        File file = new File(DATA_FOLDER, player.getUniqueId().toString() + ".txt");
+        int count = 0;
+        if (file.exists()) {
+            try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+                String line = reader.readLine();
+                if (line != null && !line.isEmpty()) {
+                    count = Integer.parseInt(line.trim());
+                }
+            } catch (IOException | NumberFormatException ignored) {
+            }
+        }
+        count++;
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(file, false))) {
+            writer.write(Integer.toString(count));
+        } catch (IOException ignored) {
+        }
+    }
+
+    /**
+     * Retrieve the corpse kill count for the given player.
+     */
+    public int getCorpseKills(Player player) {
+        File file = new File(DATA_FOLDER, player.getUniqueId().toString() + ".txt");
+        if (!file.exists()) {
+            return 0;
+        }
+        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+            String line = reader.readLine();
+            if (line != null && !line.isEmpty()) {
+                return Integer.parseInt(line.trim());
+            }
+        } catch (IOException | NumberFormatException ignored) {
+        }
+        return 0;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
@@ -19,6 +19,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -89,6 +90,25 @@ public class Gravedigging implements Listener {
         if (tool != null && tool.getType().toString().endsWith("_SHOVEL")) {
             int level = CustomEnchantmentManager.getEnchantmentLevel(tool, "Lynch");
             chance += level * 0.01;
+        }
+        PetManager petManager = PetManager.getInstance(plugin);
+        PetManager.Pet activePet = petManager.getActivePet(player);
+        if (activePet != null) {
+            if (activePet.hasPerk(PetManager.PetPerk.MEMORY)) {
+                chance += 0.01;
+            }
+            if (activePet.hasPerk(PetManager.PetPerk.HAUNTING)) {
+                chance += 0.02;
+            }
+            if (activePet.hasPerk(PetManager.PetPerk.SCREAM)) {
+                chance += 0.04;
+            }
+            if (activePet.hasPerk(PetManager.PetPerk.COLD)) {
+                chance += 0.05;
+            }
+            if (activePet.hasPerk(PetManager.PetPerk.MALIGNANCE)) {
+                chance += 0.10;
+            }
         }
         if (isNight(world)) {
             chance = Math.min(1.0, chance * 2);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/corpses/CorpseDeathEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/corpses/CorpseDeathEvent.java
@@ -1,6 +1,9 @@
 package goat.minecraft.minecraftnew.subsystems.gravedigging.corpses;
 
 import goat.minecraft.minecraftnew.subsystems.fishing.Rarity;
+import goat.minecraft.minecraftnew.subsystems.gravedigging.CorpseKillManager;
+import goat.minecraft.minecraftnew.subsystems.pets.PetRegistry;
+import org.bukkit.entity.Player;
 import net.citizensnpcs.api.npc.NPC;
 import org.bukkit.Bukkit;
 import org.bukkit.Particle;
@@ -39,6 +42,30 @@ public class CorpseDeathEvent implements Listener {
         corpseOpt.ifPresent(corpse -> {
             playDeathEffects(entity, corpse.getRarity());
         });
+
+        Player killer = entity.getKiller();
+        if (killer != null) {
+            CorpseKillManager killManager = CorpseKillManager.getInstance();
+            killManager.incrementCorpseKills(killer);
+            int kills = killManager.getCorpseKills(killer);
+            PetRegistry petRegistry = new PetRegistry();
+
+            if (kills >= 3) {
+                petRegistry.addPetByName(killer, "Imprint");
+            }
+            if (kills >= 9) {
+                petRegistry.addPetByName(killer, "Spirit");
+            }
+            if (kills >= 27) {
+                petRegistry.addPetByName(killer, "Banshee");
+            }
+            if (kills >= 94) {
+                petRegistry.addPetByName(killer, "Wraith");
+            }
+            if (kills >= 200) {
+                petRegistry.addPetByName(killer, "Revenant");
+            }
+        }
 
         // 5) Destroy the NPC so it won’t re-spawn on reload
         npc.destroy();

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
@@ -841,6 +841,18 @@ public class PetManager implements Listener {
                 return "Reduces brew time by " + ChatColor.YELLOW + level + "%" + ChatColor.GRAY + ".";
             case EXPERIMENTATION:
                 return "Potions last " + ChatColor.YELLOW + (3 * level) + "s" + ChatColor.GRAY + " longer.";
+            case MEMORY:
+                return ChatColor.GRAY + "+0.01 Grave Chance";
+            case HAUNTING:
+                return ChatColor.GRAY + "+0.02 Grave Chance";
+            case SCREAM:
+                return ChatColor.GRAY + "+0.04 Grave Chance";
+            case COLD:
+                return ChatColor.GRAY + "+0.05 Grave Chance";
+            case MALIGNANCE:
+                return ChatColor.GRAY + "+0.10 Grave Chance";
+            case REVENANT:
+                return ChatColor.GRAY + "Return from death after 2 minutes";
             case SPECTRAL:
                 return ChatColor.GRAY + "Enter " + ChatColor.DARK_PURPLE + "Spectator" + ChatColor.GRAY + " mode for scouting.";
             default:
@@ -1262,6 +1274,12 @@ public class PetManager implements Listener {
         ENDLESS_WARP("Endless Warp", ChatColor.GOLD + ""),
         SPLASH_POTION("Splash Potion", ChatColor.GOLD + ""),
         EXPERIMENTATION("Experimentation", ChatColor.GOLD + ""),
+        MEMORY("Memory", ChatColor.GOLD + "+0.01 Grave Chance"),
+        HAUNTING("Haunting", ChatColor.GOLD + "+0.02 Grave Chance"),
+        SCREAM("Scream", ChatColor.GOLD + "+0.04 Grave Chance"),
+        COLD("Cold", ChatColor.GOLD + "+0.05 Grave Chance"),
+        MALIGNANCE("Malignance", ChatColor.GOLD + "+0.10 Grave Chance"),
+        REVENANT("Revenant", ChatColor.GOLD + "Return from the dead after 2 minutes"),
         SPECTRAL("Spectral", ChatColor.GOLD + "Allows scouting in Spectator mode");
 
         private final String displayName;

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetRegistry.java
@@ -376,6 +376,42 @@ public class PetRegistry {
                 Particle.SOUL,
                 Arrays.asList(PetManager.PetPerk.SPECTRAL)
         ));
+
+        registry.put("Imprint", new PetDefinition(
+                "Imprint",
+                PetManager.Rarity.COMMON,
+                100,
+                Particle.SOUL,
+                Arrays.asList(PetManager.PetPerk.MEMORY)
+        ));
+        registry.put("Spirit", new PetDefinition(
+                "Spirit",
+                PetManager.Rarity.UNCOMMON,
+                100,
+                Particle.SOUL,
+                Arrays.asList(PetManager.PetPerk.HAUNTING, PetManager.PetPerk.SPEED_BOOST)
+        ));
+        registry.put("Banshee", new PetDefinition(
+                "Banshee",
+                PetManager.Rarity.RARE,
+                100,
+                Particle.SOUL,
+                Arrays.asList(PetManager.PetPerk.SCREAM, PetManager.PetPerk.SPEED_BOOST, PetManager.PetPerk.DIGGING_CLAWS)
+        ));
+        registry.put("Wraith", new PetDefinition(
+                "Wraith",
+                PetManager.Rarity.EPIC,
+                100,
+                Particle.SOUL,
+                Arrays.asList(PetManager.PetPerk.COLD, PetManager.PetPerk.SPEED_BOOST, PetManager.PetPerk.EARTHWORM, PetManager.PetPerk.COLLECTOR)
+        ));
+        registry.put("Revenant", new PetDefinition(
+                "Revenant",
+                PetManager.Rarity.LEGENDARY,
+                100,
+                Particle.SOUL,
+                Arrays.asList(PetManager.PetPerk.MALIGNANCE, PetManager.PetPerk.REVENANT, PetManager.PetPerk.SPEED_BOOST, PetManager.PetPerk.EARTHWORM, PetManager.PetPerk.COLLECTOR, PetManager.PetPerk.ELITE)
+        ));
     }
     // Inside PetManager class
     public void addPetByName(Player player, String petName) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/Revenant.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/Revenant.java
@@ -1,0 +1,47 @@
+package goat.minecraft.minecraftnew.subsystems.pets.perks;
+
+import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
+import org.bukkit.GameMode;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitTask;
+
+public class Revenant implements Listener {
+    private final PetManager petManager;
+    private final JavaPlugin plugin;
+
+    public Revenant(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.petManager = PetManager.getInstance(plugin);
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onPlayerDamage(EntityDamageEvent event) {
+        if (!(event.getEntity() instanceof Player player)) return;
+        PetManager.Pet active = petManager.getActivePet(player);
+        if (active == null || !active.hasPerk(PetManager.PetPerk.REVENANT)) return;
+
+        double finalDamage = event.getFinalDamage();
+        if (player.getHealth() - finalDamage > 0) return;
+
+        event.setCancelled(true);
+        final var loc = player.getLocation();
+        player.setGameMode(GameMode.SPECTATOR);
+        player.setHealth(1.0);
+        player.addPotionEffect(new PotionEffect(PotionEffectType.DARKNESS, 120 * 20, 0, false, false));
+        BukkitTask repeat = plugin.getServer().getScheduler().runTaskTimer(plugin, () -> player.teleport(loc), 0L, 1L);
+        plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
+            repeat.cancel();
+            player.teleport(loc);
+            player.setGameMode(GameMode.SURVIVAL);
+            player.removePotionEffect(PotionEffectType.DARKNESS);
+            player.setHealth(player.getMaxHealth());
+        }, 120 * 20L);
+    }
+}


### PR DESCRIPTION
## Summary
- implement CorpseKillManager for persistent corpse kill statistics
- create Revenant perk for delayed revival
- award new undead pets based on corpse kills
- define new perks and pets in PetManager and PetRegistry
- boost grave spawn chance via pet perks

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6871fba63ad4833296630359371b9149