### PR TITLE
Add Talent registry enum

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -2,14 +2,27 @@ package goat.minecraft.minecraftnew.other.skilltree;
 
 import org.bukkit.Material;
 
-public class Talent {
+/**
+ * Enumeration of all available talents in the plugin.  This acts as a
+ * registry so other classes can easily reference a specific talent by
+ * using <code>Talent.REDSTONE</code> for example.
+ */
+public enum Talent {
+    REDSTONE(
+            "Redstone",
+            "Adds 4s to potions you drink per level.",
+            25,
+            1,
+            Material.REDSTONE
+    );
+
     private final String name;
     private final String description;
     private final int maxLevel;
     private final int levelRequirement;
     private final Material icon;
 
-    public Talent(String name, String description, int maxLevel, int levelRequirement, Material icon) {
+    Talent(String name, String description, int maxLevel, int levelRequirement, Material icon) {
         this.name = name;
         this.description = description;
         this.maxLevel = maxLevel;
@@ -17,15 +30,27 @@ public class Talent {
         this.icon = icon;
     }
 
-    public String getName() { return name; }
+    public String getName() {
+        return name;
+    }
 
-    public String getDescription() { return description; }
+    public String getDescription() {
+        return description;
+    }
 
-    public int getMaxLevel() { return maxLevel; }
+    public int getMaxLevel() {
+        return maxLevel;
+    }
 
-    public int getLevelRequirement() { return levelRequirement; }
+    public int getLevelRequirement() {
+        return levelRequirement;
+    }
 
-    public Material getIcon() { return icon; }
+    public Material getIcon() {
+        return icon;
+    }
 
-    public TalentRarity getRarity() { return TalentRarity.fromRequirement(levelRequirement); }
+    public TalentRarity getRarity() {
+        return TalentRarity.fromRequirement(levelRequirement);
+    }
 }

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -1,0 +1,40 @@
+package goat.minecraft.minecraftnew.other.skilltree;
+
+import java.util.*;
+
+/**
+ * Central registry that maps {@link Skill} objects to the talents that belong
+ * to that skill.  Additional talents can be added here in the future.
+ */
+public final class TalentRegistry {
+
+    private static final Map<Skill, List<Talent>> SKILL_TALENTS = new HashMap<>();
+
+    static {
+        // Currently only the Brewing skill has talents defined.
+        SKILL_TALENTS.put(Skill.BREWING, Collections.singletonList(Talent.REDSTONE));
+    }
+
+    private TalentRegistry() {
+    }
+
+    /**
+     * Returns all talents associated with the given skill.
+     */
+    public static List<Talent> getTalents(Skill skill) {
+        return SKILL_TALENTS.getOrDefault(skill, Collections.emptyList());
+    }
+
+    /**
+     * Returns the skill associated with the given talent or {@code null} if the
+     * talent is not registered.
+     */
+    public static Skill getSkillForTalent(Talent talent) {
+        for (Map.Entry<Skill, List<Talent>> entry : SKILL_TALENTS.entrySet()) {
+            if (entry.getValue().contains(talent)) {
+                return entry.getKey();
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- convert `Talent` class into an enum
- create `TalentRegistry` to register talents per `Skill`
- update `SkillTreeManager` to use the registry and new enum
- add lookup of talent skill in `hasTalent`

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable for repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_6875b4094f04833283f6f9a07c4eb7d1