### PR TITLE
Add farming talent support

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Skill.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Skill.java
@@ -2,7 +2,8 @@ package goat.minecraft.minecraftnew.other.skilltree;
 
 public enum Skill {
     BREWING("Brewing"),
-    COMBAT("Combat");
+    COMBAT("Combat"),
+    FARMING("Farming");
 
     private final String displayName;
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -287,6 +287,12 @@ public class SkillTreeManager implements Listener {
             case VAMPIRIC_STRIKE:
                 double vampChance = level;
                 return ChatColor.YELLOW + "+" + vampChance + "% " + ChatColor.GRAY + "Soul Orb chance";
+            case BOUNTIFUL_HARVEST:
+                double cropChance = level * 4;
+                return ChatColor.YELLOW + "+" + cropChance + "% " + ChatColor.GRAY + "chance to harvest " + ChatColor.GREEN + "double crops.";
+            case VERDANT_TENDING:
+                double minutes = level * 2.5;
+                return ChatColor.YELLOW + "-" + minutes + "m " + ChatColor.GRAY + "Verdant Relic growth time";
           default:
                 return talent.getTechnicalDescription();
         }

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -239,6 +239,22 @@ public enum Talent {
             6,
             50,
             Material.GHAST_TEAR
+    ),
+    BOUNTIFUL_HARVEST(
+            "Bountiful Harvest",
+            ChatColor.GRAY + "Increases chances for extra crops",
+            ChatColor.YELLOW + "+(4*level)% " + ChatColor.GRAY + "chance to harvest " + ChatColor.GREEN + "double crops.",
+            25,
+            1,
+            Material.WHEAT
+    ),
+    VERDANT_TENDING(
+            "Verdant Tending",
+            ChatColor.GRAY + "Expertise with relic cultivation",
+            ChatColor.YELLOW + "-" + ChatColor.WHITE + "(2.5*level)m" + ChatColor.GRAY + " Verdant Relic growth time",
+            10,
+            40,
+            Material.BONE_MEAL
     );
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -51,6 +51,14 @@ public final class TalentRegistry {
                         Talent.VAMPIRIC_STRIKE
                 )
         );
+
+        SKILL_TALENTS.put(
+                Skill.FARMING,
+                Arrays.asList(
+                        Talent.BOUNTIFUL_HARVEST,
+                        Talent.VERDANT_TENDING
+                )
+        );
     //SKILL_TALENTS.put(Skill.BREWING, Collections.singletonList(Talent.REDSTONE_TWO));
     }
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/FarmingEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/FarmingEvent.java
@@ -8,6 +8,9 @@ import goat.minecraft.minecraftnew.other.beacon.CatalystManager;
 import goat.minecraft.minecraftnew.other.beacon.CatalystType;
 import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -111,9 +114,9 @@ public class FarmingEvent implements Listener {
             // Play harvest sound
             player.playSound(player.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 2.0f);
 
-            // Calculate level/2 chance for double drops
-            int farmingLevel = xpManager.getPlayerLevel(player, "Farming");
-            boolean doubled = random.nextInt(100) < farmingLevel;
+            int talentLevel = SkillTreeManager.getInstance()
+                    .getTalentLevel(player.getUniqueId(), Skill.FARMING, Talent.BOUNTIFUL_HARVEST);
+            boolean doubled = random.nextDouble() < (talentLevel * 0.04);
 
             CatalystManager catalystManager = CatalystManager.getInstance();
             boolean tripled = false;

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/VerdantRelicsSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/VerdantRelicsSubsystem.java
@@ -25,6 +25,9 @@ import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
 
 import java.io.File;
 import java.io.IOException;
@@ -284,6 +287,10 @@ public class VerdantRelicsSubsystem implements Listener {
             growthDuration = 10 * 1200 * 3; // 30 in-game days
         }
 
+        int talentLevel = SkillTreeManager.getInstance()
+                .getTalentLevel(p.getUniqueId(), Skill.FARMING, Talent.VERDANT_TENDING);
+        int reduction = talentLevel * 150; // 2.5 minutes per level
+        growthDuration = Math.max(growthDuration - reduction, 0);
 
         RelicSession session = new RelicSession(locKey, relicName, growthDuration, growthDuration);
         activeSessions.put(locKey, session);

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/SkillsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/SkillsCommand.java
@@ -3,6 +3,7 @@ package goat.minecraft.minecraftnew.utils.commands;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import goat.minecraft.minecraftnew.other.skilltree.Skill;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -161,11 +162,12 @@ public class SkillsCommand implements CommandExecutor, Listener {
                 ));
                 break;
             case "Farming":
-                double growthTimeDays = 10 - 5 * ((level - 1) / 99.0);
+                int harvestTalent = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.FARMING, Talent.BOUNTIFUL_HARVEST);
+                int growthTalent = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.FARMING, Talent.VERDANT_TENDING);
                 lore = new ArrayList<>(Arrays.asList(
                         ChatColor.YELLOW + "Level: " + ChatColor.GREEN + (int) level,
-                        ChatColor.YELLOW + "Double Crops Chance: " + ChatColor.GREEN + (level / 2) + "%",
-                        ChatColor.YELLOW + "Growth Time: " + ChatColor.GREEN + String.format("%.1f", growthTimeDays) + " days"
+                        ChatColor.YELLOW + "Double Crops Chance: " + ChatColor.GREEN + (harvestTalent * 4) + "%",
+                        ChatColor.YELLOW + "Relic Growth Reduction: " + ChatColor.GREEN + String.format("%.1f", growthTalent * 2.5) + " min"
                 ));
                 break;
 


### PR DESCRIPTION
## Summary
- introduce `BOUNTIFUL_HARVEST` and `VERDANT_TENDING` talents
- register Farming as a skill and include new talents
- use new talents for double crop chance and relic growth reduction
- show talent effects in the Skills GUI

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687887ba46908332838f2629117ba320