### PR TITLE
Add Night Vision Mastery brewing talent

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -229,6 +229,9 @@ public class SkillTreeManager implements Listener {
                 int swiftDuration = level * 50;
                 return ChatColor.YELLOW + "+" + swiftDuration + "s " + ChatColor.LIGHT_PURPLE + "Swift Step Duration, "
                         + ChatColor.AQUA + "+5% Speed";
+            case NIGHT_VISION_MASTERY:
+                int nvDuration = level * 50;
+                return ChatColor.YELLOW + "+" + nvDuration + "s " + ChatColor.AQUA + "Night Vision Duration";
             default:
                 return talent.getTechnicalDescription();
         }

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -100,6 +100,14 @@ public enum Talent {
             4,
             35,
             Material.FEATHER
+    ),
+    NIGHT_VISION_MASTERY(
+            "Night Vision Mastery",
+            ChatColor.GRAY + "Add a Spider eye",
+            ChatColor.YELLOW + "+50s " + ChatColor.AQUA + "Night Vision Duration",
+            4,
+            40,
+            Material.SPIDER_EYE
     );
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -26,7 +26,8 @@ public final class TalentRegistry {
                         Talent.SOVEREIGNTY_MASTERY,
                         Talent.STRENGTH_MASTERY,
                         Talent.OXYGEN_MASTERY,
-                        Talent.SWIFT_STEP_MASTERY)
+                        Talent.SWIFT_STEP_MASTERY,
+                        Talent.NIGHT_VISION_MASTERY)
         );
     //SKILL_TALENTS.put(Skill.BREWING, Collections.singletonList(Talent.REDSTONE_TWO));
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
@@ -248,6 +248,12 @@ public class PotionBrewingSubsystem implements Listener {
                 ingredients.add("Pumpkin");
             }
         }
+        if (name.equalsIgnoreCase("Potion of Night Vision") &&
+                SkillTreeManager.getInstance().hasTalent(player, Talent.NIGHT_VISION_MASTERY)) {
+            if (!ingredients.contains("Spider Eye")) {
+                ingredients.add("Spider Eye");
+            }
+        }
 
         if (!ingredients.equals(base.getRequiredIngredients())) {
             return new PotionRecipe(base.getName(), ingredients, base.getBrewTime(), base.getOutputItem(), base.getFinalColor(), base.getEffectLore());

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfNightVision.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfNightVision.java
@@ -27,6 +27,13 @@ public class PotionOfNightVision implements Listener {
                 Player player = event.getPlayer();
                 XPManager xpManager = new XPManager(MinecraftNew.getInstance());
                 int duration = (60 * 30);
+                if(goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager.getInstance()
+                        .hasTalent(player, goat.minecraft.minecraftnew.other.skilltree.Talent.NIGHT_VISION_MASTERY)) {
+                    int bonus = 50 * goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager.getInstance()
+                            .getTalentLevel(player.getUniqueId(), goat.minecraft.minecraftnew.other.skilltree.Skill.BREWING,
+                                    goat.minecraft.minecraftnew.other.skilltree.Talent.NIGHT_VISION_MASTERY);
+                    duration += bonus;
+                }
                 PotionManager.addCustomPotionEffect("Potion of Night Vision", player, duration);
                 player.sendMessage(ChatColor.AQUA + "Potion of Night Vision activated for " + duration + " seconds!");
                 xpManager.addXP(player, "Brewing", 100);


### PR DESCRIPTION
## Summary
- add new brewing talent `Night Vision Mastery`
- register the new talent in the brewing skill tree
- include dynamic description handling
- extend Potion of Night Vision duration when talent owned
- require Spider Eye ingredient for Night Vision potion if the talent is owned

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact due to network restriction)*

------
https://chatgpt.com/codex/tasks/task_e_6876c0493734833294e00dfe09141319