### PR TITLE
Add Solar Fury Mastery talent

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -229,6 +229,9 @@ public class SkillTreeManager implements Listener {
                 int swiftDuration = level * 50;
                 return ChatColor.YELLOW + "+" + swiftDuration + "s " + ChatColor.LIGHT_PURPLE + "Swift Step Duration, "
                         + ChatColor.AQUA + "+5% Speed";
+            case SOLAR_FURY_MASTERY:
+                int solarDuration = level * 50;
+                return ChatColor.YELLOW + "+" + solarDuration + "s " + ChatColor.GOLD + "Solar Fury Duration";
             default:
                 return talent.getTechnicalDescription();
         }

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -100,6 +100,14 @@ public enum Talent {
             4,
             35,
             Material.FEATHER
+    ),
+    SOLAR_FURY_MASTERY(
+            "Solar Fury Mastery",
+            ChatColor.GRAY + "Add a blaze rod",
+            ChatColor.YELLOW + "+50s " + ChatColor.GOLD + "Solar Fury Duration",
+            4,
+            75,
+            Material.FIRE_CHARGE
     );
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -26,7 +26,8 @@ public final class TalentRegistry {
                         Talent.SOVEREIGNTY_MASTERY,
                         Talent.STRENGTH_MASTERY,
                         Talent.OXYGEN_MASTERY,
-                        Talent.SWIFT_STEP_MASTERY)
+                        Talent.SWIFT_STEP_MASTERY,
+                        Talent.SOLAR_FURY_MASTERY)
         );
     //SKILL_TALENTS.put(Skill.BREWING, Collections.singletonList(Talent.REDSTONE_TWO));
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
@@ -248,6 +248,12 @@ public class PotionBrewingSubsystem implements Listener {
                 ingredients.add("Pumpkin");
             }
         }
+        if (name.equalsIgnoreCase("Potion of Solar Fury") &&
+                SkillTreeManager.getInstance().hasTalent(player, Talent.SOLAR_FURY_MASTERY)) {
+            if (!ingredients.contains("Blaze Rod")) {
+                ingredients.add("Blaze Rod");
+            }
+        }
 
         if (!ingredients.equals(base.getRequiredIngredients())) {
             return new PotionRecipe(base.getName(), ingredients, base.getBrewTime(), base.getOutputItem(), base.getFinalColor(), base.getEffectLore());

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfSolarFury.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfSolarFury.java
@@ -24,6 +24,13 @@ public class PotionOfSolarFury implements Listener {
             int duration = (60 * 3);
             if (displayName.equals("Potion of Solar Fury")) {
                 Player player = event.getPlayer();
+                if(goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager.getInstance()
+                        .hasTalent(player, goat.minecraft.minecraftnew.other.skilltree.Talent.SOLAR_FURY_MASTERY)) {
+                    int bonus = 50 * goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager.getInstance()
+                            .getTalentLevel(player.getUniqueId(), goat.minecraft.minecraftnew.other.skilltree.Skill.BREWING,
+                                    goat.minecraft.minecraftnew.other.skilltree.Talent.SOLAR_FURY_MASTERY);
+                    duration += bonus;
+                }
                 PotionManager.addCustomPotionEffect("Potion of Solar Fury", player, duration);
                 player.sendMessage(ChatColor.RED + "Potion of Solar Fury effect activated for " + duration + " seconds!");
                 xpManager.addXP(player, "Brewing", 100);


### PR DESCRIPTION
## Summary
- add new `SOLAR_FURY_MASTERY` talent
- include Solar Fury bonuses in dynamic description logic
- register the new talent with Brewing skill
- extend Solar Fury potion recipe with a blaze rod when the talent is owned
- extend Solar Fury potion effect duration based on talent level

## Testing
- `mvn test` *(fails: Could not download maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6876c03d03f08332b064411a25c11dbb