### PR TITLE
Add Terraforming skill talents

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Skill.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Skill.java
@@ -2,7 +2,8 @@ package goat.minecraft.minecraftnew.other.skilltree;
 
 public enum Skill {
     BREWING("Brewing"),
-    COMBAT("Combat");
+    COMBAT("Combat"),
+    TERRAFORMING("Terraforming");
 
     private final String displayName;
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -287,6 +287,12 @@ public class SkillTreeManager implements Listener {
             case VAMPIRIC_STRIKE:
                 double vampChance = level;
                 return ChatColor.YELLOW + "+" + vampChance + "% " + ChatColor.GRAY + "Soul Orb chance";
+            case CONSERVATIONIST:
+                double duraChance = level;
+                return ChatColor.YELLOW + "+" + duraChance + "% " + ChatColor.GRAY + "durability save chance";
+            case GRAVE_INTUITION:
+                double graveChance = level * 0.001;
+                return ChatColor.YELLOW + "+" + String.format("%.3f", graveChance) + ChatColor.GRAY + " grave chance";
           default:
                 return talent.getTechnicalDescription();
         }

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -239,6 +239,22 @@ public enum Talent {
             6,
             50,
             Material.GHAST_TEAR
+    ),
+    CONSERVATIONIST(
+            "Conservationist",
+            ChatColor.GRAY + "Reduce wear on your tools",
+            ChatColor.YELLOW + "+(1*level)% " + ChatColor.GRAY + "durability save chance",
+            25,
+            1,
+            Material.DIAMOND_PICKAXE
+    ),
+    GRAVE_INTUITION(
+            "Grave Intuition",
+            ChatColor.GRAY + "Sense where graves may appear",
+            ChatColor.YELLOW + "+(0.001*level) " + ChatColor.GRAY + "grave chance",
+            10,
+            25,
+            Material.BONE
     );
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -51,6 +51,14 @@ public final class TalentRegistry {
                         Talent.VAMPIRIC_STRIKE
                 )
         );
+
+        SKILL_TALENTS.put(
+                Skill.TERRAFORMING,
+                Arrays.asList(
+                        Talent.CONSERVATIONIST,
+                        Talent.GRAVE_INTUITION
+                )
+        );
     //SKILL_TALENTS.put(Skill.BREWING, Collections.singletonList(Talent.REDSTONE_TWO));
     }
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
@@ -126,6 +126,8 @@ public class Gravedigging implements Listener {
                 chance += 0.01 * level;
             }
         }
+        int intuition = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.TERRAFORMING, Talent.GRAVE_INTUITION);
+        chance += 0.001 * intuition;
         if (isNight(world)) {
             chance = Math.min(1.0, chance * 2);
         }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/terraforming/TerraformingDurability.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/terraforming/TerraformingDurability.java
@@ -1,7 +1,8 @@
 package goat.minecraft.minecraftnew.subsystems.gravedigging.terraforming;
 
-import goat.minecraft.minecraftnew.MinecraftNew;
-import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -11,13 +12,13 @@ import org.bukkit.event.player.PlayerItemDamageEvent;
  * Grants a chance to prevent durability loss based on the player's Terraforming level.
  */
 public class TerraformingDurability implements Listener {
-    private final XPManager xpManager = new XPManager(MinecraftNew.getInstance());
 
     @EventHandler
     public void onItemDamage(PlayerItemDamageEvent event) {
         Player player = event.getPlayer();
-        int level = xpManager.getPlayerLevel(player, "Terraforming");
-        double chance = level * 0.0025; // (0.25 * level)% chance
+        int level = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(),
+                Skill.TERRAFORMING, Talent.CONSERVATIONIST);
+        double chance = level * 0.01; // 1% per talent level
 
         if (Math.random() < chance) {
             event.setCancelled(true);

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/SkillsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/SkillsCommand.java
@@ -3,6 +3,7 @@ package goat.minecraft.minecraftnew.utils.commands;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import goat.minecraft.minecraftnew.other.skilltree.Skill;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -179,9 +180,14 @@ public class SkillsCommand implements CommandExecutor, Listener {
                 ));
                 break;
             case "Terraforming":
+                int duraLvl = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(),
+                        Skill.TERRAFORMING, Talent.CONSERVATIONIST);
+                int graveLvl = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(),
+                        Skill.TERRAFORMING, Talent.GRAVE_INTUITION);
                 lore = new ArrayList<>(Arrays.asList(
                         ChatColor.GREEN + "Level: " + ChatColor.GREEN + (int) level,
-                        ChatColor.GREEN + "Unbreaking Chance: " + level * 0.25 // simple descriptor
+                        ChatColor.GREEN + "Durability Save Chance: " + ChatColor.GREEN + duraLvl + "%",
+                        ChatColor.GREEN + "Grave Chance Bonus: " + ChatColor.GREEN + String.format("%.3f", graveLvl * 0.001)
                 ));
                 break;
             case "Combat":


### PR DESCRIPTION
## Summary
- support Terraforming in the talent system
- implement Conservationist and Grave Intuition talents
- use new talents for durability and grave spawning logic
- show talent info in `/skills` GUI

## Testing
- `mvn -q -DskipTests install` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6878880c97f4833284ec4b6aad45edf6