### PR TITLE
Add fishing talent and refactor sea creature scaling

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Skill.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Skill.java
@@ -2,7 +2,8 @@ package goat.minecraft.minecraftnew.other.skilltree;
 
 public enum Skill {
     BREWING("Brewing"),
-    COMBAT("Combat");
+    COMBAT("Combat"),
+    FISHING("Fishing");
 
     private final String displayName;
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -263,6 +263,9 @@ public class SkillTreeManager implements Listener {
                 int fountainDuration = level * 50;
                 return ChatColor.YELLOW + "+" + fountainDuration + "s " + ChatColor.LIGHT_PURPLE + "Fountains Duration, "
                         + ChatColor.AQUA + "+5% Sea Creature Chance";
+            case ANGLERS_INSTINCT:
+                double seaBonus = level * 0.25;
+                return ChatColor.YELLOW + "+" + seaBonus + "% " + ChatColor.AQUA + "Sea Creature Chance";
             case CHARISMA_MASTERY:
                 int charismaDuration = level * 50;
                 return ChatColor.YELLOW + "+" + charismaDuration + "s " + ChatColor.LIGHT_PURPLE + "Charismatic Bartering Duration, "

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -151,6 +151,14 @@ public enum Talent {
             60,
             Material.DARK_PRISMARINE
     ),
+    ANGLERS_INSTINCT(
+            "Angler's Instinct",
+            ChatColor.GRAY + "Hone your talent for reeling in the unusual",
+            ChatColor.YELLOW + "+0.25% " + ChatColor.AQUA + "Sea Creature Chance per level",
+            25,
+            1,
+            Material.NAUTILUS_SHELL
+    ),
     CHARISMA_MASTERY(
             "Charisma Mastery",
             ChatColor.GRAY + "Add a bribe",

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -11,7 +11,7 @@ public final class TalentRegistry {
     private static final Map<Skill, List<Talent>> SKILL_TALENTS = new HashMap<>();
 
     static {
-        // Currently only the Brewing skill has talents defined.
+        // Register talents for each supported skill.
         SKILL_TALENTS.put(
                 Skill.BREWING,
                 Arrays.asList(
@@ -49,6 +49,13 @@ public final class TalentRegistry {
                         Talent.DONT_MINE_AT_NIGHT,
                         Talent.ULTIMATUM,
                         Talent.VAMPIRIC_STRIKE
+                )
+        );
+
+        SKILL_TALENTS.put(
+                Skill.FISHING,
+                Arrays.asList(
+                        Talent.ANGLERS_INSTINCT
                 )
         );
     //SKILL_TALENTS.put(Skill.BREWING, Collections.singletonList(Talent.REDSTONE_TWO));

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/FishingEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/FishingEvent.java
@@ -106,8 +106,11 @@ public class FishingEvent implements Listener {
         int fishingLevel = xpManager.getPlayerLevel(player, "Fishing"); // Get player's fishing level
         double seaCreatureChance = 0;
         
-        // Add fishing level bonus
-        seaCreatureChance += fishingLevel / 4.0;
+
+        // Talent: Angler's Instinct grants additional sea creature chance
+        int instinctLevel = SkillTreeManager.getInstance()
+                .getTalentLevel(player.getUniqueId(), Skill.FISHING, Talent.ANGLERS_INSTINCT);
+        seaCreatureChance += instinctLevel * 0.25;
 
         // Add "Call of the Void" enchantment bonus
         int callOfTheVoidLevel = CustomEnchantmentManager.getEnchantmentLevel(player.getInventory().getItemInMainHand(), "Call of the Void");

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureChanceCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureChanceCommand.java
@@ -13,6 +13,7 @@ import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
 import goat.minecraft.minecraftnew.other.skilltree.Talent;
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -43,8 +44,9 @@ public class SeaCreatureChanceCommand implements CommandExecutor {
 
     private void sendSeaCreatureChanceBreakdown(Player player) {
         double base = 0.0;
-        int fishingLevel = xpManager.getPlayerLevel(player, "Fishing");
-        double fishingLevelBonus = fishingLevel / 4.0;
+        int instinctLevel = SkillTreeManager.getInstance()
+                .getTalentLevel(player.getUniqueId(), Skill.FISHING, Talent.ANGLERS_INSTINCT);
+        double talentBonus = instinctLevel * 0.25;
 
         int callOfTheVoidLevel = CustomEnchantmentManager.getEnchantmentLevel(player.getInventory().getItemInMainHand(), "Call of the Void");
         double callOfTheVoidBonus = callOfTheVoidLevel;
@@ -98,12 +100,11 @@ public class SeaCreatureChanceCommand implements CommandExecutor {
             }
         }
 
-        double total = base + nauticalBonus + fishingLevelBonus + callOfTheVoidBonus + fountainBonus + fountainMastery + depthBonus + talismanBonus + fathmicPenalty + sonarBonus + petBonus;
+        double total = base + nauticalBonus + talentBonus + callOfTheVoidBonus + fountainBonus + fountainMastery + depthBonus + talismanBonus + fathmicPenalty + sonarBonus + petBonus;
 
         player.sendMessage(ChatColor.AQUA + "Sea Creature Chance Breakdown:");
         player.sendMessage(ChatColor.AQUA + "Base SCC: " + ChatColor.YELLOW + "0%");
-        player.sendMessage(ChatColor.AQUA + "SCC per Fishing Level: " + ChatColor.YELLOW + "0.25");
-        player.sendMessage(ChatColor.AQUA + "SCC from Fishing Level: " + ChatColor.YELLOW + String.format("%.2f", fishingLevelBonus) + "%");
+        player.sendMessage(ChatColor.AQUA + "SCC from Angler's Instinct: " + ChatColor.YELLOW + String.format("%.2f", talentBonus) + "%");
         player.sendMessage(ChatColor.AQUA + "SCC from COTV: " + ChatColor.YELLOW + String.format("%.2f", callOfTheVoidBonus) + "%");
         player.sendMessage(ChatColor.AQUA + "SCC from Potion of Fountains: " + ChatColor.YELLOW + String.format("%.2f", fountainBonus) + "%");
         if(fountainMastery > 0){

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/SkillsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/SkillsCommand.java
@@ -3,6 +3,7 @@ package goat.minecraft.minecraftnew.utils.commands;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import goat.minecraft.minecraftnew.other.skilltree.Skill;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -155,9 +156,12 @@ public class SkillsCommand implements CommandExecutor, Listener {
                 ));
                 break;
             case "Fishing":
+                int instinct = SkillTreeManager.getInstance()
+                        .getTalentLevel(player.getUniqueId(), Skill.FISHING, Talent.ANGLERS_INSTINCT);
+                double chance = instinct * 0.25;
                 lore = new ArrayList<>(Arrays.asList(
                         ChatColor.BLUE + "Level: " + ChatColor.GREEN + (int) level,
-                        ChatColor.BLUE + "Sea Creature Chance: " + ChatColor.GREEN + (level / 4) + "%"
+                        ChatColor.BLUE + "Sea Creature Chance: " + ChatColor.GREEN + chance + "%"
                 ));
                 break;
             case "Farming":


### PR DESCRIPTION
## Summary
- introduce Fishing skill to the skill tree
- add Angler's Instinct talent and hook up dynamic descriptions
- register the new talent to Fishing
- adjust sea creature chance calculations to use the talent
- display talent bonus in skills GUI and command output

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6878874ad3f08332b5b0ebfa7287105b