### PR TITLE
Remove old upgrades and add new combat talents

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -554,6 +554,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         // Register Soul upgrade system for weapons with Soul Power
         getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.combat.SoulUpgradeSystem(this), this);
         getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.combat.SwordUpgradeListener(this), this);
+        getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.combat.CombatTalentListener(), this);
 
         // Effigy upgrade system for forestry axes
         goat.minecraft.minecraftnew.subsystems.forestry.EffigyUpgradeSystem effigyUpgradeSystem = new goat.minecraft.minecraftnew.subsystems.forestry.EffigyUpgradeSystem(this);

--- a/src/main/java/goat/minecraft/minecraftnew/other/enchanting/enchantingeffects/Bloodlust.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/enchanting/enchantingeffects/Bloodlust.java
@@ -84,53 +84,25 @@ public class Bloodlust implements Listener {
             player.addPotionEffect(new PotionEffect(PotionEffectType.HASTE, Integer.MAX_VALUE, 0, true, false));
         }
 
-        // 3 kills: Strength I + previous effects
-        if (killCount >= 3) {
-            player.addPotionEffect(new PotionEffect(PotionEffectType.STRENGTH, Integer.MAX_VALUE, 0, true, false));
-        }
-
-        // 5 kills: Speed I + previous effects
+        // 5 kills: Speed I
         if (killCount >= 5) {
             player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, Integer.MAX_VALUE, 0, true, false));
         }
 
-        // 10 kills: Double all effects (Haste II, Strength II, Speed II)
+        // 10 kills: Haste II and Speed II
         if (killCount >= 10) {
             player.removePotionEffect(PotionEffectType.HASTE);
-            player.removePotionEffect(PotionEffectType.STRENGTH);
             player.removePotionEffect(PotionEffectType.SPEED);
-            
             player.addPotionEffect(new PotionEffect(PotionEffectType.HASTE, Integer.MAX_VALUE, 1, true, false));
-            player.addPotionEffect(new PotionEffect(PotionEffectType.STRENGTH, Integer.MAX_VALUE, 1, true, false));
             player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, Integer.MAX_VALUE, 1, true, false));
         }
 
-        // 15 kills: Regeneration II + previous effects
-        if (killCount >= 15) {
-            player.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, Integer.MAX_VALUE, 1, true, false));
-        }
-
-        // 20 kills: Resistance II + previous effects
+        // 20 kills: Haste III and Speed III
         if (killCount >= 20) {
-            player.addPotionEffect(new PotionEffect(PotionEffectType.RESISTANCE, Integer.MAX_VALUE, 1, true, false));
-        }
-
-        // 25 kills: Absorption V + previous effects
-        if (killCount >= 25) {
-            player.addPotionEffect(new PotionEffect(PotionEffectType.ABSORPTION, Integer.MAX_VALUE, 4, true, false));
-        }
-
-        // 30 kills: Max bloodlust - all effects at level III
-        if (killCount >= 30) {
-            // Remove all current effects and apply max level versions
-            removeBloodlustEffects(player);
-            
+            player.removePotionEffect(PotionEffectType.HASTE);
+            player.removePotionEffect(PotionEffectType.SPEED);
             player.addPotionEffect(new PotionEffect(PotionEffectType.HASTE, Integer.MAX_VALUE, 2, true, false));
-            player.addPotionEffect(new PotionEffect(PotionEffectType.STRENGTH, Integer.MAX_VALUE, 2, true, false));
             player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, Integer.MAX_VALUE, 2, true, false));
-            player.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, Integer.MAX_VALUE, 2, true, false));
-            player.addPotionEffect(new PotionEffect(PotionEffectType.RESISTANCE, Integer.MAX_VALUE, 2, true, false));
-            player.addPotionEffect(new PotionEffect(PotionEffectType.ABSORPTION, Integer.MAX_VALUE, 4, true, false)); // Keep Absorption V
         }
     }
 
