### PR TITLE
Add Mining skill talents

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/enchanting/enchantingeffects/Forge.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/enchanting/enchantingeffects/Forge.java
@@ -2,7 +2,9 @@ package goat.minecraft.minecraftnew.other.enchanting.enchantingeffects;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentManager;
-import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -33,11 +35,14 @@ public class Forge implements Listener {
         Material smeltedType = getSmeltedMaterial(block.getType());
 
 
-        // Additional item drop logic
-        XPManager xpManager = new XPManager(MinecraftNew.getInstance());
-        int miningLevel = xpManager.getPlayerLevel(player, "Mining"); // Assuming mining level is based on player XP level
-        if (random.nextDouble() < (miningLevel / 2.0) / 100.0) {
-            if(getSmeltedMaterial(block.getType()) != null) {
+        // Additional item drop logic based on Mining talent
+        int talentLevel = 0;
+        if (SkillTreeManager.getInstance() != null) {
+            talentLevel = SkillTreeManager.getInstance()
+                    .getTalentLevel(player.getUniqueId(), Skill.MINING, Talent.RICH_VEINS);
+        }
+        if (random.nextDouble() < (talentLevel * 4) / 100.0) {
+            if (getSmeltedMaterial(block.getType()) != null) {
                 block.getWorld().dropItemNaturally(block.getLocation(), new ItemStack(Objects.requireNonNull(getSmeltedMaterial(block.getType()))));
             }
         }

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Skill.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Skill.java
@@ -2,7 +2,8 @@ package goat.minecraft.minecraftnew.other.skilltree;
 
 public enum Skill {
     BREWING("Brewing"),
-    COMBAT("Combat");
+    COMBAT("Combat"),
+    MINING("Mining");
 
     private final String displayName;
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -287,6 +287,12 @@ public class SkillTreeManager implements Listener {
             case VAMPIRIC_STRIKE:
                 double vampChance = level;
                 return ChatColor.YELLOW + "+" + vampChance + "% " + ChatColor.GRAY + "Soul Orb chance";
+            case RICH_VEINS:
+                double dropChance = level * 4;
+                return ChatColor.YELLOW + "+" + dropChance + "% " + ChatColor.GRAY + "Double Drop Chance";
+            case DEEP_LUNGS:
+                int oxygenBonus = level * 20;
+                return ChatColor.YELLOW + "+" + oxygenBonus + " " + ChatColor.AQUA + "Oxygen Capacity";
           default:
                 return talent.getTechnicalDescription();
         }

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -239,6 +239,24 @@ public enum Talent {
             6,
             50,
             Material.GHAST_TEAR
+    ),
+
+    RICH_VEINS(
+            "Rich Veins",
+            ChatColor.GRAY + "Find extra ore when mining",
+            ChatColor.YELLOW + "+(4*level)% " + ChatColor.GRAY + "Double Drop Chance",
+            25,
+            1,
+            Material.IRON_PICKAXE
+    ),
+
+    DEEP_LUNGS(
+            "Deep Lungs",
+            ChatColor.GRAY + "Increase oxygen capacity underground",
+            ChatColor.YELLOW + "+(20*level) " + ChatColor.AQUA + "Oxygen Capacity",
+            25,
+            10,
+            Material.SCUTE
     );
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -51,6 +51,14 @@ public final class TalentRegistry {
                         Talent.VAMPIRIC_STRIKE
                 )
         );
+
+        SKILL_TALENTS.put(
+                Skill.MINING,
+                Arrays.asList(
+                        Talent.RICH_VEINS,
+                        Talent.DEEP_LUNGS
+                )
+        );
     //SKILL_TALENTS.put(Skill.BREWING, Collections.singletonList(Talent.REDSTONE_TWO));
     }
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/mining/Mining.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/mining/Mining.java
@@ -228,9 +228,13 @@ public class Mining implements Listener {
                 block.getWorld().dropItemNaturally(block.getLocation(), new ItemStack(Material.DIAMOND, 1));
             }
 
-            // Apply haste effect based on Mining level
-            int miningLevel = xpManager.getPlayerLevel(player, "Mining");
-            double doubleDropChance = (double) miningLevel / 2;
+            // Determine double drop chance from talent
+            int talentLevel = 0;
+            if (SkillTreeManager.getInstance() != null) {
+                talentLevel = SkillTreeManager.getInstance()
+                        .getTalentLevel(player.getUniqueId(), Skill.MINING, Talent.RICH_VEINS);
+            }
+            double doubleDropChance = talentLevel * 4;
 
             boolean hasDiamondGem = gemManager.getGemsFromItem(tool).contains(MiningGemManager.MiningGem.DIAMOND_GEM);
             double tripleDropChance = hasDiamondGem ? 10 : 0; // 10% chance for triple drops if Diamond Gem is applied

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/mining/PlayerOxygenManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/mining/PlayerOxygenManager.java
@@ -3,7 +3,9 @@ package goat.minecraft.minecraftnew.subsystems.mining;
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.other.additionalfunctionality.BlessingUtils;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
-import goat.minecraft.minecraftnew.utils.devtools.XPManager; // Remove this if no longer needed anywhere else
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
 import org.bukkit.*;
 import org.bukkit.block.Block;
@@ -218,15 +220,18 @@ public class PlayerOxygenManager implements Listener {
      * For now, if Mining level is unavailable, a default is used.
      */
     public int calculateInitialOxygen(Player player) {
-        XPManager xpManager = new XPManager(plugin);
-        int miningLevel = xpManager.getPlayerLevel(player, "Mining");
+        int talentLevel = 0;
+        if (SkillTreeManager.getInstance() != null) {
+            talentLevel = SkillTreeManager.getInstance()
+                    .getTalentLevel(player.getUniqueId(), Skill.MINING, Talent.DEEP_LUNGS);
+        }
         int ventilationBonus = getTotalVentilationEnchantmentLevel(player) * 25;
         int dwellerBonus = 0;
-        if(BlessingUtils.hasFullSetBonus(player, "Dweller")){
+        if (BlessingUtils.hasFullSetBonus(player, "Dweller")) {
             dwellerBonus += 500;
         }
 
-        int initialOxygen = DEFAULT_OXYGEN_SECONDS + (miningLevel * 4) + ventilationBonus + dwellerBonus;
+        int initialOxygen = DEFAULT_OXYGEN_SECONDS + (talentLevel * 20) + ventilationBonus + dwellerBonus;
         return initialOxygen;
     }
 

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/SkillsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/SkillsCommand.java
@@ -3,6 +3,7 @@ package goat.minecraft.minecraftnew.utils.commands;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import goat.minecraft.minecraftnew.other.skilltree.Skill;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -170,11 +171,17 @@ public class SkillsCommand implements CommandExecutor, Listener {
                 break;
 
             case "Mining":
+                int veins = 0;
+                int lungs = 0;
+                if (SkillTreeManager.getInstance() != null) {
+                    veins = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.MINING, Talent.RICH_VEINS);
+                    lungs = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.MINING, Talent.DEEP_LUNGS);
+                }
                 double duration = 200 + (level * 4);
                 lore = new ArrayList<>(Arrays.asList(
                         ChatColor.GRAY + "Level: " + ChatColor.GREEN + (int) level,
-                        ChatColor.GRAY + "Bonus Oxygen: +" + ChatColor.GREEN + (4 * level) + " seconds",
-                        ChatColor.GRAY + "Double Drops Chance: " + ChatColor.GREEN + (level / 2) + "%",
+                        ChatColor.GRAY + "Bonus Oxygen: +" + ChatColor.GREEN + (lungs * 20) + " seconds",
+                        ChatColor.GRAY + "Double Drops Chance: " + ChatColor.GREEN + (veins * 4) + "%",
                         ChatColor.GRAY + "Gold Fever: " + ChatColor.GREEN + "Haste " + 1 + " (" + duration / 20 + "s)"
                 ));
                 break;


### PR DESCRIPTION
## Summary
- introduce new `MINING` skill
- add `RICH_VEINS` and `DEEP_LUNGS` talents
- tie mining double drop chance to the Rich Veins talent
- tie oxygen capacity to the Deep Lungs talent
- display talent effects in the skills command

## Testing
- `mvn -q test` *(fails: Could not resolve plugin from repo.maven.apache.org)*
- `mvn -q -DskipTests package` *(fails: Could not resolve plugin from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_6878870ab21883328b56afec830f33e6