### PR TITLE
Add Paranormal pet trait

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
@@ -21,6 +21,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
+import goat.minecraft.minecraftnew.subsystems.pets.PetTrait;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -109,6 +110,9 @@ public class Gravedigging implements Listener {
             }
             if (activePet.hasPerk(PetManager.PetPerk.MALIGNANCE)) {
                 chance += 0.010;
+            }
+            if (activePet.getTrait() == PetTrait.PARANORMAL) {
+                chance += activePet.getTrait().getValueForRarity(activePet.getTraitRarity());
             }
         }
         if (isNight(world)) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetTrait.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetTrait.java
@@ -15,6 +15,7 @@ public enum PetTrait {
     RESILIENT(ChatColor.WHITE, "Damage Reduction", new double[]{3,5,8,10,15,20}),
     NAUTICAL(ChatColor.AQUA, "Sea Creature Chance", new double[]{1,2,3,4,5,6}),
     HAUNTED(ChatColor.AQUA, "Spirit Chance", new double[]{1,2,3,4,5,6}),
+    PARANORMAL(ChatColor.DARK_PURPLE, "Grave Chance", new double[]{0.001,0.002,0.003,0.005,0.01,0.02}),
     PRECISE(ChatColor.RED, "Arrow Damage Increase", new double[]{3,5,8, 10,15,20}),
     FINANCIAL(ChatColor.YELLOW, "Discount", new double[]{3,5,8,10,15,20}),
     EVASIVE(ChatColor.LIGHT_PURPLE, "Dodge Chance", new double[]{3,5,8,10,15,20}),


### PR DESCRIPTION
## Summary
- add `PARANORMAL` trait to `PetTrait`
- increase grave spawn chance when active pet has the Paranormal trait

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6872031ceb18833293d322ce24eb4f0e