### PR TITLE
Add Oxygen Mastery talent

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -214,6 +214,9 @@ public class SkillTreeManager implements Listener {
                 int strengthDuration = level * 50;
                 return ChatColor.YELLOW + "+" + strengthDuration + "s " + ChatColor.LIGHT_PURPLE + "Strength Duration, "
                         + ChatColor.RED + "+5% Damage";
+            case OXYGEN_MASTERY:
+                int oxygenDuration = level * 50;
+                return ChatColor.YELLOW + "+" + oxygenDuration + "s " + ChatColor.AQUA + "Oxygen Recovery Duration";
             default:
                 return talent.getTechnicalDescription();
         }

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -66,6 +66,14 @@ public enum Talent {
             4,
             25,
             Material.DIAMOND_SWORD
+    ),
+    OXYGEN_MASTERY(
+            "Oxygen Mastery",
+            ChatColor.GRAY + "Add an obsidian block",
+            ChatColor.YELLOW + "+50s " + ChatColor.AQUA + "Oxygen Recovery Duration",
+            4,
+            45,
+            Material.GLASS_BOTTLE
     );
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -21,7 +21,8 @@ public final class TalentRegistry {
                         Talent.TRIPLE_BATCH,
                         Talent.RECURVE_MASTERY,
                         Talent.REJUVENATION,
-                        Talent.STRENGTH_MASTERY)
+                        Talent.STRENGTH_MASTERY,
+                        Talent.OXYGEN_MASTERY)
         );
     //SKILL_TALENTS.put(Skill.BREWING, Collections.singletonList(Talent.REDSTONE_TWO));
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
@@ -209,6 +209,13 @@ public class PotionBrewingSubsystem implements Listener {
             }
         }
 
+        if (name.equalsIgnoreCase("Potion of Oxygen Recovery") &&
+                SkillTreeManager.getInstance().hasTalent(player, Talent.OXYGEN_MASTERY)) {
+            if (!ingredients.contains("Obsidian")) {
+                ingredients.add("Obsidian");
+            }
+        }
+
         if (!ingredients.equals(base.getRequiredIngredients())) {
             return new PotionRecipe(base.getName(), ingredients, base.getBrewTime(), base.getOutputItem(), base.getFinalColor(), base.getEffectLore());
         }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfOxygenRecovery.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfOxygenRecovery.java
@@ -25,6 +25,13 @@ public class PotionOfOxygenRecovery implements Listener {
                 XPManager xpManager = new XPManager(MinecraftNew.getInstance());
                 int brewingLevel = xpManager.getPlayerLevel(player, "Brewing");
                 int duration = (60 * 3) + (brewingLevel * 10);
+                if(goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager.getInstance()
+                        .hasTalent(player, goat.minecraft.minecraftnew.other.skilltree.Talent.OXYGEN_MASTERY)) {
+                    int bonus = 50 * goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager.getInstance()
+                            .getTalentLevel(player.getUniqueId(), goat.minecraft.minecraftnew.other.skilltree.Skill.BREWING,
+                                    goat.minecraft.minecraftnew.other.skilltree.Talent.OXYGEN_MASTERY);
+                    duration += bonus;
+                }
                 PotionManager.addCustomPotionEffect("Potion of Oxygen Recovery", player, duration);
                 player.sendMessage(ChatColor.AQUA + "Potion of Oxygen Recovery activated for " + duration + " seconds!");
                 xpManager.addXP(player, "Brewing", 100);


### PR DESCRIPTION
## Summary
- add `Oxygen Mastery` brewing talent and register it
- extend dynamic description support in `SkillTreeManager`
- update oxygen recovery potion to scale with the talent
- require Obsidian when brewing oxygen recovery with the talent

## Testing
- `mvn package -DskipTests` *(fails: Could not transfer artifact maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6876b695c7b8833295c507e44fba506c