### PR TITLE
Add monster health bar notifications

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -53,6 +53,7 @@ import goat.minecraft.minecraftnew.utils.commands.DiscsCommand;
 import goat.minecraft.minecraftnew.utils.commands.MeritCommand;
 import goat.minecraft.minecraftnew.utils.commands.SkillsCommand;
 import goat.minecraft.minecraftnew.utils.commands.AuraCommand;
+import goat.minecraft.minecraftnew.utils.commands.ToggleHealthBarsCommand;
 import goat.minecraft.minecraftnew.utils.developercommands.*;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
 import goat.minecraft.minecraftnew.utils.developercommands.AddTalentPointCommand;
@@ -70,6 +71,7 @@ import goat.minecraft.minecraftnew.other.trinkets.EnchantedClockManager;
 import goat.minecraft.minecraftnew.other.trinkets.EnchantedHopperManager;
 import goat.minecraft.minecraftnew.other.trinkets.TrinketManager;
 import goat.minecraft.minecraftnew.other.auras.AuraManager;
+import goat.minecraft.minecraftnew.subsystems.combat.notification.MonsterHealthBarManager;
 import goat.minecraft.minecraftnew.other.armorsets.FlowManager;
 import goat.minecraft.minecraftnew.other.armorsets.MonolithSetBonus;
 import goat.minecraft.minecraftnew.other.health.HealthManager;
@@ -144,6 +146,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
     private VerdantRelicsSubsystem verdantRelicsSubsystem;
     private CombatSubsystemManager combatSubsystemManager;
     private AuraManager auraManager;
+    private MonsterHealthBarManager healthBarManager;
     private FlowManager flowManager;
 
     public ItemDisplayManager getItemDisplayManager() {
@@ -340,6 +343,9 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         auraManager = new AuraManager(this);
         getCommand("previewauratemplate").setExecutor(new PreviewAuraTemplateCommand(auraManager));
         getCommand("aura").setExecutor(new AuraCommand(auraManager));
+
+        healthBarManager = MonsterHealthBarManager.getInstance(this);
+        getCommand("togglehealthbars").setExecutor(new ToggleHealthBarsCommand(healthBarManager));
 
 
         xpManager = new XPManager(this);
@@ -749,6 +755,9 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         }
         if (playerOxygenManager != null) {
             playerOxygenManager.saveOnShutdown();
+        }
+        if (healthBarManager != null) {
+            healthBarManager.shutdown();
         }
 
         if (combatSubsystemManager != null) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/notification/MonsterHealthBarManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/notification/MonsterHealthBarManager.java
