### PR TITLE
Add Sovereignty Mastery talent

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -210,6 +210,11 @@ public class SkillTreeManager implements Listener {
             case REJUVENATION:
                 int bonusTime = level * 50;
                 return ChatColor.YELLOW + "+" + bonusTime + "s " + ChatColor.GREEN + "Bonus Health" + ChatColor.GRAY + " and " + ChatColor.GREEN + "Health Surge";
+            case SOVEREIGNTY_MASTERY:
+                int sovDuration = level * 50;
+                int deflect = level * 5;
+                return ChatColor.YELLOW + "+" + sovDuration + "s " + ChatColor.LIGHT_PURPLE + "Sovereignty Duration, "
+                        + ChatColor.RED + "+" + deflect + " Deflection Stacks";
             case STRENGTH_MASTERY:
                 int strengthDuration = level * 50;
                 return ChatColor.YELLOW + "+" + strengthDuration + "s " + ChatColor.LIGHT_PURPLE + "Strength Duration, "

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -58,6 +58,15 @@ public enum Talent {
             45,
             Material.GHAST_TEAR
     ),
+    SOVEREIGNTY_MASTERY(
+            "Sovereignty Mastery",
+            ChatColor.GRAY + "Add an ender pearl",
+            ChatColor.YELLOW + "+50s " + ChatColor.LIGHT_PURPLE + "Sovereignty Duration, "
+                    + ChatColor.RED + "+5 Deflection Stacks",
+            4,
+            60,
+            Material.PRISMARINE_SHARD
+    ),
     STRENGTH_MASTERY(
             "Strength Mastery",
             ChatColor.GRAY + "Add a Singularity",

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -21,6 +21,7 @@ public final class TalentRegistry {
                         Talent.TRIPLE_BATCH,
                         Talent.RECURVE_MASTERY,
                         Talent.REJUVENATION,
+                        Talent.SOVEREIGNTY_MASTERY,
                         Talent.STRENGTH_MASTERY)
         );
     //SKILL_TALENTS.put(Skill.BREWING, Collections.singletonList(Talent.REDSTONE_TWO));

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
@@ -220,6 +220,13 @@ public class PotionBrewingSubsystem implements Listener {
             }
             return new PotionRecipe(base.getName(), ingredients, base.getBrewTime(), base.getOutputItem(), base.getFinalColor(), base.getEffectLore());
         }
+        if (base != null && name.equalsIgnoreCase("Potion of Sovereignty") &&
+                SkillTreeManager.getInstance().hasTalent(player, Talent.SOVEREIGNTY_MASTERY)) {
+            if (!ingredients.contains("Ender Pearl")) {
+                ingredients.add("Ender Pearl");
+            }
+            return new PotionRecipe(base.getName(), ingredients, base.getBrewTime(), base.getOutputItem(), base.getFinalColor(), base.getEffectLore());
+        }
         return base;
     }
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfSovereignty.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfSovereignty.java
@@ -36,15 +36,29 @@ public class PotionOfSovereignty implements Listener {
         if (displayName.equals("Potion of Sovereignty")) {
             Player player = event.getPlayer();
             UUID uuid = player.getUniqueId();
-            // Reset deflections to 5
-            activeDeflections.put(uuid, 5);
+            int maxDeflections = 5;
+            if(goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager.getInstance()
+                    .hasTalent(player, goat.minecraft.minecraftnew.other.skilltree.Talent.SOVEREIGNTY_MASTERY)) {
+                int level = goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager.getInstance()
+                        .getTalentLevel(player.getUniqueId(), goat.minecraft.minecraftnew.other.skilltree.Skill.BREWING,
+                                goat.minecraft.minecraftnew.other.skilltree.Talent.SOVEREIGNTY_MASTERY);
+                maxDeflections += 5 * level;
+            }
+            activeDeflections.put(uuid, maxDeflections);
 
             XPManager xpManager = new XPManager(MinecraftNew.getInstance());
             int brewingLevel = xpManager.getPlayerLevel(player, "Brewing");
             int duration = (60 * 3) + (brewingLevel * 10);
+            if(goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager.getInstance()
+                    .hasTalent(player, goat.minecraft.minecraftnew.other.skilltree.Talent.SOVEREIGNTY_MASTERY)) {
+                int bonus = 50 * goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager.getInstance()
+                        .getTalentLevel(player.getUniqueId(), goat.minecraft.minecraftnew.other.skilltree.Skill.BREWING,
+                                goat.minecraft.minecraftnew.other.skilltree.Talent.SOVEREIGNTY_MASTERY);
+                duration += bonus;
+            }
             PotionManager.addCustomPotionEffect("Potion of Sovereignty", player, duration);
 
-            player.sendMessage(ChatColor.GREEN + "Sovereignty activated! Your deflections have been refreshed to 5.");
+            player.sendMessage(ChatColor.GREEN + "Sovereignty activated! Your deflections have been refreshed to " + maxDeflections + ".");
             xpManager.addXP(player, "Brewing", 100);
         }
     }
