### PR TITLE
Add monster health bars

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatEventHandler.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatEventHandler.java
@@ -5,6 +5,7 @@ import goat.minecraft.minecraftnew.subsystems.combat.damage.DamageCalculationRes
 import goat.minecraft.minecraftnew.subsystems.combat.damage.DamageCalculationService;
 import goat.minecraft.minecraftnew.subsystems.combat.notification.DamageNotificationService;
 import goat.minecraft.minecraftnew.subsystems.combat.notification.PlayerFeedbackService;
+import goat.minecraft.minecraftnew.subsystems.combat.notification.MonsterHealthBarService;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.ChatColor;
@@ -29,15 +30,18 @@ public class CombatEventHandler implements Listener {
     private final DamageCalculationService damageCalculationService;
     private final DamageNotificationService notificationService;
     private final PlayerFeedbackService feedbackService;
+    private final MonsterHealthBarService healthBarService;
     private final CombatConfiguration config;
     
     public CombatEventHandler(DamageCalculationService damageCalculationService,
                              DamageNotificationService notificationService,
                              PlayerFeedbackService feedbackService,
+                             MonsterHealthBarService healthBarService,
                              CombatConfiguration config) {
         this.damageCalculationService = damageCalculationService;
         this.notificationService = notificationService;
         this.feedbackService = feedbackService;
+        this.healthBarService = healthBarService;
         this.config = config;
     }
     
@@ -78,6 +82,13 @@ public class CombatEventHandler implements Listener {
             // Show damage notification if enabled and applicable
             if (config.getNotificationConfig().isEnabled() && shouldShowNotification(event)) {
                 notificationService.showDamageIndicator(event.getEntity().getLocation(), result.getFinalDamage());
+            }
+
+            // Show monster health bar
+            if (event.getEntity() instanceof org.bukkit.entity.LivingEntity living
+                    && !(event.getEntity() instanceof Player)) {
+                double predicted = Math.max(0, living.getHealth() - event.getFinalDamage());
+                healthBarService.showHealthBar(living, predicted);
             }
             
         } catch (DamageCalculationService.DamageCalculationException e) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatSubsystemManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatSubsystemManager.java
@@ -10,10 +10,12 @@ import goat.minecraft.minecraftnew.subsystems.combat.damage.strategies.RangedDam
 import goat.minecraft.minecraftnew.subsystems.combat.damage.strategies.CorpseLevelDamageStrategy;
 import goat.minecraft.minecraftnew.subsystems.combat.damage.strategies.SwordTalentDamageStrategy;
 import goat.minecraft.minecraftnew.subsystems.combat.commands.CombatReloadCommand;
+import goat.minecraft.minecraftnew.subsystems.combat.commands.ToggleHealthBarsCommand;
 import goat.minecraft.minecraftnew.subsystems.combat.hostility.HostilityGUIController;
 import goat.minecraft.minecraftnew.subsystems.combat.hostility.HostilityService;
 import goat.minecraft.minecraftnew.subsystems.combat.notification.DamageNotificationService;
 import goat.minecraft.minecraftnew.subsystems.combat.notification.PlayerFeedbackService;
+import goat.minecraft.minecraftnew.subsystems.combat.notification.MonsterHealthBarService;
 import goat.minecraft.minecraftnew.subsystems.combat.FireDamageHandler;
 import goat.minecraft.minecraftnew.subsystems.combat.DeteriorationDamageHandler;
 import goat.minecraft.minecraftnew.subsystems.combat.ZombieReinforcementBlocker;
@@ -45,6 +47,7 @@ public class CombatSubsystemManager implements CommandExecutor {
     private DamageNotificationService notificationService;
     private PlayerFeedbackService feedbackService;
     private HostilityService hostilityService;
+    private MonsterHealthBarService healthBarService;
 
     private FireDamageHandler fireDamageHandler;
     private DeteriorationDamageHandler decayDamageHandler;
@@ -222,6 +225,7 @@ public class CombatSubsystemManager implements CommandExecutor {
         notificationService = new DamageNotificationService(plugin, configuration.getNotificationConfig());
         feedbackService = new PlayerFeedbackService(configuration.getSoundConfig());
         hostilityService = new HostilityService(plugin, configuration.getHostilityConfig());
+        healthBarService = new MonsterHealthBarService(plugin);
         
         logger.fine("Core combat services initialized");
     }
@@ -263,6 +267,7 @@ public class CombatSubsystemManager implements CommandExecutor {
             damageCalculationService,
             notificationService,
             feedbackService,
+            healthBarService,
             configuration
         );
         
@@ -300,6 +305,10 @@ public class CombatSubsystemManager implements CommandExecutor {
             plugin.getCommand("combatreload").setExecutor(new CombatReloadCommand(this));
         }
 
+        if (plugin.getCommand("togglehealthbars") != null) {
+            plugin.getCommand("togglehealthbars").setExecutor(new ToggleHealthBarsCommand(healthBarService));
+        }
+
 
         
         logger.fine("Combat commands registered");
@@ -312,6 +321,10 @@ public class CombatSubsystemManager implements CommandExecutor {
         try {
             if (notificationService != null) {
                 notificationService.cleanup();
+            }
+
+            if (healthBarService != null) {
+                healthBarService.cleanup();
             }
             
             if (hostilityService != null) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/commands/ToggleHealthBarsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/commands/ToggleHealthBarsCommand.java
@@ -1,0 +1,29 @@
+package goat.minecraft.minecraftnew.subsystems.combat.commands;
+
+import goat.minecraft.minecraftnew.subsystems.combat.notification.MonsterHealthBarService;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Command allowing players to toggle monster health bar visibility.
+ */
+public class ToggleHealthBarsCommand implements CommandExecutor {
+
+    private final MonsterHealthBarService service;
+
+    public ToggleHealthBarsCommand(MonsterHealthBarService service) {
+        this.service = service;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("This command can only be used by players.");
+            return true;
+        }
+        service.toggle(player);
+        return true;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/notification/MonsterHealthBarService.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/notification/MonsterHealthBarService.java
@@ -1,0 +1,161 @@
+package goat.minecraft.minecraftnew.subsystems.combat.notification;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.EntityType;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Displays short-lived monster health bars using armor stands.
+ */
+public class MonsterHealthBarService {
+
+    private final JavaPlugin plugin;
+    private final Logger logger;
+
+    private final Map<LivingEntity, BarInfo> activeBars = new ConcurrentHashMap<>();
+    private final Set<UUID> hiddenPlayers = ConcurrentHashMap.newKeySet();
+
+    private File dataFile;
+    private YamlConfiguration dataConfig;
+    private static final String HIDDEN_KEY = "hidden";
+
+    public MonsterHealthBarService(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.logger = plugin.getLogger();
+        initStorage();
+    }
+
+    private void initStorage() {
+        dataFile = new File(plugin.getDataFolder(), "healthbars.yml");
+        if (!dataFile.exists()) {
+            try {
+                dataFile.createNewFile();
+            } catch (IOException e) {
+                logger.log(Level.WARNING, "Failed creating health bar data file", e);
+            }
+        }
+        dataConfig = YamlConfiguration.loadConfiguration(dataFile);
+        List<String> stored = dataConfig.getStringList(HIDDEN_KEY);
+        for (String s : stored) {
+            try {
+                hiddenPlayers.add(UUID.fromString(s));
+            } catch (IllegalArgumentException ignore) {}
+        }
+    }
+
+    private void saveData() {
+        List<String> list = new ArrayList<>();
+        for (UUID id : hiddenPlayers) {
+            list.add(id.toString());
+        }
+        dataConfig.set(HIDDEN_KEY, list);
+        try {
+            dataConfig.save(dataFile);
+        } catch (IOException e) {
+            logger.log(Level.WARNING, "Failed saving health bar data", e);
+        }
+    }
+
+    /** Toggle health bar visibility for a player. */
+    public void toggle(Player player) {
+        UUID id = player.getUniqueId();
+        if (hiddenPlayers.contains(id)) {
+            hiddenPlayers.remove(id);
+            player.sendMessage(ChatColor.GREEN + "Monster health bars enabled.");
+        } else {
+            hiddenPlayers.add(id);
+            player.sendMessage(ChatColor.YELLOW + "Monster health bars disabled.");
+        }
+        saveData();
+    }
+
+    /** Shows a health bar above the given entity for 1 second. */
+    public void showHealthBar(LivingEntity entity, double health) {
+        if (entity == null || entity.isDead()) return;
+        // Remove any existing bar
+        BarInfo old = activeBars.remove(entity);
+        if (old != null) {
+            old.task.cancel();
+            if (old.stand.isValid()) old.stand.remove();
+        }
+
+        String barText = buildBar(entity, health);
+        Location loc = entity.getLocation().add(0, entity.getHeight() + 0.5, 0);
+        ArmorStand stand = (ArmorStand) entity.getWorld().spawnEntity(loc, EntityType.ARMOR_STAND);
+        stand.setMarker(true);
+        stand.setInvisible(true);
+        stand.setGravity(false);
+        stand.setSmall(true);
+        stand.setCustomName(barText);
+        stand.setCustomNameVisible(true);
+
+        for (Player p : Bukkit.getOnlinePlayers()) {
+            if (hiddenPlayers.contains(p.getUniqueId())) {
+                p.hideEntity(plugin, stand);
+            }
+        }
+
+        BukkitTask task = new BukkitRunnable() {
+            int ticks = 0;
+            @Override
+            public void run() {
+                if (!stand.isValid() || entity.isDead()) {
+                    cleanup();
+                    return;
+                }
+                Location target = entity.getLocation().add(0, entity.getHeight() + 0.5, 0);
+                stand.teleport(target);
+                if (ticks++ >= 20) {
+                    cleanup();
+                }
+            }
+            private void cleanup() {
+                this.cancel();
+                if (stand.isValid()) stand.remove();
+                activeBars.remove(entity);
+            }
+        }.runTaskTimer(plugin, 0L, 1L);
+
+        activeBars.put(entity, new BarInfo(stand, task));
+    }
+
+    private String buildBar(LivingEntity entity, double health) {
+        double max = entity.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue();
+        int segments = 20;
+        int filled = (int) Math.round(Math.max(0, Math.min(health, max)) / max * segments);
+        StringBuilder sb = new StringBuilder(ChatColor.GREEN.toString());
+        for (int i = 0; i < filled; i++) sb.append('|');
+        return sb.toString();
+    }
+
+    public void cleanup() {
+        for (BarInfo info : activeBars.values()) {
+            info.task.cancel();
+            if (info.stand.isValid()) info.stand.remove();
+        }
+        activeBars.clear();
+        saveData();
+    }
+
+    private static class BarInfo {
+        final ArmorStand stand;
+        final BukkitTask task;
+        BarInfo(ArmorStand stand, BukkitTask task) { this.stand = stand; this.task = task; }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -229,3 +229,7 @@ commands:
     description: Displays your total Spirit Chance
     usage: /spiritchance
     default: true
+  togglehealthbars:
+    description: Toggle monster health bar displays
+    usage: /togglehealthbars
+    default: true


### PR DESCRIPTION
## Summary
- spawn an ArmorStand health bar above damaged monsters
- persist players who toggle these bars with `/togglehealthbars`
- register toggle command and service initialization

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68770af5068c8332850c032aec0fdf74