### PR TITLE
Add configurable delay for Enchanted Hopper

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TrinketManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TrinketManager.java
@@ -168,6 +168,9 @@ public class TrinketManager implements Listener {
                 if (event.getClick().isLeftClick()) {
                     EnchantedHopperManager.getInstance().openHopper(player, item);
                     event.setCancelled(true);
+                } else if (event.getClick() == ClickType.SHIFT_RIGHT) {
+                    EnchantedHopperManager.getInstance().cycleDelay(player, item);
+                    event.setCancelled(true);
                 }
             }
         }

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -1390,7 +1390,9 @@ public class ItemRegistry {
                 ChatColor.YELLOW + "Enchanted Hopper",
                 List.of(
                         ChatColor.GRAY + "Transfers whitelisted items to container above",
-                        ChatColor.BLUE + "Right-click" + ChatColor.GRAY + ": Configure"
+                        ChatColor.BLUE + "Left-click" + ChatColor.GRAY + ": Configure",
+                        ChatColor.BLUE + "Shift-Right-click" + ChatColor.GRAY + ": Change delay",
+                        ChatColor.GRAY + "Delay: " + ChatColor.WHITE + "0.5s"
                 ),
                 1,
                 false,


### PR DESCRIPTION
## Summary
- allow shift-right-clicking enchanted hoppers to cycle transfer delay
- persist delay selection in the item
- show current delay in item lore
- fix lore to say left-click to configure

## Testing
- `mvn test` *(fails: PluginResolutionException due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68770bfd4e008332a7197c0e6b63352a