@@ -1,0 +1,184 @@
+package goat.minecraft.minecraftnew.subsystems.combat.notification;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Monster;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Displays temporary health bars above damaged monsters.
+ * Players can toggle visibility with /togglehealthbars.
+ */
+public class MonsterHealthBarManager implements Listener {
+    private static MonsterHealthBarManager instance;
+
+    private final JavaPlugin plugin;
+    private final Map<LivingEntity, ArmorStand> activeBars = new HashMap<>();
+    private final Map<LivingEntity, BukkitTask> tasks = new HashMap<>();
+    private final Set<UUID> hiddenPlayers = new HashSet<>();
+
+    private File dataFile;
+    private FileConfiguration dataConfig;
+
+    private MonsterHealthBarManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        loadData();
+    }
+
+    public static MonsterHealthBarManager getInstance(JavaPlugin plugin) {
+        if (instance == null) {
+            instance = new MonsterHealthBarManager(plugin);
+            Bukkit.getPluginManager().registerEvents(instance, plugin);
+        }
+        return instance;
+    }
+
+    public static MonsterHealthBarManager getInstance() {
+        return instance;
+    }
+
+    private void loadData() {
+        dataFile = new File(plugin.getDataFolder(), "healthbars.yml");
+        if (!dataFile.exists()) {
+            try {
+                dataFile.getParentFile().mkdirs();
+                dataFile.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        dataConfig = YamlConfiguration.loadConfiguration(dataFile);
+        List<String> list = dataConfig.getStringList("hidden");
+        for (String s : list) {
+            try {
+                hiddenPlayers.add(UUID.fromString(s));
+            } catch (IllegalArgumentException ignore) {}
+        }
+    }
+
+    private void saveData() {
+        List<String> list = new ArrayList<>();
+        for (UUID id : hiddenPlayers) {
+            list.add(id.toString());
+        }
+        dataConfig.set("hidden", list);
+        try {
+            dataConfig.save(dataFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void shutdown() {
+        tasks.values().forEach(BukkitTask::cancel);
+        tasks.clear();
+        activeBars.values().forEach(Entity::remove);
+        activeBars.clear();
+        saveData();
+    }
+
+    public void toggle(Player player) {
+        UUID id = player.getUniqueId();
+        if (hiddenPlayers.contains(id)) {
+            hiddenPlayers.remove(id);
+            player.sendMessage(ChatColor.GREEN + "Monster health bars enabled.");
+        } else {
+            hiddenPlayers.add(id);
+            player.sendMessage(ChatColor.RED + "Monster health bars disabled.");
+        }
+        saveData();
+    }
+
+    public boolean isHidden(Player player) {
+        return hiddenPlayers.contains(player.getUniqueId());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onEntityDamage(EntityDamageEvent event) {
+        if (!(event.getEntity() instanceof Monster entity)) return;
+        // Delay to ensure health is updated
+        Bukkit.getScheduler().runTask(plugin, () -> displayBar(entity));
+    }
+
+    private void displayBar(LivingEntity entity) {
+        ArmorStand existing = activeBars.remove(entity);
+        if (existing != null && existing.isValid()) existing.remove();
+        BukkitTask existingTask = tasks.remove(entity);
+        if (existingTask != null) existingTask.cancel();
+
+        if (entity.isDead()) return;
+
+        ArmorStand stand = (ArmorStand) entity.getWorld().spawnEntity(
+                entity.getLocation().add(0, entity.getHeight() + 0.5, 0), EntityType.ARMOR_STAND);
+        stand.setVisible(false);
+        stand.setGravity(false);
+        stand.setMarker(true);
+        stand.setSmall(true);
+        stand.setBasePlate(false);
+        stand.setArms(false);
+        stand.setCustomNameVisible(true);
+
+        updateName(stand, entity);
+
+        for (Player p : Bukkit.getOnlinePlayers()) {
+            if (isHidden(p)) {
+                p.hideEntity(plugin, stand);
+            }
+        }
+
+        activeBars.put(entity, stand);
+
+        BukkitTask task = new BukkitRunnable() {
+            int ticks = 0;
+            @Override
+            public void run() {
+                if (!stand.isValid() || entity.isDead()) {
+                    cleanup();
+                    return;
+                }
+                if (ticks >= 20) {
+                    cleanup();
+                    return;
+                }
+                stand.teleport(entity.getLocation().add(0, entity.getHeight() + 0.5, 0));
+                ticks++;
+            }
+            private void cleanup() {
+                tasks.remove(entity);
+                activeBars.remove(entity);
+                stand.remove();
+                cancel();
+            }
+        }.runTaskTimer(plugin, 0L, 1L);
+        tasks.put(entity, task);
+    }
+
+    private void updateName(ArmorStand stand, LivingEntity entity) {
+        double max = entity.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue();
+        double pct = Math.max(0, Math.min(1, entity.getHealth() / max));
+        int bars = (int) Math.round(pct * 20);
+        StringBuilder sb = new StringBuilder(ChatColor.GREEN.toString());
+        for (int i = 0; i < bars; i++) {
+            sb.append("|");
+        }
+        stand.setCustomName(sb.toString());
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/ToggleHealthBarsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/ToggleHealthBarsCommand.java
@@ -1,0 +1,29 @@
+package goat.minecraft.minecraftnew.utils.commands;
+
+import goat.minecraft.minecraftnew.subsystems.combat.notification.MonsterHealthBarManager;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Command to toggle monster health bar display for a player.
+ */
+public class ToggleHealthBarsCommand implements CommandExecutor {
+    private final MonsterHealthBarManager manager;
+
+    public ToggleHealthBarsCommand(MonsterHealthBarManager manager) {
+        this.manager = manager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+        manager.toggle(player);
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -229,3 +229,7 @@ commands:
     description: Displays your total Spirit Chance
     usage: /spiritchance
     default: true
+  togglehealthbars:
+    description: Toggle monster health bar display
+    usage: /togglehealthbars
+    default: true


### PR DESCRIPTION
## Summary
- add `MonsterHealthBarManager` to display health bars above damaged monsters
- introduce `/togglehealthbars` command for players
- register command and manager in plugin
- persist toggled players in `healthbars.yml`

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve maven plugin due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68770af5068c8332850c032aec0fdf74