### PR TITLE
Add Swift Step Mastery talent

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -85,6 +85,7 @@ import goat.minecraft.minecraftnew.other.armorsets.ThunderforgeSetBonus;
 import goat.minecraft.minecraftnew.other.armorsets.LostLegionSetBonus;
 import goat.minecraft.minecraftnew.other.armorsets.CountershotSetBonus;
 import goat.minecraft.minecraftnew.other.armorsets.StriderSetBonus;
+import goat.minecraft.minecraftnew.other.skilltree.SwiftStepMasteryBonus;
 import goat.minecraft.minecraftnew.other.structureblocks.StructureBlockManager;
 import goat.minecraft.minecraftnew.other.structureblocks.GetStructureBlockCommand;
 import goat.minecraft.minecraftnew.other.structureblocks.SetStructureBlockPowerCommand;
@@ -134,6 +135,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
     private LostLegionSetBonus lostLegionSetBonus;
     private CountershotSetBonus countershotSetBonus;
     private StriderSetBonus striderSetBonus;
+    private SwiftStepMasteryBonus swiftStepMasteryBonus;
     private RejuvenationCatalystListener rejuvenationCatalystListener;
 
 
@@ -312,6 +314,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         lostLegionSetBonus = new LostLegionSetBonus(this);
         countershotSetBonus = new CountershotSetBonus(this);
         striderSetBonus = new StriderSetBonus(this);
+        swiftStepMasteryBonus = new SwiftStepMasteryBonus(this);
         // Initialize catalyst manager for beacon charm catalysts
         CatalystManager.initialize(this);
         rejuvenationCatalystListener = new RejuvenationCatalystListener(this);
@@ -792,6 +795,9 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         }
         if (striderSetBonus != null) {
             striderSetBonus.removeAllBonuses();
+        }
+        if (swiftStepMasteryBonus != null) {
+            swiftStepMasteryBonus.removeAllBonuses();
         }
         BeaconPassivesGUI.saveAllPassives();
         if (CatalystManager.getInstance() != null) {

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -214,6 +214,10 @@ public class SkillTreeManager implements Listener {
                 int strengthDuration = level * 50;
                 return ChatColor.YELLOW + "+" + strengthDuration + "s " + ChatColor.LIGHT_PURPLE + "Strength Duration, "
                         + ChatColor.RED + "+5% Damage";
+            case SWIFT_STEP_MASTERY:
+                int swiftDuration = level * 50;
+                return ChatColor.YELLOW + "+" + swiftDuration + "s " + ChatColor.LIGHT_PURPLE + "Swift Step Duration, "
+                        + ChatColor.AQUA + "+5% Speed";
             default:
                 return talent.getTechnicalDescription();
         }

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SwiftStepMasteryBonus.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SwiftStepMasteryBonus.java
@@ -1,0 +1,73 @@
+package goat.minecraft.minecraftnew.other.skilltree;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Applies a small permanent speed bonus when the player has the
+ * {@link Talent#SWIFT_STEP_MASTERY} talent.
+ */
+public class SwiftStepMasteryBonus implements Listener {
+
+    private final JavaPlugin plugin;
+    private final Map<UUID, Float> baseSpeed = new HashMap<>();
+
+    public SwiftStepMasteryBonus(JavaPlugin plugin) {
+        this.plugin = plugin;
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                checkPlayer(player);
+            }
+        }, 1L);
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Bukkit.getScheduler().runTaskLater(plugin, () -> checkPlayer(event.getPlayer()), 1L);
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (event.getWhoClicked() instanceof Player player) {
+            Bukkit.getScheduler().runTaskLater(plugin, () -> checkPlayer(player), 1L);
+        }
+    }
+
+    private void checkPlayer(Player player) {
+        boolean hasTalent = SkillTreeManager.getInstance().hasTalent(player, Talent.SWIFT_STEP_MASTERY);
+        UUID id = player.getUniqueId();
+        if (hasTalent) {
+            if (!baseSpeed.containsKey(id)) {
+                baseSpeed.put(id, player.getWalkSpeed());
+                player.setWalkSpeed((float) (player.getWalkSpeed() * 1.05));
+            }
+        } else {
+            if (baseSpeed.containsKey(id)) {
+                player.setWalkSpeed(baseSpeed.remove(id));
+            }
+        }
+    }
+
+    /**
+     * Removes all applied speed bonuses. Called on plugin disable.
+     */
+    public void removeAllBonuses() {
+        for (Map.Entry<UUID, Float> entry : baseSpeed.entrySet()) {
+            Player player = Bukkit.getPlayer(entry.getKey());
+            if (player != null) {
+                player.setWalkSpeed(entry.getValue());
+            }
+        }
+        baseSpeed.clear();
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -66,6 +66,15 @@ public enum Talent {
             4,
             25,
             Material.DIAMOND_SWORD
+    ),
+    SWIFT_STEP_MASTERY(
+            "Swift Step Mastery",
+            ChatColor.GRAY + "Add a Pumpkin for added sugar",
+            ChatColor.YELLOW + "+50s " + ChatColor.LIGHT_PURPLE + "Swift Step Duration, "
+                    + ChatColor.AQUA + "+5% Speed",
+            4,
+            35,
+            Material.FEATHER
     );
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -21,7 +21,8 @@ public final class TalentRegistry {
                         Talent.TRIPLE_BATCH,
                         Talent.RECURVE_MASTERY,
                         Talent.REJUVENATION,
-                        Talent.STRENGTH_MASTERY)
+                        Talent.STRENGTH_MASTERY,
+                        Talent.SWIFT_STEP_MASTERY)
         );
     //SKILL_TALENTS.put(Skill.BREWING, Collections.singletonList(Talent.REDSTONE_TWO));
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
@@ -209,6 +209,13 @@ public class PotionBrewingSubsystem implements Listener {
             }
         }
 
