### PR TITLE
Add combat sword talents and damage strategy

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Skill.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Skill.java
@@ -1,7 +1,8 @@
 package goat.minecraft.minecraftnew.other.skilltree;
 
 public enum Skill {
-    BREWING("Brewing");
+    BREWING("Brewing"),
+    COMBAT("Combat");
 
     private final String displayName;
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -267,6 +267,14 @@ public class SkillTreeManager implements Listener {
                 int charismaDuration = level * 50;
                 return ChatColor.YELLOW + "+" + charismaDuration + "s " + ChatColor.LIGHT_PURPLE + "Charismatic Bartering Duration, "
                         + ChatColor.GOLD + "+5% Discount";
+            case WOODEN_SWORD:
+            case STONE_SWORD:
+            case IRON_SWORD:
+            case GOLD_SWORD:
+            case DIAMOND_SWORD:
+            case NETHERITE_SWORD:
+                int bonus = level * 8;
+                return ChatColor.RED + "+" + bonus + "% Damage";
           default:
                 return talent.getTechnicalDescription();
         }

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -159,6 +159,54 @@ public enum Talent {
             4,
             50,
             Material.GOLD_BLOCK
+    ),
+    WOODEN_SWORD(
+            "Wooden Sword",
+            ChatColor.GRAY + "Train with a wooden blade",
+            ChatColor.RED + "+8% Damage",
+            4,
+            1,
+            Material.WOODEN_SWORD
+    ),
+    STONE_SWORD(
+            "Stone Sword",
+            ChatColor.GRAY + "Master the stone blade",
+            ChatColor.RED + "+8% Damage",
+            4,
+            15,
+            Material.STONE_SWORD
+    ),
+    IRON_SWORD(
+            "Iron Sword",
+            ChatColor.GRAY + "Hone iron sword techniques",
+            ChatColor.RED + "+8% Damage",
+            4,
+            30,
+            Material.IRON_SWORD
+    ),
+    GOLD_SWORD(
+            "Gold Sword",
+            ChatColor.GRAY + "Wield the golden sword with skill",
+            ChatColor.RED + "+8% Damage",
+            4,
+            45,
+            Material.GOLDEN_SWORD
+    ),
+    DIAMOND_SWORD(
+            "Diamond Sword",
+            ChatColor.GRAY + "Harness the power of diamond",
+            ChatColor.RED + "+8% Damage",
+            4,
+            60,
+            Material.DIAMOND_SWORD
+    ),
+    NETHERITE_SWORD(
+            "Netherite Sword",
+            ChatColor.GRAY + "Master the ultimate blade",
+            ChatColor.RED + "+8% Damage",
+            4,
+            75,
+            Material.NETHERITE_SWORD
     );
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -35,6 +35,18 @@ public final class TalentRegistry {
                         Talent.FOUNTAIN_MASTERY,
                         Talent.CHARISMA_MASTERY)
         );
+
+        SKILL_TALENTS.put(
+                Skill.COMBAT,
+                Arrays.asList(
+                        Talent.WOODEN_SWORD,
+                        Talent.STONE_SWORD,
+                        Talent.IRON_SWORD,
+                        Talent.GOLD_SWORD,
+                        Talent.DIAMOND_SWORD,
+                        Talent.NETHERITE_SWORD
+                )
+        );
     //SKILL_TALENTS.put(Skill.BREWING, Collections.singletonList(Talent.REDSTONE_TWO));
     }
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatSubsystemManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatSubsystemManager.java
@@ -8,6 +8,7 @@ import goat.minecraft.minecraftnew.subsystems.combat.damage.strategies.MonsterLe
 import goat.minecraft.minecraftnew.subsystems.combat.damage.strategies.PowerCatalystDamageStrategy;
 import goat.minecraft.minecraftnew.subsystems.combat.damage.strategies.RangedDamageStrategy;
 import goat.minecraft.minecraftnew.subsystems.combat.damage.strategies.CorpseLevelDamageStrategy;
