### PR TITLE
Add Enchanted Clock & Hopper trinkets

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -64,6 +64,8 @@ import goat.minecraft.minecraftnew.other.trinkets.CulinaryPouchManager;
 import goat.minecraft.minecraftnew.other.trinkets.MiningPouchManager;
 import goat.minecraft.minecraftnew.other.trinkets.TransfigurationPouchManager;
 import goat.minecraft.minecraftnew.other.trinkets.LavaBucketManager;
+import goat.minecraft.minecraftnew.other.trinkets.EnchantedClockManager;
+import goat.minecraft.minecraftnew.other.trinkets.EnchantedHopperManager;
 import goat.minecraft.minecraftnew.other.trinkets.TrinketManager;
 import goat.minecraft.minecraftnew.other.auras.AuraManager;
 import goat.minecraft.minecraftnew.other.armorsets.FlowManager;
@@ -357,6 +359,8 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         MiningPouchManager.init(this);
         TransfigurationPouchManager.init(this);
         LavaBucketManager.init(this);
+        EnchantedClockManager.init(this);
+        EnchantedHopperManager.init(this);
         TrinketManager.init(this);
         StructureBlockManager.init(this);
         //getServer().getPluginManager().registerEvents(new GamblingTable(this), this);

--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/CustomBundleGUI.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/CustomBundleGUI.java
@@ -609,4 +609,30 @@ public class CustomBundleGUI implements Listener {
             e.printStackTrace();
         }
     }