+        if (name.equalsIgnoreCase("Potion of Swift Step") &&
+                SkillTreeManager.getInstance().hasTalent(player, Talent.SWIFT_STEP_MASTERY)) {
+            if (!ingredients.contains("Pumpkin")) {
+                ingredients.add("Pumpkin");
+            }
+        }
+
         if (!ingredients.equals(base.getRequiredIngredients())) {
             return new PotionRecipe(base.getName(), ingredients, base.getBrewTime(), base.getOutputItem(), base.getFinalColor(), base.getEffectLore());
         }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfSwiftStep.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfSwiftStep.java
@@ -3,6 +3,9 @@ package goat.minecraft.minecraftnew.subsystems.brewing.custompotions;
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -31,6 +34,11 @@ public class PotionOfSwiftStep implements Listener {
                 XPManager xpManager = new XPManager(MinecraftNew.getInstance());
                 int brewingLevel = xpManager.getPlayerLevel(player, "Brewing");
                 int duration = (60 * 3) + (brewingLevel * 10); // Custom scaling
+                if (SkillTreeManager.getInstance().hasTalent(player, Talent.SWIFT_STEP_MASTERY)) {
+                    int bonus = 50 * SkillTreeManager.getInstance()
+                            .getTalentLevel(player.getUniqueId(), Skill.BREWING, Talent.SWIFT_STEP_MASTERY);
+                    duration += bonus;
+                }
                 PotionManager.addCustomPotionEffect("Potion of Swift Step", player, duration);
                 player.sendMessage(ChatColor.AQUA + "Potion of Swift Step activated for " + duration + " seconds!");
                 xpManager.addXP(player, "Brewing", 100);


### PR DESCRIPTION
## Summary
- add `SWIFT_STEP_MASTERY` talent
- register new talent in the registry and dynamic description logic
- extend Potion of Swift Step duration when talent owned
- require Pumpkin ingredient if the talent is unlocked
- give players a permanent 5% speed boost via `SwiftStepMasteryBonus`
- wire new bonus class into plugin enable/disable lifecycle

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve plugin due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6876b62174c08332a4b8aa02e3fb3f76