@@ -62,7 +76,15 @@ public class PotionOfSovereignty implements Listener {
         if(PotionManager.isActive("Potion of Sovereignty", player)) {
             UUID uuid = player.getUniqueId();
             if(!activeDeflections.containsKey(uuid)){
-                activeDeflections.put(uuid, 5);
+                int maxDeflections = 5;
+                if(goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager.getInstance()
+                        .hasTalent(player, goat.minecraft.minecraftnew.other.skilltree.Talent.SOVEREIGNTY_MASTERY)) {
+                    int level = goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager.getInstance()
+                            .getTalentLevel(player.getUniqueId(), goat.minecraft.minecraftnew.other.skilltree.Skill.BREWING,
+                                    goat.minecraft.minecraftnew.other.skilltree.Talent.SOVEREIGNTY_MASTERY);
+                    maxDeflections += 5 * level;
+                }
+                activeDeflections.put(uuid, maxDeflections);
             }
             int availableDeflections = activeDeflections.getOrDefault(uuid, 0);
             if (availableDeflections > 0) {
@@ -74,8 +96,15 @@ public class PotionOfSovereignty implements Listener {
                 // Schedule restoration of one deflection after 2 minutes (120 seconds)
                 Bukkit.getScheduler().runTaskLater(MinecraftNew.getInstance(), () -> {
                     int current = activeDeflections.getOrDefault(uuid, 0);
-                    // Restore a deflection but never exceed 5 total
-                    activeDeflections.put(uuid, Math.min(current + 1, 5));
+                    int maxDeflections = 5;
+                    if(goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager.getInstance()
+                            .hasTalent(player, goat.minecraft.minecraftnew.other.skilltree.Talent.SOVEREIGNTY_MASTERY)) {
+                        int level = goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager.getInstance()
+                                .getTalentLevel(player.getUniqueId(), goat.minecraft.minecraftnew.other.skilltree.Skill.BREWING,
+                                        goat.minecraft.minecraftnew.other.skilltree.Talent.SOVEREIGNTY_MASTERY);
+                        maxDeflections += 5 * level;
+                    }
+                    activeDeflections.put(uuid, Math.min(current + 1, maxDeflections));
                     // Play a sound to indicate the deflection is restored
                     player.playSound(player.getLocation(), Sound.BLOCK_ENCHANTMENT_TABLE_USE, 1.0f, 10.0f);
                     player.sendMessage(ChatColor.GREEN + "A Sovereignty deflection has been restored! You now have " + activeDeflections.get(uuid) + " deflections available.");


### PR DESCRIPTION
## Summary
- add `SOVEREIGNTY_MASTERY` talent to `Talent` enum and register it
- provide dynamic description for Sovereignty Mastery
- update talent registry mapping
- modify potion recipe creation to require ender pearl when the talent is owned
- boost Sovereignty potion duration and deflection stacks when talent is applied

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6876b71e0f4883329881bc1a20b60496