### PR TITLE
Add Metal Detection Mastery talent

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -229,6 +229,11 @@ public class SkillTreeManager implements Listener {
                 int swiftDuration = level * 50;
                 return ChatColor.YELLOW + "+" + swiftDuration + "s " + ChatColor.LIGHT_PURPLE + "Swift Step Duration, "
                         + ChatColor.AQUA + "+5% Speed";
+            case METAL_DETECTION_MASTERY:
+                int metalDuration = level * 50;
+                double graveBonus = level * 0.01;
+                return ChatColor.YELLOW + "+" + metalDuration + "s " + ChatColor.LIGHT_PURPLE + "Metal Detection Duration, "
+                        + ChatColor.YELLOW + "+" + graveBonus + ChatColor.GRAY + " grave chance";
             default:
                 return talent.getTechnicalDescription();
         }

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -100,6 +100,15 @@ public enum Talent {
             4,
             35,
             Material.FEATHER
+    ),
+    METAL_DETECTION_MASTERY(
+            "Metal Detection Mastery",
+            ChatColor.GRAY + "Add a diamond",
+            ChatColor.YELLOW + "+(50*level)s " + ChatColor.LIGHT_PURPLE + "Metal Detection Duration, "
+                    + ChatColor.YELLOW + "+(0.01*level) " + ChatColor.GRAY + "grave chance",
+            4,
+            55,
+            Material.ZOMBIE_HEAD
     );
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -26,7 +26,8 @@ public final class TalentRegistry {
                         Talent.SOVEREIGNTY_MASTERY,
                         Talent.STRENGTH_MASTERY,
                         Talent.OXYGEN_MASTERY,
-                        Talent.SWIFT_STEP_MASTERY)
+                        Talent.SWIFT_STEP_MASTERY,
+                        Talent.METAL_DETECTION_MASTERY)
         );
     //SKILL_TALENTS.put(Skill.BREWING, Collections.singletonList(Talent.REDSTONE_TWO));
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
@@ -248,6 +248,12 @@ public class PotionBrewingSubsystem implements Listener {
                 ingredients.add("Pumpkin");
             }
         }
+        if (name.equalsIgnoreCase("Potion of Metal Detection") &&
+                SkillTreeManager.getInstance().hasTalent(player, Talent.METAL_DETECTION_MASTERY)) {
+            if (!ingredients.contains("Diamond")) {
+                ingredients.add("Diamond");
+            }
+        }
 
         if (!ingredients.equals(base.getRequiredIngredients())) {
             return new PotionRecipe(base.getName(), ingredients, base.getBrewTime(), base.getOutputItem(), base.getFinalColor(), base.getEffectLore());

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfMetalDetection.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfMetalDetection.java
@@ -20,6 +20,13 @@ public class PotionOfMetalDetection implements Listener {
                 Player player = event.getPlayer();
                 XPManager xpManager = new XPManager(MinecraftNew.getInstance());
                 int duration = (60 * 3);
+                if(goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager.getInstance()
+                        .hasTalent(player, goat.minecraft.minecraftnew.other.skilltree.Talent.METAL_DETECTION_MASTERY)) {
+                    int bonus = 50 * goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager.getInstance()
+                            .getTalentLevel(player.getUniqueId(), goat.minecraft.minecraftnew.other.skilltree.Skill.BREWING,
+                                    goat.minecraft.minecraftnew.other.skilltree.Talent.METAL_DETECTION_MASTERY);
+                    duration += bonus;
+                }
                 PotionManager.addCustomPotionEffect("Potion of Metal Detection", player, duration);
                 player.sendMessage(ChatColor.GREEN + "Potion of Metal Detection effect activated for " + duration + " seconds!");
                 xpManager.addXP(player, "Brewing", 100);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
@@ -23,6 +23,9 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
 import goat.minecraft.minecraftnew.subsystems.pets.PetTrait;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -118,6 +121,10 @@ public class Gravedigging implements Listener {
         }
         if (PotionManager.isActive("Potion of Metal Detection", player)) {
             chance += 0.01;
+            if (SkillTreeManager.getInstance().hasTalent(player, Talent.METAL_DETECTION_MASTERY)) {
+                int level = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.BREWING, Talent.METAL_DETECTION_MASTERY);
+                chance += 0.01 * level;
+            }
         }
         if (isNight(world)) {
             chance = Math.min(1.0, chance * 2);


### PR DESCRIPTION
## Summary
- add Metal Detection Mastery talent and register it with Brewing
- extend SkillTree dynamic text to cover the new talent
- modify Potion of Metal Detection to scale with the talent
- require a diamond in the recipe when the talent is owned
- boost grave chance from Metal Detection potion using the talent

## Testing
- `mvn -q test` *(fails: Plugin resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_6876c0522a548332842e85b981d893ab