### PR TITLE
Add Redstone III and IV brewing talents

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -217,6 +217,8 @@ public class SkillTreeManager implements Listener {
                 return ChatColor.YELLOW + "-" + reduction + "s " + ChatColor.GOLD + "Brew Time.";
             case REDSTONE_ONE:
             case REDSTONE_TWO:
+            case REDSTONE_THREE:
+            case REDSTONE_FOUR:
                 int seconds = level * 4;
                 return ChatColor.YELLOW + "+" + seconds + "s " + ChatColor.LIGHT_PURPLE + "Potion Duration, "
                         + ChatColor.GOLD + "+" + seconds + "s " + ChatColor.GOLD + "Brew Time.";

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -41,6 +41,22 @@ public enum Talent {
                     20,
             Material.REDSTONE_BLOCK
     ),
+    REDSTONE_THREE(
+            "Redstone III",
+            ChatColor.GRAY + "Allows Potions to steep for even longer",
+            ChatColor.YELLOW + "+4s " + ChatColor.LIGHT_PURPLE + "Potion Duration, " + ChatColor.GOLD + "+4s " + ChatColor.GOLD + "Brew Time.",
+            10,
+            60,
+            Material.REDSTONE_TORCH
+    ),
+    REDSTONE_FOUR(
+            "Redstone IV",
+            ChatColor.GRAY + "Allows Potions to steep for even longer",
+            ChatColor.YELLOW + "+4s " + ChatColor.LIGHT_PURPLE + "Potion Duration, " + ChatColor.GOLD + "+4s " + ChatColor.GOLD + "Brew Time.",
+            10,
+            80,
+            Material.REDSTONE_ORE
+    ),
     RECURVE_MASTERY(
             "Recurve Mastery",
             ChatColor.GRAY + "Add a Skeleton Skull",

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -17,6 +17,8 @@ public final class TalentRegistry {
                 Arrays.asList(
                         Talent.REDSTONE_ONE,
                         Talent.REDSTONE_TWO,
+                        Talent.REDSTONE_THREE,
+                        Talent.REDSTONE_FOUR,
                         Talent.OPTIMAL_CONFIGURATION,
                         Talent.TRIPLE_BATCH,
                         Talent.RECURVE_MASTERY,

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionManager.java
@@ -61,6 +61,16 @@ public class PotionManager {
             Bukkit.getLogger().info("Potion Duration extended by " + redstoneBuff + "s from " + duration + "s");
             duration += redstoneBuff;
         }
+        if(SkillTreeManager.getInstance().hasTalent(player, Talent.REDSTONE_THREE)){
+            int redstoneBuff = (4*SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.BREWING, Talent.REDSTONE_THREE));
+            Bukkit.getLogger().info("Potion Duration extended by " + redstoneBuff + "s from " + duration + "s");
+            duration += redstoneBuff;
+        }
+        if(SkillTreeManager.getInstance().hasTalent(player, Talent.REDSTONE_FOUR)){
+            int redstoneBuff = (4*SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.BREWING, Talent.REDSTONE_FOUR));
+            Bukkit.getLogger().info("Potion Duration extended by " + redstoneBuff + "s from " + duration + "s");
+            duration += redstoneBuff;
+        }
         if (SkillTreeManager.getInstance().hasTalent(player, Talent.REJUVENATION)) {
             int level = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.BREWING, Talent.REJUVENATION);
             int hpBoostduration = level * 50 * 20;


### PR DESCRIPTION
## Summary
- add new Redstone III and Redstone IV perks to Talent enum
- register new talents in TalentRegistry
- extend SkillTreeManager dynamic descriptions for new perks
- apply new perks in PotionManager

## Testing
- `mvn -q package -DskipTests` *(fails: Could not transfer artifact maven-resources-plugin from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_6876dd0e36d48332afb47b7fdbdfbe17