### PR TITLE
Add ultimate enchantment smithing items

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/enchanting/UltimateEnchantingSystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/enchanting/UltimateEnchantingSystem.java
@@ -118,7 +118,7 @@ public class UltimateEnchantingSystem implements Listener {
         if (event.getClickedBlock().getType() == Material.ENCHANTING_TABLE &&
                 event.getAction() == Action.RIGHT_CLICK_BLOCK) {
             event.setCancelled(true);
-            openUltimateEnchantmentGUI(event.getPlayer());
+            event.getPlayer().sendMessage(ChatColor.RED + "Ultimate enchantments are applied with smithing items.");
         }
     }
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/corpses/CorpseDeathEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/corpses/CorpseDeathEvent.java
@@ -6,6 +6,7 @@ import goat.minecraft.minecraftnew.subsystems.gravedigging.CorpseKillManager;
 import goat.minecraft.minecraftnew.subsystems.pets.PetRegistry;
 import org.bukkit.entity.Player;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
 import net.citizensnpcs.api.npc.NPC;
 import org.bukkit.Bukkit;
 import org.bukkit.Particle;
@@ -57,6 +58,10 @@ public class CorpseDeathEvent implements Listener {
                 };
                 int terraXP = 200 * tier;
                 xpManager.addXP(killer, "Terraforming", terraXP);