+import goat.minecraft.minecraftnew.subsystems.combat.damage.strategies.SwordTalentDamageStrategy;
 import goat.minecraft.minecraftnew.subsystems.combat.commands.CombatReloadCommand;
 import goat.minecraft.minecraftnew.subsystems.combat.hostility.HostilityGUIController;
 import goat.minecraft.minecraftnew.subsystems.combat.hostility.HostilityService;
@@ -233,9 +234,11 @@ public class CombatSubsystemManager implements CommandExecutor {
         if (configuration.getBuffConfig().isSkillDamageScaling()) {
             damageCalculationService.registerStrategy(
                 new MeleeDamageStrategy(configuration.getDamageConfig(), xpManager));
-            
+
             damageCalculationService.registerStrategy(
                 new RangedDamageStrategy(configuration.getDamageConfig(), xpManager));
+
+            damageCalculationService.registerStrategy(new SwordTalentDamageStrategy());
         }
         
         if (configuration.getBuffConfig().isMonsterLevelScaling()) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/damage/strategies/SwordTalentDamageStrategy.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/damage/strategies/SwordTalentDamageStrategy.java
@@ -1,0 +1,77 @@
+package goat.minecraft.minecraftnew.subsystems.combat.damage.strategies;
+
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
+import goat.minecraft.minecraftnew.subsystems.combat.damage.DamageCalculationContext;
+import goat.minecraft.minecraftnew.subsystems.combat.damage.DamageCalculationResult;
+import goat.minecraft.minecraftnew.subsystems.combat.damage.DamageCalculationStrategy;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+public class SwordTalentDamageStrategy implements DamageCalculationStrategy {
+
+    @Override
+    public DamageCalculationResult calculateDamage(DamageCalculationContext context) {
+        if (!isApplicable(context)) {
+            return DamageCalculationResult.noChange(context.getBaseDamage());
+        }
+
+        Player player = context.getAttackerPlayer().get();
+        ItemStack weapon = context.getWeapon().get();
+        Material type = weapon.getType();
+
+        SkillTreeManager manager = SkillTreeManager.getInstance();
+        if (manager == null) {
+            return DamageCalculationResult.noChange(context.getBaseDamage());
+        }
+
+        Talent talent;
+        switch (type) {
+            case WOODEN_SWORD -> talent = Talent.WOODEN_SWORD;
+            case STONE_SWORD -> talent = Talent.STONE_SWORD;
+            case IRON_SWORD -> talent = Talent.IRON_SWORD;
+            case GOLDEN_SWORD -> talent = Talent.GOLD_SWORD;
+            case DIAMOND_SWORD -> talent = Talent.DIAMOND_SWORD;
+            case NETHERITE_SWORD -> talent = Talent.NETHERITE_SWORD;
+            default -> {
+                return DamageCalculationResult.noChange(context.getBaseDamage());
+            }
+        }
+
+        int level = manager.getTalentLevel(player.getUniqueId(), Skill.COMBAT, talent);
+        if (level <= 0) {
+            return DamageCalculationResult.noChange(context.getBaseDamage());
+        }
+
+        double multiplier = 1.0 + (level * 0.08);
+        double finalDamage = context.getBaseDamage() * multiplier;
+
+        DamageCalculationResult.DamageModifier modifier =
+                DamageCalculationResult.DamageModifier.multiplicative(
+                        talent.getName(),
+                        multiplier,
+                        "+" + (level * 8) + "% Damage"
+                );
+
+        return DamageCalculationResult.withModifier(context.getBaseDamage(), finalDamage, modifier);
+    }
+
+    @Override
+    public boolean isApplicable(DamageCalculationContext context) {
+        return context.getAttackerPlayer().isPresent()
+                && context.getWeapon().isPresent()
+                && context.getDamageType() == DamageCalculationContext.DamageType.MELEE;
+    }
+
+    @Override
+    public int getPriority() {
+        return 75;
+    }
+
+    @Override
+    public String getName() {
+        return "Sword Talent Damage";
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `COMBAT` skill
- add wooden, stone, iron, gold, diamond and netherite sword talents
- register combat talents in the talent registry
- compute dynamic description for sword talents
- implement `SwordTalentDamageStrategy` and register it with the combat subsystem

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6876fe8328888332a484345031f100d4