+
+    /**
+     * Retrieves an item from the player's stored backpack at the given slot.
+     */
+    public ItemStack getBackpackItem(Player player, int slot) {
+        String path = player.getUniqueId() + "." + slot;
+        if (!storageConfig.contains(path)) return null;
+        return storageConfig.getItemStack(path);
+    }
+
+    /**
+     * Sets an item in the player's stored backpack at the given slot.
+     */
+    public void setBackpackItem(Player player, int slot, ItemStack item) {
+        String path = player.getUniqueId() + "." + slot;
+        if (item == null) {
+            storageConfig.set(path, null);
+        } else {
+            storageConfig.set(path, item);
+        }
+        try {
+            storageConfig.save(storageFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/EnchantedClockManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/EnchantedClockManager.java
@@ -1,0 +1,105 @@
+package goat.minecraft.minecraftnew.other.trinkets;
+
+import goat.minecraft.minecraftnew.other.additionalfunctionality.CustomBundleGUI;
+import goat.minecraft.minecraftnew.other.trinkets.BankAccountManager;
+import goat.minecraft.minecraftnew.other.trinkets.PotionPouchManager;
+import goat.minecraft.minecraftnew.other.trinkets.CulinaryPouchManager;
+import goat.minecraft.minecraftnew.other.trinkets.MiningPouchManager;
+import goat.minecraft.minecraftnew.other.trinkets.TransfigurationPouchManager;
+import goat.minecraft.minecraftnew.other.trinkets.SeedPouchManager;
+import goat.minecraft.minecraftnew.other.trinkets.TrinketManager;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+/**
+ * Handles the automated behaviour of the Enchanted Clock trinket. Every three
+ * minutes the clock will trigger the left click functionality of the trinket
+ * located directly above it in the player's backpack storage.
+ */
+public class EnchantedClockManager {
+    private static EnchantedClockManager instance;
+    private final JavaPlugin plugin;
+
+    private EnchantedClockManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        startTask();
+    }
+
+    public static void init(JavaPlugin plugin) {
+        if (instance == null) {
+            instance = new EnchantedClockManager(plugin);
+        }
+    }
+
+    public static EnchantedClockManager getInstance() {
+        return instance;
+    }
+
+    private void startTask() {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                for (Player player : Bukkit.getOnlinePlayers()) {
+                    processPlayer(player);
+                }
+            }
+        }.runTaskTimer(plugin, 20L * 60 * 3, 20L * 60 * 3);
+    }
+
+    private void processPlayer(Player player) {
+        for (int slot = 9; slot < 54; slot++) {
+            ItemStack item = CustomBundleGUI.getInstance().getBackpackItem(player, slot);
+            if (item == null) continue;
+            ItemMeta meta = item.getItemMeta();
+            if (meta == null || !meta.hasDisplayName()) continue;
+            String name = ChatColor.stripColor(meta.getDisplayName());
+            if (!name.equals("Enchanted Clock")) continue;
+            ItemStack above = CustomBundleGUI.getInstance().getBackpackItem(player, slot - 9);
+            if (above == null) continue;
+            triggerLeftClick(player, above);
+        }
+    }
+
+    private void triggerLeftClick(Player player, ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null || !meta.hasDisplayName()) return;
+        String name = ChatColor.stripColor(meta.getDisplayName());
+        switch (name) {
+            case "Bank Account" -> {
+                int deposited = BankAccountManager.getInstance().depositAll(player);
+                TrinketManager.getInstance().refreshBankLore(player);
+                if (deposited > 0) {
+                    player.sendMessage(ChatColor.GREEN + "Deposited " + deposited + " emeralds.");
+                }
+            }
+            case "Pouch of Potions" -> {
+                PotionPouchManager.getInstance().depositPotions(player);
+                TrinketManager.getInstance().refreshPotionPouchLore(player);
+            }
+            case "Pouch of Culinary Delights" -> {
+                CulinaryPouchManager.getInstance().depositDelights(player);
+                TrinketManager.getInstance().refreshCulinaryPouchLore(player);
+            }
+            case "Mining Pouch" -> {
+                MiningPouchManager.getInstance().depositOres(player);
+                TrinketManager.getInstance().refreshMiningPouchLore(player);
+            }
+            case "Transfiguration Pouch" -> {
+                TransfigurationPouchManager.getInstance().depositItems(player);
+                TrinketManager.getInstance().refreshTransfigurationPouchLore(player);
+            }
+            case "Pouch of Seeds" -> {
+                SeedPouchManager.getInstance().depositSeeds(player);
+                TrinketManager.getInstance().refreshPouchLore(player);
+            }
+            default -> {
+                // do nothing for other trinkets
+            }
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/EnchantedHopperManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/EnchantedHopperManager.java
@@ -1,0 +1,225 @@
+package goat.minecraft.minecraftnew.other.trinkets;
+
+import goat.minecraft.minecraftnew.other.additionalfunctionality.CustomBundleGUI;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.block.ShulkerBox;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BlockStateMeta;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.NamespacedKey;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Handles Enchanted Hopper trinkets. Items placed inside the hopper GUI act as a
+ * whitelist. Matching items from the player's inventory are periodically moved
+ * to the container directly above the hopper in the backpack.
+ */
+public class EnchantedHopperManager implements Listener {
+    private static EnchantedHopperManager instance;
+    private final JavaPlugin plugin;
+    private final NamespacedKey idKey;
+    private File hopperFile;
+    private FileConfiguration hopperConfig;
+    private final Map<UUID, UUID> openHoppers = new HashMap<>();
+
+    private EnchantedHopperManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        idKey = new NamespacedKey(plugin, "hopper_id");
+        initFile();
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+        startTask();
+    }
+
+    public static void init(JavaPlugin plugin) {
+        if (instance == null) {
+            instance = new EnchantedHopperManager(plugin);
+        }
+    }
+
+    public static EnchantedHopperManager getInstance() {
+        return instance;
+    }
+
+    private void initFile() {
+        hopperFile = new File(plugin.getDataFolder(), "enchanted_hoppers.yml");
+        if (!hopperFile.exists()) {
+            try {
+                plugin.getDataFolder().mkdirs();
+                hopperFile.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        hopperConfig = YamlConfiguration.loadConfiguration(hopperFile);
+    }
+
+    private void save() {
+        try {
+            hopperConfig.save(hopperFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void openHopper(Player player, ItemStack hopperItem) {
+        UUID id = getOrCreateId(hopperItem);
+        Inventory inv = Bukkit.createInventory(null, 9, "Enchanted Hopper");
+        String base = id.toString();
+        for (int i = 0; i < 9; i++) {
+            ItemStack stack = hopperConfig.getItemStack(base + "." + i);
+            if (stack != null) {
+                inv.setItem(i, stack);
+            }
+        }
+        openHoppers.put(player.getUniqueId(), id);
+        player.openInventory(inv);
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (!event.getView().getTitle().equals("Enchanted Hopper")) return;
+        Player player = (Player) event.getPlayer();
+        UUID id = openHoppers.remove(player.getUniqueId());
+        if (id == null) return;
+        String base = id.toString();
+        Inventory inv = event.getInventory();
+        for (int i = 0; i < 9; i++) {
+            ItemStack stack = inv.getItem(i);
+            if (stack != null && stack.getType() != Material.AIR) {
+                hopperConfig.set(base + "." + i, stack);
+            } else {
+                hopperConfig.set(base + "." + i, null);
+            }
+        }
+        save();
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!event.getView().getTitle().equals("Enchanted Hopper")) return;
+        if (event.getClickedInventory() == null || event.getClickedInventory() != event.getInventory()) return;
+        event.setCancelled(false);
+    }
+
+    private UUID getOrCreateId(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return UUID.randomUUID();
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        String existing = container.get(idKey, PersistentDataType.STRING);
+        if (existing != null) {
+            return UUID.fromString(existing);
+        }
+        UUID id = UUID.randomUUID();
+        container.set(idKey, PersistentDataType.STRING, id.toString());
+        item.setItemMeta(meta);
+        return id;
+    }
+
+    private List<ItemStack> getWhitelist(UUID id) {
+        List<ItemStack> list = new ArrayList<>();
+        String base = id.toString();
+        for (int i = 0; i < 9; i++) {
+            ItemStack stack = hopperConfig.getItemStack(base + "." + i);
+            if (stack != null) {
+                list.add(stack);
+            }
+        }
+        return list;
+    }
+
+    private void startTask() {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                for (Player player : Bukkit.getOnlinePlayers()) {
+                    processPlayer(player);
+                }
+            }
+        }.runTaskTimer(plugin, 20L, 20L);
+    }
+
+    private void processPlayer(Player player) {
+        for (int slot = 9; slot < 54; slot++) {
+            ItemStack item = CustomBundleGUI.getInstance().getBackpackItem(player, slot);
+            if (item == null) continue;
+            ItemMeta meta = item.getItemMeta();
+            if (meta == null || !meta.hasDisplayName()) continue;
+            String name = ChatColor.stripColor(meta.getDisplayName());
+            if (!name.equals("Enchanted Hopper")) continue;
+            UUID id = getOrCreateId(item);
+            ItemStack containerItem = CustomBundleGUI.getInstance().getBackpackItem(player, slot - 9);
+            if (containerItem == null) continue;
+            transferItems(player, containerItem, getWhitelist(id));
+            CustomBundleGUI.getInstance().setBackpackItem(player, slot - 9, containerItem);
+            CustomBundleGUI.getInstance().setBackpackItem(player, slot, item);
+        }
+    }
+
+    private void transferItems(Player player, ItemStack containerItem, List<ItemStack> whitelist) {
+        if (whitelist.isEmpty()) return;
+        for (ItemStack filter : whitelist) {
+            for (ItemStack invItem : player.getInventory().getContents()) {
+                if (invItem == null || invItem.getType() == Material.AIR) continue;
+                if (matches(filter, invItem)) {
+                    moveOne(containerItem, invItem, player);
+                }
+            }
+        }
+    }
+
+    private boolean matches(ItemStack filter, ItemStack candidate) {
+        if (filter.getType() != candidate.getType()) return false;
+        if (filter.hasItemMeta() != candidate.hasItemMeta()) return false;
+        if (filter.hasItemMeta()) {
+            ItemMeta fMeta = filter.getItemMeta();
+            ItemMeta cMeta = candidate.getItemMeta();
+            if (fMeta.hasDisplayName() != cMeta.hasDisplayName()) return false;
+            if (fMeta.hasDisplayName() && !fMeta.getDisplayName().equals(cMeta.getDisplayName())) return false;
+            if (fMeta.hasEnchants() != cMeta.hasEnchants()) return false;
+        }
+        return true;
+    }
+
+    private void moveOne(ItemStack containerItem, ItemStack fromInv, Player player) {
+        if (fromInv.getAmount() <= 0) return;
+        ItemStack toMove = new ItemStack(fromInv.getType(), 1);
+        if (fromInv.hasItemMeta()) {
+            toMove.setItemMeta(fromInv.getItemMeta());
+        }
+        boolean success = false;
+        ItemMeta meta = containerItem.getItemMeta();
+        if (meta instanceof BlockStateMeta bsm && bsm.getBlockState() instanceof ShulkerBox box) {
+            success = box.getInventory().addItem(toMove).isEmpty();
+            bsm.setBlockState(box);
+            containerItem.setItemMeta(bsm);
+        } else {
+            String name = ChatColor.stripColor(meta.getDisplayName());
+            if (name.equals("Blue Satchel") || name.equals("Black Satchel") || name.equals("Green Satchel")) {
+                SatchelManager.getInstance().depositItem(player, name.split(" ")[0], toMove);
+                success = true;
+            } else if (name.equals("Enchanted Lava Bucket")) {
+                success = true; // item simply deleted
+            }
+        }
+        if (success) {
+            fromInv.setAmount(fromInv.getAmount() - 1);
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TrinketManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TrinketManager.java
@@ -5,6 +5,7 @@ import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.other.trinkets.PotionPouchManager;
 import goat.minecraft.minecraftnew.other.trinkets.MiningPouchManager;
 import goat.minecraft.minecraftnew.other.trinkets.TransfigurationPouchManager;
+import goat.minecraft.minecraftnew.other.trinkets.EnchantedHopperManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -160,6 +161,12 @@ public class TrinketManager implements Listener {
                     event.setCancelled(true);
                 } else if (event.getClick() == ClickType.SHIFT_RIGHT) {
                     LavaBucketManager.getInstance().openTrash(player);
+                    event.setCancelled(true);
+                }
+            }
+            case "Enchanted Hopper" -> {
+                if (event.getClick().isLeftClick()) {
+                    EnchantedHopperManager.getInstance().openHopper(player, item);
                     event.setCancelled(true);
                 }
             }

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -1360,6 +1360,44 @@ public class ItemRegistry {
         );
     }
 
+    /**
+     * Creates an Enchanted Clock trinket. When placed in the backpack the clock
+     * will automatically activate the left-click behaviour of the trinket
+     * directly above it every three minutes.
+     */
+    public static ItemStack getEnchantedClockTrinket() {
+        return createCustomItem(
+                Material.CLOCK,
+                ChatColor.YELLOW + "Enchanted Clock",
+                List.of(
+                        ChatColor.GRAY + "Activates the trinket above every 3 minutes",
+                        ChatColor.BLUE + "Right-click" + ChatColor.GRAY + ": Pick up"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
+    /**
+     * Creates an Enchanted Hopper trinket. Items placed inside will be
+     * periodically transferred to the container above it when kept in the
+     * backpack.
+     */
+    public static ItemStack getEnchantedHopperTrinket() {
+        return createCustomItem(
+                Material.HOPPER,
+                ChatColor.YELLOW + "Enchanted Hopper",
+                List.of(
+                        ChatColor.GRAY + "Transfers whitelisted items to container above",
+                        ChatColor.BLUE + "Right-click" + ChatColor.GRAY + ": Configure"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
     public static ItemStack getClericEnchant() {
         return createCustomItem(Material.SUGAR_CANE, ChatColor.YELLOW +
                 "Alchemical Bundle", Arrays.asList(


### PR DESCRIPTION
## Summary
- create `EnchantedClockManager` and `EnchantedHopperManager`
- add trinket items in `ItemRegistry`
- integrate new managers with `MinecraftNew`
- extend `TrinketManager` with hopper GUI behaviour
- allow backpack item access in `CustomBundleGUI`
- add satchel deposit helper method

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68756d4392748332a32a4c2dbab76574