### PR TITLE
Simplify Swift Step potion effect

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
@@ -241,7 +241,7 @@ public class PotionBrewingSubsystem implements Listener {
                 new PotionRecipe("Potion of Fountains", fountainsIngredients, 60*4, new ItemStack(Material.POTION), fountainsColor, fountainsLore)
         );
         List<String> swiftStepIngredients = Arrays.asList("Glass Bottle", "Nether Wart", "Sugar", "Entropy");
-        List<String> swiftStepLore = Arrays.asList("Increases movement speed by 30%", "Base Duration of " + baseDuration);
+        List<String> swiftStepLore = Arrays.asList("Increases movement speed by 40%", "Base Duration of " + baseDuration);
         Color swiftStepColor = Color.fromRGB(150, 200, 255); // A light blue-ish color
         recipeRegistry.add(
                 new PotionRecipe("Potion of Swift Step", swiftStepIngredients, 60*30, new ItemStack(Material.POTION), swiftStepColor, swiftStepLore)

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfSwiftStep.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfSwiftStep.java
@@ -4,25 +4,19 @@ import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import org.bukkit.ChatColor;
-import org.bukkit.Material;
-import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.util.Vector;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 
 public class PotionOfSwiftStep implements Listener {
 
-    // Track whether each player was holding an item in their main hand on the previous move event.
-    // true = holding an item; false = empty.
-    private static final Map<UUID, Boolean> wasHoldingItem = new HashMap<>();
 
     /**
      * When a player drinks a Potion of Swift Step, apply the custom effect for a duration based on Brewing level.
@@ -45,40 +39,14 @@ public class PotionOfSwiftStep implements Listener {
     }
 
     /**
-     * When the effect is active and the player is sprinting with an empty main hand,
-     * add a subtle forward boost to simulate dashing.
-     * Also, play a leather-equip sound if the player transitions from holding an item to an empty hand.
+     * Grants the player a Speed II effect while the custom potion is active.
      */
     @EventHandler
     public void onPlayerMove(PlayerMoveEvent event) {
         Player player = event.getPlayer();
-        UUID uuid = player.getUniqueId();
 
-        boolean effectActive = PotionManager.isActive("Potion of Swift Step", player);
-        boolean sprinting = player.isSprinting();
-        ItemStack mainHand = player.getInventory().getItemInMainHand();
-        boolean handEmpty = (mainHand == null || mainHand.getType() == Material.AIR);
-        boolean shouldDash = effectActive && sprinting && handEmpty;
-
-        // Determine current holding state: true if player is holding something.
-        boolean currentlyHolding = !handEmpty;
-        // Default to true (assuming they start with an item in hand).
-        boolean previouslyHolding = wasHoldingItem.getOrDefault(uuid, true);
-
-        // Only play the sound when the player transitions from holding an item to an empty hand.
-        if (shouldDash && !currentlyHolding && previouslyHolding) {
-            player.getWorld().playSound(player.getLocation(), Sound.ITEM_ARMOR_EQUIP_LEATHER, 0.5f, 1.0f);
-        }
-
-        // Update the player's holding state.
-        wasHoldingItem.put(uuid, currentlyHolding);
-
-        // If conditions are met, apply the forward dash boost.
-        if (shouldDash && player.isOnGround()) {
-            Vector forward = player.getLocation().getDirection().normalize();
-            double multiplier = 0.2;  // Subtle boost multiplier.
-            Vector boost = forward.multiply(multiplier);
-            player.setVelocity(player.getVelocity().add(boost));
+        if (PotionManager.isActive("Potion of Swift Step", player)) {
+            player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 15 * 20, 1, false, false));
         }
     }
 }


### PR DESCRIPTION
## Summary
- rework `PotionOfSwiftStep` so the effect simply grants Speed II
- update potion lore to mention the 40% speed bonus

## Testing
- `mvn -q -DskipTests package` *(fails: Could not download maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6875bf4373348332b407b75e50ae8325