### PR TITLE
Implement Brewing skill tree prototype

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -54,6 +54,8 @@ import goat.minecraft.minecraftnew.utils.commands.MeritCommand;
 import goat.minecraft.minecraftnew.utils.commands.SkillsCommand;
 import goat.minecraft.minecraftnew.utils.commands.AuraCommand;
 import goat.minecraft.minecraftnew.utils.developercommands.*;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.utils.developercommands.AddTalentPointCommand;
 import goat.minecraft.minecraftnew.utils.devtools.*;
 import goat.minecraft.minecraftnew.utils.dimensions.end.BetterEnd;
 import goat.minecraft.minecraftnew.other.trinkets.BankAccountManager;
@@ -515,6 +517,9 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         this.getCommand("loadsubsystems").setExecutor(new LoadSubsystemsCommand(this));
         this.getCommand("skills").setExecutor(new SkillsCommand(xpManager));
         new SetSkillLevelCommand(this, xpManager);
+
+        SkillTreeManager.init(this);
+        new AddTalentPointCommand(this, SkillTreeManager.getInstance());
 
         getCommand("getpet").setExecutor(new PetCommand(petManager));
         getServer().getPluginManager().registerEvents(new FishingEvent(), MinecraftNew.getInstance());

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Skill.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Skill.java
@@ -1,0 +1,24 @@
+package goat.minecraft.minecraftnew.other.skilltree;
+
+public enum Skill {
+    BREWING("Brewing");
+
+    private final String displayName;
+
+    Skill(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public static Skill fromDisplay(String name) {
+        for (Skill s : values()) {
+            if (s.displayName.equalsIgnoreCase(name)) {
+                return s;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -1,0 +1,284 @@
+package goat.minecraft.minecraftnew.other.skilltree;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class SkillTreeManager implements Listener {
+    private static SkillTreeManager instance;
+    private final JavaPlugin plugin;
+    private File dataFile;
+    private FileConfiguration dataConfig;
+    private final Map<Skill, List<Talent>> skillTalents = new HashMap<>();
+
+    private final Talent redstoneTalent = new Talent(
+            "Redstone",
+            "Adds 4s to potions you drink per level.",
+            25,
+            1,
+            Material.REDSTONE
+    );
+
+    public static void init(JavaPlugin plugin) {
+        if (instance == null) {
+            instance = new SkillTreeManager(plugin);
+            Bukkit.getPluginManager().registerEvents(instance, plugin);
+        }
+    }
+
+    public static SkillTreeManager getInstance() {
+        return instance;
+    }
+
+    private SkillTreeManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        initStorage();
+        loadTalents();
+    }
+
+    private void initStorage() {
+        dataFile = new File(plugin.getDataFolder(), "skill_talents.yml");
+        if (!dataFile.exists()) {
+            try {
+                dataFile.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        dataConfig = YamlConfiguration.loadConfiguration(dataFile);
+    }
+
+    private void saveConfig() {
+        try {
+            dataConfig.save(dataFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void loadTalents() {
+        skillTalents.put(Skill.BREWING, Collections.singletonList(redstoneTalent));
+    }
+
+    // =============================================================
+    // Public API
+    // =============================================================
+
+    public void openSkillTree(Player player, Skill skill) {
+        openSkillTree(player, skill, 1);
+    }
+
+    private void openSkillTree(Player player, Skill skill, int page) {
+        List<Talent> talents = skillTalents.getOrDefault(skill, Collections.emptyList());
+        int totalPages = (int) Math.ceil(talents.size() / 40.0);
+        if (totalPages == 0) totalPages = 1;
+        if (page < 1) page = 1;
+        if (page > totalPages) page = totalPages;
+
+        Inventory gui = Bukkit.createInventory(null, 54,
+                ChatColor.DARK_GREEN + skill.getDisplayName() + " Skill Tree: Page " + page + "/" + totalPages);
+
+        ItemStack pane = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
+        ItemMeta pm = pane.getItemMeta();
+        pm.setDisplayName(ChatColor.BLACK + "");
+        pane.setItemMeta(pm);
+
+        for (int i = 0; i < 9; i++) {
+            gui.setItem(i, pane.clone());
+        }
+        for (int row = 0; row < 5; row++) {
+            gui.setItem(9 + row * 9, pane.clone());
+        }
+
+        if (page > 1) {
+            ItemStack prev = new ItemStack(Material.ARROW);
+            ItemMeta meta = prev.getItemMeta();
+            meta.setDisplayName(ChatColor.YELLOW + "Previous Page");
+            prev.setItemMeta(meta);
+            gui.setItem(0, prev);
+        }
+
+        if (page < totalPages) {
+            ItemStack next = new ItemStack(Material.ARROW);
+            ItemMeta meta = next.getItemMeta();
+            meta.setDisplayName(ChatColor.YELLOW + "Next Page");
+            next.setItemMeta(meta);
+            gui.setItem(8, next);
+        }
+
+        ItemStack points = new ItemStack(Material.DIAMOND);
+        ItemMeta dmeta = points.getItemMeta();
+        dmeta.setDisplayName(ChatColor.AQUA + "Talent Points: " + getAvailableTalentPoints(player, skill));
+        points.setItemMeta(dmeta);
+        gui.setItem(4, points);
+
+        int startIndex = (page - 1) * 40;
+        int endIndex = Math.min(talents.size(), startIndex + 40);
+        int slotIndex = 9;
+        for (int i = startIndex; i < endIndex; i++) {
+            Talent talent = talents.get(i);
+            if (slotIndex % 9 == 0) slotIndex++;
+            if (slotIndex >= 54) break;
+
+            int currentLevel = getTalentLevel(player.getUniqueId(), skill, talent);
+            ItemStack item = new ItemStack(talent.getIcon());
+            ItemMeta im = item.getItemMeta();
+            im.setDisplayName(talent.getRarity().getColor() + talent.getName());
+            List<String> lore = new ArrayList<>();
+            lore.add(ChatColor.GRAY + talent.getDescription());
+            lore.add(ChatColor.YELLOW + "Level: " + currentLevel + "/" + talent.getMaxLevel());
+            lore.add(ChatColor.GRAY + "Requires " + skill.getDisplayName() + " " + talent.getLevelRequirement());
+            im.setLore(lore);
+            if (currentLevel > 0) {
+                im.addEnchant(org.bukkit.enchantments.Enchantment.UNBREAKING, 1, true);
+                im.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            }
+            item.setItemMeta(im);
+            gui.setItem(slotIndex, item);
+            slotIndex++;
+        }
+
+        for (int i = 0; i < gui.getSize(); i++) {
+            if (gui.getItem(i) == null) {
+                gui.setItem(i, pane.clone());
+            }
+        }
+
+        player.openInventory(gui);
+    }
+
+    public int getAvailableTalentPoints(Player player, Skill skill) {
+        XPManager xp = MinecraftNew.getInstance().getXPManager();
+        int levelPoints = xp.getPlayerLevel(player, skill.getDisplayName());
+        int extra = dataConfig.getInt(player.getUniqueId() + "." + skill + ".extra_points", 0);
+        int spent = skillTalents.getOrDefault(skill, Collections.emptyList()).stream()
+                .mapToInt(t -> getTalentLevel(player.getUniqueId(), skill, t)).sum();
+        return levelPoints + extra - spent;
+    }
+
+    public int getTalentLevel(UUID uuid, Skill skill, Talent talent) {
+        return dataConfig.getInt(uuid + "." + skill + ".talents." + talent.getName(), 0);
+    }
+
+    public boolean hasTalent(Player player, Talent talent) {
+        return getTalentLevel(player.getUniqueId(), Skill.BREWING, talent) > 0;
+    }
+
+    private void setTalentLevel(UUID uuid, Skill skill, Talent talent, int level) {
+        dataConfig.set(uuid + "." + skill + ".talents." + talent.getName(), level);
+        saveConfig();
+    }
+
+    public void addExtraTalentPoints(UUID uuid, Skill skill, int amount) {
+        int current = dataConfig.getInt(uuid + "." + skill + ".extra_points", 0);
+        dataConfig.set(uuid + "." + skill + ".extra_points", current + amount);
+        saveConfig();
+    }
+
+    // =============================================================
+    // Event Handling
+    // =============================================================
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        String raw = ChatColor.stripColor(event.getView().getTitle());
+        if (!raw.endsWith("Skill Tree") && !raw.contains("Skill Tree: Page")) return;
+        event.setCancelled(true);
+        Player player = (Player) event.getWhoClicked();
+        Skill skill = Skill.BREWING; // only one supported for now
+        int page = 1;
+        if (raw.contains("Page")) {
+            try {
+                String pagePart = raw.substring(raw.indexOf("Page") + 5);
+                page = Integer.parseInt(pagePart.split("/")[0]);
+            } catch (Exception ignored) {}
+        }
+
+        ItemStack clicked = event.getCurrentItem();
+        if (clicked == null || clicked.getType() == Material.AIR || !clicked.hasItemMeta()) return;
+        String name = ChatColor.stripColor(clicked.getItemMeta().getDisplayName());
+        if (name.equalsIgnoreCase("Next Page")) {
+            openSkillTree(player, skill, page + 1);
+            return;
+        }
+        if (name.equalsIgnoreCase("Previous Page")) {
+            openSkillTree(player, skill, page - 1);
+            return;
+        }
+        Talent talent = skillTalents.get(skill).stream()
+                .filter(t -> t.getName().equalsIgnoreCase(name))
+                .findFirst().orElse(null);
+        if (talent == null) return;
+
+        int playerLevel = MinecraftNew.getInstance().getXPManager().getPlayerLevel(player, skill.getDisplayName());
+        int currentLevel = getTalentLevel(player.getUniqueId(), skill, talent);
+        if (playerLevel < talent.getLevelRequirement()) {
+            player.sendMessage(ChatColor.RED + "Requires " + skill.getDisplayName() + " " + talent.getLevelRequirement());
+            return;
+        }
+        if (currentLevel >= talent.getMaxLevel()) {
+            player.sendMessage(ChatColor.RED + "Talent already maxed.");
+            return;
+        }
+        if (getAvailableTalentPoints(player, skill) <= 0) {
+            player.sendMessage(ChatColor.RED + "No talent points available.");
+            return;
+        }
+        setTalentLevel(player.getUniqueId(), skill, talent, currentLevel + 1);
+        player.sendMessage(ChatColor.GREEN + "Upgraded " + talent.getName() + " to " + (currentLevel + 1));
+        openSkillTree(player, skill, page);
+    }
+
+    @EventHandler
+    public void onPotionDrink(PlayerItemConsumeEvent event) {
+        ItemStack item = event.getItem();
+        if (item == null) return;
+        Material type = item.getType();
+        if (type != Material.POTION && type != Material.SPLASH_POTION && type != Material.LINGERING_POTION) return;
+        Player player = event.getPlayer();
+        int redstoneLevel = getTalentLevel(player.getUniqueId(), Skill.BREWING, redstoneTalent);
+        if (redstoneLevel <= 0) return;
+        Set<PotionEffectType> before = player.getActivePotionEffects().stream()
+                .map(PotionEffect::getType).collect(Collectors.toSet());
+        int extra = redstoneLevel * 4 * 20;
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                for (PotionEffect effect : player.getActivePotionEffects()) {
+                    if (!before.contains(effect.getType())) {
+                        player.addPotionEffect(new PotionEffect(
+                                effect.getType(),
+                                effect.getDuration() + extra,
+                                effect.getAmplifier(),
+                                effect.isAmbient(),
+                                effect.hasParticles(),
+                                effect.hasIcon()
+                        ), true);
+                    }
+                }
+            }
+        }.runTaskLater(plugin, 1L);
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -1,0 +1,31 @@
+package goat.minecraft.minecraftnew.other.skilltree;
+
+import org.bukkit.Material;
+
+public class Talent {
+    private final String name;
+    private final String description;
+    private final int maxLevel;
+    private final int levelRequirement;
+    private final Material icon;
+
+    public Talent(String name, String description, int maxLevel, int levelRequirement, Material icon) {
+        this.name = name;
+        this.description = description;
+        this.maxLevel = maxLevel;
+        this.levelRequirement = levelRequirement;
+        this.icon = icon;
+    }
+
+    public String getName() { return name; }
+
+    public String getDescription() { return description; }
+
+    public int getMaxLevel() { return maxLevel; }
+
+    public int getLevelRequirement() { return levelRequirement; }
+
+    public Material getIcon() { return icon; }
+
+    public TalentRarity getRarity() { return TalentRarity.fromRequirement(levelRequirement); }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRarity.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRarity.java
@@ -1,0 +1,29 @@
+package goat.minecraft.minecraftnew.other.skilltree;
+
+import net.md_5.bungee.api.ChatColor;
+
+public enum TalentRarity {
+    COMMON(ChatColor.WHITE),
+    UNCOMMON(ChatColor.GREEN),
+    RARE(ChatColor.BLUE),
+    EPIC(ChatColor.DARK_PURPLE),
+    LEGENDARY(ChatColor.GOLD);
+
+    private final ChatColor color;
+
+    TalentRarity(ChatColor color) {
+        this.color = color;
+    }
+
+    public ChatColor getColor() {
+        return color;
+    }
+
+    public static TalentRarity fromRequirement(int levelRequirement) {
+        if (levelRequirement < 20) return COMMON;
+        if (levelRequirement < 40) return UNCOMMON;
+        if (levelRequirement < 60) return RARE;
+        if (levelRequirement < 80) return EPIC;
+        return LEGENDARY;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/SkillsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/SkillsCommand.java
@@ -1,6 +1,8 @@
 package goat.minecraft.minecraftnew.utils.commands;
 
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -37,6 +39,19 @@ public class SkillsCommand implements CommandExecutor {
         // Check if the clicked inventory is the Skills GUI
         if (title.equals("Your Skills")) {
             event.setCancelled(true); // Prevent any interaction
+
+            ItemStack clicked = event.getCurrentItem();
+            if (clicked == null || clicked.getType() == Material.AIR || !clicked.hasItemMeta()) {
+                return;
+            }
+            String name = ChatColor.stripColor(clicked.getItemMeta().getDisplayName());
+            if (name.endsWith(" Skill")) {
+                name = name.replace(" Skill", "");
+                Skill skill = Skill.fromDisplay(name);
+                if (skill != null) {
+                    SkillTreeManager.getInstance().openSkillTree((Player) event.getWhoClicked(), skill);
+                }
+            }
         }
     }
 

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/AddTalentPointCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/AddTalentPointCommand.java
@@ -1,0 +1,61 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class AddTalentPointCommand implements CommandExecutor {
+    private final JavaPlugin plugin;
+    private final SkillTreeManager manager;
+
+    public AddTalentPointCommand(JavaPlugin plugin, SkillTreeManager manager) {
+        this.plugin = plugin;
+        this.manager = manager;
+        plugin.getCommand("addtalentpoint").setExecutor(this);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("continuity.admin")) {
+            sender.sendMessage(ChatColor.RED + "You do not have permission to use this command.");
+            return true;
+        }
+        if (args.length != 3) {
+            sender.sendMessage(ChatColor.RED + "Usage: /addTalentPoint <player> <skill> <amount>");
+            return true;
+        }
+        OfflinePlayer target = Bukkit.getOfflinePlayer(args[0]);
+        if (target == null) {
+            sender.sendMessage(ChatColor.RED + "Player not found.");
+            return true;
+        }
+        Skill skill = Skill.fromDisplay(args[1]);
+        if (skill == null) {
+            sender.sendMessage(ChatColor.RED + "Unknown skill.");
+            return true;
+        }
+        int amount;
+        try {
+            amount = Integer.parseInt(args[2]);
+        } catch (NumberFormatException e) {
+            sender.sendMessage(ChatColor.RED + "Amount must be a number.");
+            return true;
+        }
+        manager.addExtraTalentPoints(target.getUniqueId(), skill, amount);
+        sender.sendMessage(ChatColor.GREEN + "Added " + amount + " talent points to " + target.getName());
+        if (target.isOnline()) {
+            Player p = target.getPlayer();
+            if (p != null) {
+                p.sendMessage(ChatColor.GREEN + "You received " + amount + " talent points for " + skill.getDisplayName());
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -159,6 +159,10 @@ commands:
     description: Sets a player's skill level
     usage: /setskilllevel <player> <skill> <level>
     permission: continuity.admin
+  addtalentpoint:
+    description: Gives talent points to a player
+    usage: /addTalentPoint <player> <skill> <amount>
+    permission: continuity.admin
   grantLegacyTaming:
     description: Grants Taming XP based on existing pets
     usage: /grantLegacyTaming <player>


### PR DESCRIPTION
## Summary
- add new skill tree architecture
- prototype Brewing skill tree with Redstone talent
- allow admins to grant talent points via `/addTalentPoint`
- open skill tree from Skills menu

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6875a641bb4c8332b1dfdce0a3172f29