### PR TITLE
Add Charisma Mastery talent

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -244,6 +244,10 @@ public class SkillTreeManager implements Listener {
                 int fountainDuration = level * 50;
                 return ChatColor.YELLOW + "+" + fountainDuration + "s " + ChatColor.LIGHT_PURPLE + "Fountains Duration, "
                         + ChatColor.AQUA + "+5% Sea Creature Chance";
+            case CHARISMA_MASTERY:
+                int charismaDuration = level * 50;
+                return ChatColor.YELLOW + "+" + charismaDuration + "s " + ChatColor.LIGHT_PURPLE + "Charismatic Bartering Duration, "
+                        + ChatColor.GOLD + "+5% Discount";
           default:
                 return talent.getTechnicalDescription();
         }

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -134,6 +134,15 @@ public enum Talent {
             4,
             60,
             Material.DARK_PRISMARINE
+    ),
+    CHARISMA_MASTERY(
+            "Charisma Mastery",
+            ChatColor.GRAY + "Add a bribe",
+            ChatColor.YELLOW + "+50s " + ChatColor.LIGHT_PURPLE + "Charismatic Bartering Duration, "
+                    + ChatColor.GOLD + "+5% Discount",
+            4,
+            50,
+            Material.GOLD_BLOCK
     );
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -30,7 +30,8 @@ public final class TalentRegistry {
                         Talent.METAL_DETECTION_MASTERY,
                         Talent.NIGHT_VISION_MASTERY,
                         Talent.SOLAR_FURY_MASTERY,
-                        Talent.FOUNTAIN_MASTERY)
+                        Talent.FOUNTAIN_MASTERY,
+                        Talent.CHARISMA_MASTERY)
         );
     //SKILL_TALENTS.put(Skill.BREWING, Collections.singletonList(Talent.REDSTONE_TWO));
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
@@ -236,6 +236,12 @@ public class PotionBrewingSubsystem implements Listener {
                 ingredients.add("Gold Block");
             }
         }
+        if (name.equalsIgnoreCase("Potion of Charismatic Bartering") &&
+                SkillTreeManager.getInstance().hasTalent(player, Talent.CHARISMA_MASTERY)) {
+            if (!ingredients.contains("Gold Block")) {
+                ingredients.add("Gold Block");
+            }
+        }
         if (name.equalsIgnoreCase("Potion of Oxygen Recovery") &&
                 SkillTreeManager.getInstance().hasTalent(player, Talent.OXYGEN_MASTERY)) {
             if (!ingredients.contains("Obsidian")) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfCharismaticBartering.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfCharismaticBartering.java
@@ -3,6 +3,9 @@ package goat.minecraft.minecraftnew.subsystems.brewing.custompotions;
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -23,6 +26,11 @@ public class PotionOfCharismaticBartering implements Listener {
                 Player player = event.getPlayer();
                 XPManager xpManager = new XPManager(MinecraftNew.getInstance());
                 int duration = (60 * 3);
+                if (SkillTreeManager.getInstance().hasTalent(player, Talent.CHARISMA_MASTERY)) {
+                    int bonus = 50 * SkillTreeManager.getInstance()
+                            .getTalentLevel(player.getUniqueId(), Skill.BREWING, Talent.CHARISMA_MASTERY);
+                    duration += bonus;
+                }
                 PotionManager.addCustomPotionEffect("Potion of Charismatic Bartering", player, duration);
                 player.sendMessage(ChatColor.GREEN + "Potion of Charismatic Bartering activated for " + duration + " seconds!");
                 xpManager.addXP(player, "Brewing", 100);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -14,6 +14,9 @@ import goat.minecraft.minecraftnew.utils.devtools.Speech;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
 import goat.minecraft.minecraftnew.other.trinkets.BankAccountManager;
 import goat.minecraft.minecraftnew.other.trinkets.TrinketManager;
 import org.bukkit.*;
@@ -1165,7 +1168,12 @@ public class VillagerTradeManager implements Listener {
         finalCost *= (1 - barteringDiscount);
 
         if (PotionManager.isActive("Potion of Charismatic Bartering", player)) {
-            finalCost *= 0.8; // additional 20% discount
+            double discount = 0.20;
+            if (SkillTreeManager.getInstance().hasTalent(player, Talent.CHARISMA_MASTERY)) {
+                int level = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.BREWING, Talent.CHARISMA_MASTERY);
+                discount += 0.05 * level;
+            }
+            finalCost *= (1 - discount);
         }
 
         return Math.max(1, (int) Math.floor(finalCost));
@@ -1596,7 +1604,12 @@ public class VillagerTradeManager implements Listener {
         finalCost *= (1 - barteringDiscount);
 
         if (PotionManager.isActive("Potion of Charismatic Bartering", player)) {
-            finalCost *= 0.8; // additional 20% discount
+            double discount = 0.20;
+            if (SkillTreeManager.getInstance().hasTalent(player, Talent.CHARISMA_MASTERY)) {
+                int level = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.BREWING, Talent.CHARISMA_MASTERY);
+                discount += 0.05 * level;
+            }
+            finalCost *= (1 - discount);
         }
 
         // Ensure at least cost of 1


### PR DESCRIPTION
## Summary
- add new Brewing talent `Charisma Mastery`
- register the talent and provide dynamic description
- extend Potion of Charismatic Bartering when the talent is owned
- require a Gold Block in the recipe when the talent is owned
- apply bonus discount when trading with the potion active

## Testing
- `mvn -q -DskipTests package` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6876d7a07e188332acaac28462446099