@@ -157,7 +129,6 @@ public class Bloodlust implements Listener {
     }
 
     private void removeBloodlustEffects(Player player) {
-        player.removePotionEffect(PotionEffectType.STRENGTH);
         player.removePotionEffect(PotionEffectType.SPEED);
         player.removePotionEffect(PotionEffectType.HASTE);
         player.removePotionEffect(PotionEffectType.REGENERATION);

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -281,6 +281,15 @@ public class SkillTreeManager implements Listener {
             case DONT_MINE_AT_NIGHT:
                 int creeperBonus = level * 10;
                 return ChatColor.YELLOW + "+" + creeperBonus + "% " + ChatColor.RED + "Creeper Damage";
+            case ULTIMATUM:
+                double furyChance = level;
+                return ChatColor.YELLOW + "+" + furyChance + "% " + ChatColor.GRAY + "Fury activation chance";
+            case ARMAGEDDON:
+                double armChance = level;
+                return ChatColor.YELLOW + "+" + armChance + "% " + ChatColor.GRAY + "Armageddon chance";
+            case VAMPIRIC_STRIKE:
+                double vampChance = level;
+                return ChatColor.YELLOW + "+" + vampChance + "% " + ChatColor.GRAY + "Soul Orb chance";
           default:
                 return talent.getTechnicalDescription();
         }

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -223,6 +223,30 @@ public enum Talent {
             6,
             50,
             Material.TNT
+    ),
+    ULTIMATUM(
+            "Ultimatum",
+            ChatColor.GRAY + "Occasionally unleash devastating fury",
+            ChatColor.YELLOW + "1% chance per level to trigger Fury",
+            25,
+            50,
+            Material.LIGHTNING_ROD
+    ),
+    ARMAGEDDON(
+            "Armageddon",
+            ChatColor.GRAY + "Scatter hordes with a kinetic blast",
+            ChatColor.YELLOW + "1% chance per level to blast foes away",
+            25,
+            50,
+            Material.TNT
+    ),
+    VAMPIRIC_STRIKE(
+            "Vampiric Strike",
+            ChatColor.GRAY + "Harvest souls for brief vitality",
+            ChatColor.YELLOW + "1% chance per level to spawn a Soul Orb",
+            25,
+            50,
+            Material.GHAST_TEAR
     );
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -46,7 +46,10 @@ public final class TalentRegistry {
                         Talent.DIAMOND_SWORD,
                         Talent.NETHERITE_SWORD,
                         Talent.BOW_MASTERY,
-                        Talent.DONT_MINE_AT_NIGHT
+                        Talent.DONT_MINE_AT_NIGHT,
+                        Talent.ULTIMATUM,
+                        Talent.ARMAGEDDON,
+                        Talent.VAMPIRIC_STRIKE
                 )
         );
     //SKILL_TALENTS.put(Skill.BREWING, Collections.singletonList(Talent.REDSTONE_TWO));

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatTalentListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatTalentListener.java
@@ -1,0 +1,152 @@
+package goat.minecraft.minecraftnew.subsystems.combat;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Monster;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.util.Vector;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.bukkit.profile.PlayerProfile;
+import org.bukkit.profile.PlayerTextures;
+import java.util.Base64;
+
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+/**
+ * Handles activation of combat talents like Ultimatum, Armageddon and Vampiric Strike.
+ */
+public class CombatTalentListener implements Listener {
+
+    private static final String SOUL_ORB_KEY = "SOUL_ORB";
+    private static final String SOUL_ORB_TEXTURE = "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvM2NkYWE1YmYwYmM1NDIwNTBjNzM0YzU4ZjQyODMyMTVjOWE0ZjBmMThjM2RkYWQ4NzE5MTNkYmY2NjdjZTQzMyJ9fX0=";
+
+    private final Random random = new Random();
+    private final Map<UUID, Long> ultimatumCooldown = new HashMap<>();
+
+    @EventHandler
+    public void onDamage(EntityDamageByEntityEvent event) {
+        if (!(event.getDamager() instanceof Player player)) return;
+        if (!(event.getEntity() instanceof LivingEntity target) || !(target instanceof Monster)) return;
+        SkillTreeManager manager = SkillTreeManager.getInstance();
+        if (manager == null) return;
+
+        int ultLevel = manager.getTalentLevel(player.getUniqueId(), Skill.COMBAT, Talent.ULTIMATUM);
+        if (ultLevel > 0) {
+            long last = ultimatumCooldown.getOrDefault(player.getUniqueId(), 0L);
+            if (System.currentTimeMillis() - last >= 20_000L && random.nextDouble() < ultLevel * 0.01) {
+                Location loc = player.getLocation();
+                for (Entity e : player.getWorld().getNearbyEntities(loc, 25, 25, 25)) {
+                    if (e instanceof Monster mob) {
+                        mob.getWorld().strikeLightning(mob.getLocation());
+                        mob.damage(100, player);
+                        FireDamageHandler.addFireStacks(mob, 20);
+                    }
+                }
+                ultimatumCooldown.put(player.getUniqueId(), System.currentTimeMillis());
+            }
+        }
+
+        int armLevel = manager.getTalentLevel(player.getUniqueId(), Skill.COMBAT, Talent.ARMAGEDDON);
+        if (armLevel > 0 && random.nextDouble() < armLevel * 0.01) {
+            List<Monster> mobs = new ArrayList<>();
+            for (Entity e : player.getWorld().getNearbyEntities(player.getLocation(), 15, 15, 15)) {
+                if (e instanceof Monster m) mobs.add(m);
+            }
+            if (mobs.size() > 8) {
+                for (Monster mob : mobs) {
+                    if (mob.equals(target)) continue;
+                    Vector vec = mob.getLocation().toVector().subtract(player.getLocation().toVector()).normalize().multiply(1.5);
+                    vec.setY(0.4);
+                    mob.setVelocity(vec);
+                }
+            }
+        }
+    }
+
+    @EventHandler
+    public void onKill(EntityDeathEvent event) {
+        if (!(event.getEntity() instanceof Monster mob)) return;
+        Player killer = mob.getKiller();
+        if (killer == null) return;
+        SkillTreeManager manager = SkillTreeManager.getInstance();
+        if (manager == null) return;
+        int level = manager.getTalentLevel(killer.getUniqueId(), Skill.COMBAT, Talent.VAMPIRIC_STRIKE);
+        if (level > 0 && random.nextDouble() < level * 0.01) {
+            spawnSoulOrb(mob.getLocation(), killer.getUniqueId());
+        }
+    }
+
+    @EventHandler
+    public void onOrbDeath(EntityDeathEvent event) {
+        if (!(event.getEntity() instanceof ArmorStand stand)) return;
+        if (!stand.hasMetadata(SOUL_ORB_KEY)) return;
+        Player killer = event.getEntity().getKiller();
+        if (killer != null) {
+            killer.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, 40, 254));
+        }
+    }
+
+    private void spawnSoulOrb(Location loc, UUID owner) {
+        World world = loc.getWorld();
+        if (world == null) return;
+        ArmorStand stand = world.spawn(loc, ArmorStand.class);
+        stand.setInvisible(true);
+        stand.setSmall(true);
+        stand.setMarker(false);
+        stand.setSilent(true);
+        stand.setCustomName("Soul Orb");
+        stand.setCustomNameVisible(false);
+        stand.getEquipment().setHelmet(createSkull());
+        stand.setHealth(1);
+        stand.setMetadata(SOUL_ORB_KEY, new FixedMetadataValue(MinecraftNew.getInstance(), owner.toString()));
+    }
+
+    private ItemStack createSkull() {
+        ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+        SkullMeta meta = (SkullMeta) head.getItemMeta();
+        setCustomSkullTexture(meta, SOUL_ORB_TEXTURE);
+        head.setItemMeta(meta);
+        return head;
+    }
+
+    private SkullMeta setCustomSkullTexture(SkullMeta skullMeta, String base64Json) {
+        if (skullMeta == null || base64Json == null || base64Json.isEmpty()) {
+            return skullMeta;
+        }
+        try {
+            byte[] decoded = Base64.getDecoder().decode(base64Json);
+            String json = new String(decoded, StandardCharsets.UTF_8);
+            JsonObject root = JsonParser.parseString(json).getAsJsonObject();
+            String urlText = root.getAsJsonObject("textures").getAsJsonObject("SKIN").get("url").getAsString();
+            PlayerProfile profile = Bukkit.createPlayerProfile(UUID.randomUUID());
+            PlayerTextures textures = profile.getTextures();
+            textures.setSkin(new URL(urlText), PlayerTextures.SkinModel.CLASSIC);
+            profile.setTextures(textures);
+            skullMeta.setOwnerProfile(profile);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+        return skullMeta;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SoulUpgradeSystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SoulUpgradeSystem.java
@@ -29,21 +29,19 @@ public class SoulUpgradeSystem implements Listener {
     // ----- ENUMERATIONS -----
 
     public enum SwordUpgrade {
-        LETHALITY("Lethality", "+2% damage per level", Material.NETHERITE_SWORD, 5, 5),
-        LIFESTEAL_REGEN("Regeneration", "+5% chance to gain regeneration per level", Material.GHAST_TEAR, 3, 11),
-        LIFESTEAL_POTENCY("Potency", "+1 regen potency per level", Material.BLAZE_POWDER, 2, 12),
-        LIFESTEAL_DURATION("Duration", "+5 seconds of regeneration per level", Material.CLOCK, 3, 13),
-        FEED("Feed", "15% chance to gain +1 hunger and +2 saturation when hitting a monster", Material.COOKED_BEEF, 1, 14),
+        /* Removed Lethality upgrade */
+        /* Removed regeneration upgrades */
+        /* Removed feed upgrade */
         ASPECT_OF_DECAY("Aspect of Decay", "+5 Deterioration stacks per level", Material.WITHER_ROSE, 4, 6),
         LOYAL_AUGMENT("Loyal Augment", "-1s cooldown per level", Material.NETHER_STAR, 4, 20),
         SHRED_AUGMENT("Shred Augment", "+3 stacks of shredders per level", Material.IRON_SWORD, 6, 21),
         WARP_AUGMENT("Warp Augment", "+5 warp charges per level", Material.ENDER_PEARL, 6, 22),
-        FURY("Fury", "Strike lightning when below 50% HP (30s CD)", Material.LIGHTNING_ROD, 1, 3),
-        BETRAYAL("Betrayal", "+4% creeper disc chance per level", Material.MUSIC_DISC_11, 4, 4),
+        /* Removed fury upgrade */
+        /* Removed betrayal upgrade */
         STARLESS_NIGHT("Starless Night", "+3 seconds of night when killing a monster", Material.BLACK_DYE, 1, 29),
         CHALLENGE("Challenge", "Chance for monsters to spawn twice: +5% chance per level", Material.PAPER, 4, 30),
         BLOOD_MOON("Blood Moon", "Chance for monsters to spawn an additional time: +5% chance per level", Material.RED_BED, 5, 31),
-        APOCALYPSE("Apocalypse", "Enables Death Mutation: 5% per level", Material.WITHER_SKELETON_SKULL, 3, 32),
+        /* Removed apocalypse upgrade */
         BALLAD_OF_THE_CATS("Ballad of the Cats", "increases monster level by 20 per level", Material.MUSIC_DISC_CAT, 5, 33);
 
         private final String name;
@@ -91,18 +89,13 @@ public class SoulUpgradeSystem implements Listener {
         // ----- Hit Effects Row -----
         gui.setItem(0, createHeader(Material.DIAMOND_SWORD, ChatColor.GOLD + "⚔ Hit Effects"));
         gui.setItem(1, createColoredPane(Material.ORANGE_STAINED_GLASS_PANE, ""));
-        gui.setItem(SwordUpgrade.FURY.getSlot(), createUpgradeItem(weapon, SwordUpgrade.FURY, available));
-        gui.setItem(SwordUpgrade.BETRAYAL.getSlot(), createUpgradeItem(weapon, SwordUpgrade.BETRAYAL, available));
-        gui.setItem(SwordUpgrade.LETHALITY.getSlot(), createUpgradeItem(weapon, SwordUpgrade.LETHALITY, available));
+        // Removed Fury, Betrayal and Lethality upgrades
         gui.setItem(SwordUpgrade.ASPECT_OF_DECAY.getSlot(), createUpgradeItem(weapon, SwordUpgrade.ASPECT_OF_DECAY, available));
 
         // ----- Regeneration Row -----
         gui.setItem(9, createHeader(Material.GHAST_TEAR, ChatColor.LIGHT_PURPLE + "❤ Regeneration"));
         gui.setItem(10, createColoredPane(Material.PINK_STAINED_GLASS_PANE, ""));
-        gui.setItem(SwordUpgrade.LIFESTEAL_REGEN.getSlot(), createUpgradeItem(weapon, SwordUpgrade.LIFESTEAL_REGEN, available));
-        gui.setItem(SwordUpgrade.LIFESTEAL_POTENCY.getSlot(), createUpgradeItem(weapon, SwordUpgrade.LIFESTEAL_POTENCY, available));
-        gui.setItem(SwordUpgrade.LIFESTEAL_DURATION.getSlot(), createUpgradeItem(weapon, SwordUpgrade.LIFESTEAL_DURATION, available));
-        gui.setItem(SwordUpgrade.FEED.getSlot(), createUpgradeItem(weapon, SwordUpgrade.FEED, available));
+        // Removed regeneration and feed upgrades
 
         // ----- Augment Row -----
         gui.setItem(18, createHeader(Material.NETHER_STAR, ChatColor.AQUA + "✦ Augments"));
@@ -117,7 +110,7 @@ public class SoulUpgradeSystem implements Listener {
         gui.setItem(SwordUpgrade.STARLESS_NIGHT.getSlot(), createUpgradeItem(weapon, SwordUpgrade.STARLESS_NIGHT, available));
         gui.setItem(SwordUpgrade.CHALLENGE.getSlot(), createUpgradeItem(weapon, SwordUpgrade.CHALLENGE, available));
         gui.setItem(SwordUpgrade.BLOOD_MOON.getSlot(), createUpgradeItem(weapon, SwordUpgrade.BLOOD_MOON, available));
-        gui.setItem(SwordUpgrade.APOCALYPSE.getSlot(), createUpgradeItem(weapon, SwordUpgrade.APOCALYPSE, available));
+        // Removed apocalypse upgrade
         gui.setItem(SwordUpgrade.BALLAD_OF_THE_CATS.getSlot(), createUpgradeItem(weapon, SwordUpgrade.BALLAD_OF_THE_CATS, available));
 
         gui.setItem(49, createExtendedPowerDisplay(power, getPowerCap(weapon), available));
@@ -360,21 +353,19 @@ public class SoulUpgradeSystem implements Listener {
     // ----- SYMBOLS & COLORS -----
     private String getSymbol(String key) {
         switch (key) {
-            case "LIFESTEAL_REGEN": return "❤";
-            case "LIFESTEAL_POTENCY": return "✚";
-            case "LIFESTEAL_DURATION": return "⌛";
+            // Removed regeneration related symbols
             case "LOYAL_AUGMENT": return "⚔";
             case "SHRED_AUGMENT": return "✂";
             case "WARP_AUGMENT": return "✦";
-            case "FURY": return "⚡";
-            case "BETRAYAL": return "♬";
-            case "LETHALITY": return "✖";
-            case "FEED": return "☕";
+            // Removed fury symbol
+            // Removed betrayal symbol
+            // Removed lethality symbol
+            // Removed feed symbol
             case "ASPECT_OF_DECAY": return "☣";
             case "STARLESS_NIGHT": return "☾";
             case "CHALLENGE": return "⚑";
             case "BLOOD_MOON": return "☽";
-            case "APOCALYPSE": return "☢";
+            // Removed apocalypse symbol
             case "BALLAD_OF_THE_CATS": return "♪";
             default: return "⬡";
         }
@@ -478,21 +469,19 @@ public class SoulUpgradeSystem implements Listener {
 
     private static String getSymbolStatic(String key) {
         return switch (key) {
-            case "LIFESTEAL_REGEN" -> "❤";
-            case "LIFESTEAL_POTENCY" -> "✚";
-            case "LIFESTEAL_DURATION" -> "⌛";
+            // Removed regeneration related symbols
             case "LOYAL_AUGMENT" -> "⚔";
             case "SHRED_AUGMENT" -> "✂";
             case "WARP_AUGMENT" -> "✦";
-            case "FURY" -> "⚡";
-            case "BETRAYAL" -> "♬";
-            case "LETHALITY" -> "✖";
-            case "FEED" -> "☕";
+            // Removed fury symbol
+            // Removed betrayal symbol
+            // Removed lethality symbol
+            // Removed feed symbol
             case "ASPECT_OF_DECAY" -> "☣";
             case "STARLESS_NIGHT" -> "☾";
             case "CHALLENGE" -> "⚑";
             case "BLOOD_MOON" -> "☽";
-            case "APOCALYPSE" -> "☢";
+            // Removed apocalypse symbol
             case "BALLAD_OF_THE_CATS" -> "♪";
             default -> "⬡";
         };

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SpawnMonsters.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SpawnMonsters.java
@@ -309,18 +309,7 @@ public class SpawnMonsters implements Listener {
         Random random = new Random();
 
 
-        if(getNearestPlayer(entity, 1000) != null){
-            int apocalypse = SoulUpgradeSystem.getUpgradeLevel(getNearestPlayer(entity, 1000).getItemInUse(), SoulUpgradeSystem.SwordUpgrade.APOCALYPSE);
-            if (apocalypse > 0 && entity instanceof Monster && random.nextDouble() < apocalypse * 0.05) {
-                new BukkitRunnable() {
-                    @Override
-                    public void run() {
-                        applyMobAttributes((LivingEntity) entity, 300);
-                    }
-                }.runTaskLater(MinecraftNew.getInstance(), 41L);
-
-            }
-        }
+        // Apocalypse upgrade removed
 
         if (entity instanceof Creeper) {
             int randomValue = random.nextInt(100) + 1;

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SwordUpgradeListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SwordUpgradeListener.java
@@ -16,8 +16,6 @@ import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntitySpawnEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 
 import java.util.*;
 
@@ -28,7 +26,6 @@ import static goat.minecraft.minecraftnew.subsystems.villagers.VillagerWorkCycle
  */
 public class SwordUpgradeListener implements Listener {
     private final Random random = new Random();
-    private final Map<UUID, Long> furyCooldown = new HashMap<>();
     private final XPManager xpManager;
 
     public SwordUpgradeListener(MinecraftNew plugin) {
@@ -42,10 +39,6 @@ public class SwordUpgradeListener implements Listener {
         if (weapon == null) return;
         if (!(event.getEntity() instanceof LivingEntity target)) return;
 
-        int lethality = SoulUpgradeSystem.getUpgradeLevel(weapon, SoulUpgradeSystem.SwordUpgrade.LETHALITY);
-        if (lethality > 0) {
-            event.setDamage(event.getDamage() * (1 + lethality * 0.02));
-        }
         int decayLvl = SoulUpgradeSystem.getUpgradeLevel(weapon, SoulUpgradeSystem.SwordUpgrade.ASPECT_OF_DECAY);
         if (decayLvl > 0) {
             int stacks = decayLvl * 2;
@@ -66,31 +59,11 @@ public class SwordUpgradeListener implements Listener {
             }
         }
 
-        int regenLvl = SoulUpgradeSystem.getUpgradeLevel(weapon, SoulUpgradeSystem.SwordUpgrade.LIFESTEAL_REGEN);
-        if (regenLvl > 0 && random.nextDouble() < regenLvl * 0.05) {
-            int pot = SoulUpgradeSystem.getUpgradeLevel(weapon, SoulUpgradeSystem.SwordUpgrade.LIFESTEAL_POTENCY);
-            int dur = SoulUpgradeSystem.getUpgradeLevel(weapon, SoulUpgradeSystem.SwordUpgrade.LIFESTEAL_DURATION);
-            int ticks = (5 + dur * 5) * 20;
-            player.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, ticks, pot));
-        }
+        // Regeneration upgrades removed
 
-        if (SoulUpgradeSystem.getUpgradeLevel(weapon, SoulUpgradeSystem.SwordUpgrade.FEED) > 0 && target instanceof Monster) {
-            if (random.nextDouble() < 0.15) {
-                player.setFoodLevel(Math.min(20, player.getFoodLevel() + 1));
-                player.setSaturation(Math.min(20f, player.getSaturation() + 2f));
-                player.playSound(player.getLocation(), Sound.ENTITY_PLAYER_BURP, 1f, 1f);
-            }
-        }
+        // Feed upgrade removed
 
-        if (SoulUpgradeSystem.getUpgradeLevel(weapon, SoulUpgradeSystem.SwordUpgrade.FURY) > 0) {
-            if (player.getHealth() <= player.getMaxHealth() / 2) {
-                long last = furyCooldown.getOrDefault(player.getUniqueId(), 0L);
-                if (System.currentTimeMillis() - last > 30_000L) {
-                    target.getWorld().strikeLightning(target.getLocation());
-                    furyCooldown.put(player.getUniqueId(), System.currentTimeMillis());
-                }
-            }
-        }
+        // Fury upgrade removed
     }
     @EventHandler
     public void onSpawn(EntitySpawnEvent e) {
@@ -136,12 +109,7 @@ public class SwordUpgradeListener implements Listener {
         if (weapon == null) return;
         LivingEntity mob = event.getEntity();
 
-        if (mob instanceof Creeper) {
-            int level = SoulUpgradeSystem.getUpgradeLevel(weapon, SoulUpgradeSystem.SwordUpgrade.BETRAYAL);
-            if (level > 0 && random.nextDouble() < level * 0.04) {
-                mob.getWorld().dropItemNaturally(mob.getLocation(), new ItemStack(Material.MUSIC_DISC_11));
-            }
-        }
+        // Betrayal upgrade removed
 
         if (SoulUpgradeSystem.getUpgradeLevel(weapon, SoulUpgradeSystem.SwordUpgrade.STARLESS_NIGHT) > 0 && mob instanceof Monster) {
             World world = mob.getWorld();


### PR DESCRIPTION
## Summary
- delete fury, regeneration, feed, lethality, betrayal and apocalypse sword upgrades
- slim Bloodlust enchantment down to only haste and speed
- register new combat talents (Ultimatum, Armageddon and Vampiric Strike)
- implement `CombatTalentListener` to handle the new talents
- wire up new listener in plugin enable

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6877462e606883328a128e3d853f5599