### PR TITLE
Pause trinket automation while other inventories are open

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/EnchantedClockManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/EnchantedClockManager.java
@@ -13,6 +13,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -52,6 +53,10 @@ public class EnchantedClockManager {
     }
 
     private void processPlayer(Player player) {
+        InventoryType openType = player.getOpenInventory().getTopInventory().getType();
+        if (openType != InventoryType.CRAFTING && openType != InventoryType.CREATIVE) {
+            return; // pause while the player has any other inventory open
+        }
         for (int slot = 9; slot < 54; slot++) {
             ItemStack item = CustomBundleGUI.getInstance().getBackpackItem(player, slot);
             if (item == null) continue;

--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/EnchantedHopperManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/EnchantedHopperManager.java
@@ -10,6 +10,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BlockStateMeta;
@@ -156,6 +157,10 @@ public class EnchantedHopperManager implements Listener {
     }
 
     private void processPlayer(Player player) {
+        InventoryType openType = player.getOpenInventory().getTopInventory().getType();
+        if (openType != InventoryType.CRAFTING && openType != InventoryType.CREATIVE) {
+            return; // pause automation when a container is open
+        }
         for (int slot = 9; slot < 54; slot++) {
             ItemStack item = CustomBundleGUI.getInstance().getBackpackItem(player, slot);
             if (item == null) continue;


### PR DESCRIPTION
## Summary
- stop Enchanted Clock automation when any container GUI is open
- stop Enchanted Hopper automation when any container GUI is open

## Testing
- `mvn -q package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_68757728bf5c83328a5d8b149260d6a0