### PR TITLE
Add Recurve Mastery brewing talent

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -203,6 +203,9 @@ public class SkillTreeManager implements Listener {
                 int seconds = level * 4;
                 return ChatColor.YELLOW + "+" + seconds + "s " + ChatColor.LIGHT_PURPLE + "Potion Duration, "
                         + ChatColor.GOLD + "+" + seconds + "s " + ChatColor.GOLD + "Brew Time.";
+            case RECURVE_MASTERY:
+                int recurveDuration = level * 50;
+                return ChatColor.YELLOW + "+" + recurveDuration + "s " + ChatColor.LIGHT_PURPLE + "Recurve Duration";
             default:
                 return talent.getTechnicalDescription();
         }

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -40,7 +40,15 @@ public enum Talent {
             10,
                     20,
             Material.REDSTONE_BLOCK
-            );
+    ),
+    RECURVE_MASTERY(
+            "Recurve Mastery",
+            ChatColor.GRAY + "Add a Skeleton Skull",
+            ChatColor.YELLOW + "+50s " + ChatColor.LIGHT_PURPLE + "Recurve Duration",
+            4,
+            25,
+            Material.BOW
+    );
 
 
     private final String name;

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -14,7 +14,12 @@ public final class TalentRegistry {
         // Currently only the Brewing skill has talents defined.
         SKILL_TALENTS.put(
                 Skill.BREWING,
-                Arrays.asList(Talent.REDSTONE_ONE, Talent.REDSTONE_TWO, Talent.OPTIMAL_CONFIGURATION, Talent.TRIPLE_BATCH)
+                Arrays.asList(
+                        Talent.REDSTONE_ONE,
+                        Talent.REDSTONE_TWO,
+                        Talent.OPTIMAL_CONFIGURATION,
+                        Talent.TRIPLE_BATCH,
+                        Talent.RECURVE_MASTERY)
         );
     //SKILL_TALENTS.put(Skill.BREWING, Collections.singletonList(Talent.REDSTONE_TWO));
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
@@ -187,11 +187,20 @@ public class PotionBrewingSubsystem implements Listener {
         return item.getItemMeta().getDisplayName().contains("Potion Recipe");
     }
 
-    private PotionRecipe parseRecipeFromPaper(ItemStack paper) {
+    private PotionRecipe parseRecipeFromPaper(ItemStack paper, Player player) {
         String name = ChatColor.stripColor(paper.getItemMeta().getDisplayName())
                 .replace("Recipe (Potion Recipe)", "")
                 .trim();
-        return findRecipeByName(name);
+        PotionRecipe base = findRecipeByName(name);
+        if (base != null && name.equalsIgnoreCase("Potion of Recurve") &&
+                SkillTreeManager.getInstance().hasTalent(player, Talent.RECURVE_MASTERY)) {
+            java.util.List<String> ingredients = new java.util.ArrayList<>(base.getRequiredIngredients());
+            if (!ingredients.contains("Skeleton Skull")) {
+                ingredients.add("Skeleton Skull");
+            }
+            return new PotionRecipe(base.getName(), ingredients, base.getBrewTime(), base.getOutputItem(), base.getFinalColor(), base.getEffectLore());
+        }
+        return base;
     }
 
     // Candidate particles for random selection
@@ -362,7 +371,7 @@ public class PotionBrewingSubsystem implements Listener {
                 player.sendMessage(ChatColor.RED + "That is not a valid potion recipe item.");
                 return;
             }
-            PotionRecipe recipe = parseRecipeFromPaper(hand);
+            PotionRecipe recipe = parseRecipeFromPaper(hand, player);
             if (recipe == null) {
                 player.sendMessage(ChatColor.RED + "Unrecognized or invalid potion recipe item.");
                 return;

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfRecurve.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfRecurve.java
@@ -22,6 +22,10 @@ public class PotionOfRecurve implements Listener {
             int duration = (60 * 3) + (brewingLevel * 10);
             if (displayName.equals("Potion of Recurve")) {
                 Player player = event.getPlayer();
+                if(goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager.getInstance().hasTalent(player, goat.minecraft.minecraftnew.other.skilltree.Talent.RECURVE_MASTERY)) {
+                    int bonus = 50 * goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), goat.minecraft.minecraftnew.other.skilltree.Skill.BREWING, goat.minecraft.minecraftnew.other.skilltree.Talent.RECURVE_MASTERY);
+                    duration += bonus;
+                }
                 PotionManager.addCustomPotionEffect("Potion of Recurve", player, duration);
                 player.sendMessage(ChatColor.DARK_GREEN + "Potion of Recurve effect activated for " + duration + " seconds!");
                 xpManager.addXP(player, "Brewing", 100);


### PR DESCRIPTION
## Summary
- add new `RECURVE_MASTERY` talent
- register the talent with the Brewing skill
- show dynamic duration bonus in skill tree
- extend Potion of Recurve duration when talent is owned
- require Skeleton Skull in Potion of Recurve recipe if the player has the talent

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6875e134ee0c8332a98ce428d6ea5c44