+            }
+
+            if (corpse.getRarity() == Rarity.LEGENDARY && Math.random() < 0.04) {
+                event.getDrops().add(ItemRegistry.getRandomUltimateSmithingItem());
             }
         });
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
@@ -1006,6 +1006,30 @@ public class AnvilRepair implements Listener {
             CustomEnchantmentManager.addEnchantment(player, billItem, repairee, "Water Aspect", CustomEnchantmentManager.getEnchantmentLevel(repairee, "Water Aspect") +1);
             player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
             return;
+        }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "The Law of Gravity") && TOOLS.contains(repairee.getType())){
+            CustomEnchantmentManager.addUltimateEnchantment(player, billItem, repairee, "Ultimate: Treecapitator", 1);
+            player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
+            return;
+        }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Unstoppable vs Immovable") && TOOLS.contains(repairee.getType())){
+            CustomEnchantmentManager.addUltimateEnchantment(player, billItem, repairee, "Ultimate: Hammer", 1);
+            player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
+            return;
+        }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Draupnir") && MELEE.contains(repairee.getType())){
+            CustomEnchantmentManager.addUltimateEnchantment(player, billItem, repairee, "Ultimate: Shred", 1);
+            player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
+            return;
+        }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Quantum Physics") && MELEE.contains(repairee.getType())){
+            CustomEnchantmentManager.addUltimateEnchantment(player, billItem, repairee, "Ultimate: Warp", 1);
+            player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
+            return;
+        }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Evisceration") && isShovel(repairee)){
+            CustomEnchantmentManager.addUltimateEnchantment(player, billItem, repairee, "Ultimate: Mulch", 1);
+            player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
+            return;
+        }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Revenant") && MELEE.contains(repairee.getType())){
+            CustomEnchantmentManager.addUltimateEnchantment(player, billItem, repairee, "Ultimate: Loyal", 1);
+            player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
+            return;
         }
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -227,6 +227,8 @@ public class VillagerTradeManager implements Listener {
         weaponsmithPurchases.add(createTradeMap("WEAPONSMITH_ENCHANT", 1, 64, 4)); // ItemRegistry.getWeaponsmithEnchant()
         weaponsmithPurchases.add(createTradeMap("LEGENDARY_SWORD_REFORGE", 1, 512, 5)); // ItemRegistry.getLegendarySwordReforge()
         weaponsmithPurchases.add(createTradeMap("BLUE_LANTERN", 1, 512, 5)); // Custom Item
+        weaponsmithPurchases.add(createTradeMap("REVENANT", 1, 256, 5));
+        weaponsmithPurchases.add(createTradeMap("DRAUPNIR", 1, 256, 5));
         defaultConfig.set("WEAPONSMITH.purchases", weaponsmithPurchases);
 
         List<Map<String, Object>> weaponsmithSells = new ArrayList<>();
@@ -273,6 +275,7 @@ public class VillagerTradeManager implements Listener {
         fletcherPurchases.add(createTradeMap("FLETCHER_POWER", 1, 64, 4)); // Custom item
         fletcherPurchases.add(createTradeMap("DARK_OAK_BOW", 1, 128*2, 5)); // Custom item
         fletcherPurchases.add(createTradeMap("FLETCHER_CROSSBOW_ENCHANT", 1, 32, 5)); // Custom item
+        fletcherPurchases.add(createTradeMap("THE_LAW_OF_GRAVITY", 1, 256, 5));
         defaultConfig.set("FLETCHER.purchases", fletcherPurchases);
 
         List<Map<String, Object>> fletcherSells = new ArrayList<>();
@@ -306,6 +309,7 @@ public class VillagerTradeManager implements Listener {
         cartographerPurchases.add(createTradeMap("CARTOGRAPHER_BASTION_REMNANT", 1, 64, 4)); // Custom item
 
         cartographerPurchases.add(createTradeMap("CARTOGRAPHER_WOODLAND_MANSION", 1, 128, 5)); // Custom item
+        cartographerPurchases.add(createTradeMap("QUANTUM_PHYSICS", 1, 256, 5));
         defaultConfig.set("CARTOGRAPHER.purchases", cartographerPurchases);
 
 // Cartographer Sells
@@ -447,6 +451,8 @@ public class VillagerTradeManager implements Listener {
         toolsmithPurchases.add(createTradeMap("REDSTONE_GEMSTONE", 1, 128, 5)); // Custom Item
         toolsmithPurchases.add(createTradeMap("JACKHAMMER", 1, 32, 3)); // Custom Item
         toolsmithPurchases.add(createTradeMap("COMPOSTER_ENCHANT", 1, 32, 3)); // Custom Item
+        toolsmithPurchases.add(createTradeMap("EVISCERATION", 1, 256, 5));
+        toolsmithPurchases.add(createTradeMap("UNSTOPPABLE_VS_IMMOVABLE", 1, 256, 5));
 
         defaultConfig.set("TOOLSMITH.purchases", toolsmithPurchases);
 
@@ -1077,6 +1083,18 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getInfernalSharpness();
             case "WARP_GATE":
                 return ItemRegistry.getWarpGate();
+            case "THE_LAW_OF_GRAVITY":
+                return ItemRegistry.getLawOfGravity();
+            case "UNSTOPPABLE_VS_IMMOVABLE":
+                return ItemRegistry.getUnstoppableVsImmovable();
+            case "DRAUPNIR":
+                return ItemRegistry.getDraupnir();
+            case "QUANTUM_PHYSICS":
+                return ItemRegistry.getQuantumPhysics();
+            case "EVISCERATION":
+                return ItemRegistry.getEvisceration();
+            case "REVENANT":
+                return ItemRegistry.getRevenant();
             default:
                 plugin.getLogger().warning("Unknown custom item ID: " + identifier);
                 return null;

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -897,6 +897,78 @@ public class ItemRegistry {
                 ), 1, false, true);
     }
 
+    public static ItemStack getLawOfGravity() {
+        return createCustomItem(
+                Material.ANVIL,
+                ChatColor.YELLOW + "The Law of Gravity",
+                Arrays.asList(
+                        ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Applies Treecapitator.",
+                        ChatColor.DARK_PURPLE + "Smithing Item"
+                ), 1, false, true);
+    }
+
+    public static ItemStack getUnstoppableVsImmovable() {
+        return createCustomItem(
+                Material.IRON_BLOCK,
+                ChatColor.YELLOW + "Unstoppable vs Immovable",
+                Arrays.asList(
+                        ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Applies Hammer.",
+                        ChatColor.DARK_PURPLE + "Smithing Item"
+                ), 1, false, true);
+    }
+
+    public static ItemStack getDraupnir() {
+        return createCustomItem(
+                Material.GOLD_NUGGET,
+                ChatColor.YELLOW + "Draupnir",
+                Arrays.asList(
+                        ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Applies Shred.",
+                        ChatColor.DARK_PURPLE + "Smithing Item"
+                ), 1, false, true);
+    }
+
+    public static ItemStack getQuantumPhysics() {
+        return createCustomItem(
+                Material.ENDER_PEARL,
+                ChatColor.YELLOW + "Quantum Physics",
+                Arrays.asList(
+                        ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Applies Warp.",
+                        ChatColor.DARK_PURPLE + "Smithing Item"
+                ), 1, false, true);
+    }
+
+    public static ItemStack getEvisceration() {
+        return createCustomItem(
+                Material.FLINT,
+                ChatColor.YELLOW + "Evisceration",
+                Arrays.asList(
+                        ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Applies Mulch.",
+                        ChatColor.DARK_PURPLE + "Smithing Item"
+                ), 1, false, true);
+    }
+
+    public static ItemStack getRevenant() {
+        return createCustomItem(
+                Material.ROTTEN_FLESH,
+                ChatColor.YELLOW + "Revenant",
+                Arrays.asList(
+                        ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Applies Loyal.",
+                        ChatColor.DARK_PURPLE + "Smithing Item"
+                ), 1, false, true);
+    }
+
+    public static ItemStack getRandomUltimateSmithingItem() {
+        ItemStack[] items = {
+                getLawOfGravity(),
+                getUnstoppableVsImmovable(),
+                getDraupnir(),
+                getQuantumPhysics(),
+                getEvisceration(),
+                getRevenant()
+        };
+        return items[new java.util.Random().nextInt(items.length)];
+    }
+
 
 
     public static ItemStack getExperienceArtifact() {


### PR DESCRIPTION
## Summary
- add smithing items for ultimate enchantments
- allow legendary corpses to drop random ultimate smithing items
- add trades for new smithing items to villager purchases
- disable ultimate enchantment GUI in favour of smithing items
- allow anvils to apply the new ultimate smithing items

## Testing
- `mvn -q test` *(fails: Plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6872078a1cc08332b0aa206bbf4e1c46