### PR TITLE
Add Fountain Mastery talent

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -229,6 +229,10 @@ public class SkillTreeManager implements Listener {
                 int swiftDuration = level * 50;
                 return ChatColor.YELLOW + "+" + swiftDuration + "s " + ChatColor.LIGHT_PURPLE + "Swift Step Duration, "
                         + ChatColor.AQUA + "+5% Speed";
+            case FOUNTAIN_MASTERY:
+                int fountainDuration = level * 50;
+                return ChatColor.YELLOW + "+" + fountainDuration + "s " + ChatColor.LIGHT_PURPLE + "Fountains Duration, "
+                        + ChatColor.AQUA + "+5% Sea Creature Chance";
             default:
                 return talent.getTechnicalDescription();
         }

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -100,6 +100,15 @@ public enum Talent {
             4,
             35,
             Material.FEATHER
+    ),
+    FOUNTAIN_MASTERY(
+            "Fountain Mastery",
+            ChatColor.GRAY + "Add a heart of the sea",
+            ChatColor.YELLOW + "+50s " + ChatColor.LIGHT_PURPLE + "Fountains Duration, "
+                    + ChatColor.AQUA + "+5% Sea Creature Chance",
+            4,
+            60,
+            Material.DARK_PRISMARINE
     );
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -26,7 +26,8 @@ public final class TalentRegistry {
                         Talent.SOVEREIGNTY_MASTERY,
                         Talent.STRENGTH_MASTERY,
                         Talent.OXYGEN_MASTERY,
-                        Talent.SWIFT_STEP_MASTERY)
+                        Talent.SWIFT_STEP_MASTERY,
+                        Talent.FOUNTAIN_MASTERY)
         );
     //SKILL_TALENTS.put(Skill.BREWING, Collections.singletonList(Talent.REDSTONE_TWO));
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
@@ -249,6 +249,13 @@ public class PotionBrewingSubsystem implements Listener {
             }
         }
 
+        if (name.equalsIgnoreCase("Potion of Fountains") &&
+                SkillTreeManager.getInstance().hasTalent(player, Talent.FOUNTAIN_MASTERY)) {
+            if (!ingredients.contains("Heart of the Sea")) {
+                ingredients.add("Heart of the Sea");
+            }
+        }
+
         if (!ingredients.equals(base.getRequiredIngredients())) {
             return new PotionRecipe(base.getName(), ingredients, base.getBrewTime(), base.getOutputItem(), base.getFinalColor(), base.getEffectLore());
         }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfFountains.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfFountains.java
@@ -3,6 +3,9 @@ package goat.minecraft.minecraftnew.subsystems.brewing.custompotions;
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -20,7 +23,12 @@ public class PotionOfFountains implements Listener {
             int duration = (60 * 3);
             if (displayName.equals("Potion of Fountains")) {
                 Player player = event.getPlayer();
-                // Add the custom effect for 15 seconds
+                if (SkillTreeManager.getInstance().hasTalent(player, Talent.FOUNTAIN_MASTERY)) {
+                    int bonus = 50 * SkillTreeManager.getInstance()
+                            .getTalentLevel(player.getUniqueId(), Skill.BREWING, Talent.FOUNTAIN_MASTERY);
+                    duration += bonus;
+                }
+                // Add the custom effect
                 PotionManager.addCustomPotionEffect("Potion of Fountains", player, duration);
                 player.sendMessage(ChatColor.GREEN + "Potion of Fountains effect activated for " + duration + " seconds!");
                 xpManager.addXP(player, "Brewing", 100);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/FishingEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/FishingEvent.java
@@ -14,6 +14,8 @@ import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
 import goat.minecraft.minecraftnew.subsystems.combat.SpawnMonsters;
 import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
 import org.bukkit.*;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Entity;
@@ -113,6 +115,9 @@ public class FishingEvent implements Listener {
 
         if(PotionManager.isActive("Potion of Fountains", player)){
             seaCreatureChance += 10;
+        }
+        if(SkillTreeManager.getInstance().hasTalent(player, Talent.FOUNTAIN_MASTERY)){
+            seaCreatureChance += 5;
         }
 
         CatalystManager catalystManager = CatalystManager.getInstance();

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureChanceCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureChanceCommand.java
@@ -11,6 +11,8 @@ import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
 import goat.minecraft.minecraftnew.subsystems.pets.PetTrait;
 import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -48,6 +50,7 @@ public class SeaCreatureChanceCommand implements CommandExecutor {
         double callOfTheVoidBonus = callOfTheVoidLevel;
 
         double fountainBonus = PotionManager.isActive("Potion of Fountains", player) ? 10.0 : 0.0;
+        double fountainMastery = SkillTreeManager.getInstance().hasTalent(player, Talent.FOUNTAIN_MASTERY) ? 5.0 : 0.0;
 
         CatalystManager catalystManager = CatalystManager.getInstance();
         double depthBonus = 0.0;
@@ -96,7 +99,7 @@ public class SeaCreatureChanceCommand implements CommandExecutor {
             }
         }
 
-        double total = base + nauticalBonus + fishingLevelBonus + callOfTheVoidBonus + fountainBonus + depthBonus + talismanBonus + masterAnglerBonus + fathmicPenalty + sonarBonus + petBonus;
+        double total = base + nauticalBonus + fishingLevelBonus + callOfTheVoidBonus + fountainBonus + fountainMastery + depthBonus + talismanBonus + masterAnglerBonus + fathmicPenalty + sonarBonus + petBonus;
 
         player.sendMessage(ChatColor.AQUA + "Sea Creature Chance Breakdown:");
         player.sendMessage(ChatColor.AQUA + "Base SCC: " + ChatColor.YELLOW + "0%");
@@ -104,6 +107,9 @@ public class SeaCreatureChanceCommand implements CommandExecutor {
         player.sendMessage(ChatColor.AQUA + "SCC from Fishing Level: " + ChatColor.YELLOW + String.format("%.2f", fishingLevelBonus) + "%");
         player.sendMessage(ChatColor.AQUA + "SCC from COTV: " + ChatColor.YELLOW + String.format("%.2f", callOfTheVoidBonus) + "%");
         player.sendMessage(ChatColor.AQUA + "SCC from Potion of Fountains: " + ChatColor.YELLOW + String.format("%.2f", fountainBonus) + "%");
+        if(fountainMastery > 0){
+            player.sendMessage(ChatColor.AQUA + "SCC from Fountain Mastery: " + ChatColor.YELLOW + String.format("%.2f", fountainMastery) + "%");
+        }
         player.sendMessage(ChatColor.AQUA + "SCC from Depth Catalyst: " + ChatColor.YELLOW + String.format("%.2f", depthBonus) + "%");
         player.sendMessage(ChatColor.AQUA + "SCC from Sea Creature Talisman: " + ChatColor.YELLOW + String.format("%.2f", talismanBonus) + "%");
         player.sendMessage(ChatColor.AQUA + "SCC from Master Angler Merit: " + ChatColor.YELLOW + String.format("%.2f", masterAnglerBonus) + "%");


### PR DESCRIPTION
## Summary
- add Fountain Mastery brewing talent
- register the talent and dynamic description
- update Potion of Fountains effect and recipe
- grant extra sea creature chance with Fountain Mastery
- display bonus in SCC breakdown

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6876c03391d48332bce6f7e91ef72378