### PR TITLE
Add custom durability system

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -57,6 +57,8 @@ import goat.minecraft.minecraftnew.utils.developercommands.*;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
 import goat.minecraft.minecraftnew.utils.developercommands.AddTalentPointCommand;
 import goat.minecraft.minecraftnew.utils.devtools.*;
+import goat.minecraft.minecraftnew.other.durability.CustomDurabilityManager;
+import goat.minecraft.minecraftnew.utils.developercommands.SetCustomDurabilityCommand;
 import goat.minecraft.minecraftnew.utils.dimensions.end.BetterEnd;
 import goat.minecraft.minecraftnew.other.trinkets.BankAccountManager;
 import goat.minecraft.minecraftnew.other.trinkets.SatchelManager;
@@ -210,7 +212,9 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         PlayerOxygenManager oxygenManager = new PlayerOxygenManager(this);
         this.getCommand("setplayeroxygen").setExecutor(new SetPlayerOxygenCommand());
 
-
+        // Initialize custom durability system
+        CustomDurabilityManager durabilityManager = CustomDurabilityManager.init(this);
+        this.getCommand("setcustomdurability").setExecutor(new SetCustomDurabilityCommand(durabilityManager));
 
         new SetDurabilityCommand(this);
         this.getCommand("skin").setExecutor(new SkinCommand());

--- a/src/main/java/goat/minecraft/minecraftnew/other/durability/CustomDurabilityManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/durability/CustomDurabilityManager.java
@@ -1,0 +1,134 @@
+package goat.minecraft.minecraftnew.other.durability;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerItemBreakEvent;
+import org.bukkit.event.player.PlayerItemDamageEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Manages custom durability values for items. All durability events should
+ * pass through this manager so we can track a custom current and maximum
+ * durability stored in the item's persistent data container. The durability
+ * is displayed on the last line of the item's lore.
+ */
+public class CustomDurabilityManager implements Listener {
+
+    private static CustomDurabilityManager instance;
+
+    private final JavaPlugin plugin;
+    private final NamespacedKey currentKey;
+    private final NamespacedKey maxKey;
+
+    private CustomDurabilityManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.currentKey = new NamespacedKey(plugin, "custom_durability_current");
+        this.maxKey = new NamespacedKey(plugin, "custom_durability_max");
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    /**
+     * Initializes the durability manager.
+     */
+    public static CustomDurabilityManager init(JavaPlugin plugin) {
+        if (instance == null) {
+            instance = new CustomDurabilityManager(plugin);
+        }
+        return instance;
+    }
+
+    /**
+     * Gets the singleton instance.
+     */
+    public static CustomDurabilityManager getInstance() {
+        return instance;
+    }
+
+    /**
+     * Sets custom durability values on the provided item.
+     */
+    public void setCustomDurability(ItemStack item, int current, int max) {
+        if (item == null) return;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        container.set(currentKey, PersistentDataType.INTEGER, Math.max(current, 0));
+        container.set(maxKey, PersistentDataType.INTEGER, Math.max(max, 1));
+        item.setItemMeta(meta);
+        updateLore(item);
+    }
+
+    /**
+     * Updates the last lore line of the item to display durability.
+     */
+    private void updateLore(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        Integer current = container.get(currentKey, PersistentDataType.INTEGER);
+        Integer max = container.get(maxKey, PersistentDataType.INTEGER);
+        if (current == null || max == null) return;
+        java.util.List<String> lore = meta.getLore();
+        if (lore == null) lore = new java.util.ArrayList<>();
+        String line = "Durability: " + current + "/" + max;
+        if (lore.isEmpty()) {
+            lore.add(line);
+        } else {
+            if (lore.size() == 1) {
+                lore.set(0, line);
+            } else {
+                lore.set(lore.size() - 1, line);
+            }
+        }
+        meta.setLore(lore);
+        item.setItemMeta(meta);
+    }
+
+    /**
+     * Handles durability usage for items with custom durability. Unbreaking is
+     * ignored for now.
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onItemDamage(PlayerItemDamageEvent event) {
+        if (event.isCancelled()) return;
+        ItemStack item = event.getItem();
+        if (item == null) return;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        Integer current = container.get(currentKey, PersistentDataType.INTEGER);
+        Integer max = container.get(maxKey, PersistentDataType.INTEGER);
+        if (current == null || max == null) return; // Not a custom item
+
+        event.setCancelled(true); // ignore vanilla durability handling
+
+        int newCurrent = current - event.getDamage();
+        if (newCurrent < 0) newCurrent = 0;
+        container.set(currentKey, PersistentDataType.INTEGER, newCurrent);
+        item.setItemMeta(meta);
+        updateLore(item);
+
+        if (newCurrent == 0) {
+            Player player = event.getPlayer();
+            PlayerItemBreakEvent breakEvent = new PlayerItemBreakEvent(player, item);
+            Bukkit.getPluginManager().callEvent(breakEvent);
+            if (!breakEvent.isCancelled()) {
+                EquipmentSlot slot = event.getHand();
+                if (slot != null && player.getInventory().getItem(slot) != null) {
+                    player.getInventory().setItem(slot, new ItemStack(Material.AIR));
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/SetCustomDurabilityCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/SetCustomDurabilityCommand.java
@@ -1,0 +1,61 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import goat.minecraft.minecraftnew.other.durability.CustomDurabilityManager;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Developer command to directly set custom durability values on the item held
+ * in the player's main hand.
+ */
+public class SetCustomDurabilityCommand implements CommandExecutor {
+
+    private final CustomDurabilityManager durabilityManager;
+
+    public SetCustomDurabilityCommand(CustomDurabilityManager manager) {
+        this.durabilityManager = manager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command!");
+            return true;
+        }
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You don't have permission to use this command.");
+            return true;
+        }
+        if (args.length != 2) {
+            player.sendMessage(ChatColor.YELLOW + "Usage: /setcustomdurability <current> <max>");
+            return true;
+        }
+        int current;
+        int max;
+        try {
+            current = Integer.parseInt(args[0]);
+            max = Integer.parseInt(args[1]);
+        } catch (NumberFormatException e) {
+            player.sendMessage(ChatColor.RED + "Values must be integers.");
+            return true;
+        }
+        if (max <= 0) {
+            player.sendMessage(ChatColor.RED + "Max durability must be positive.");
+            return true;
+        }
+        if (current < 0) current = 0;
+        if (current > max) current = max;
+        ItemStack item = player.getInventory().getItemInMainHand();
+        if (item == null || item.getType().isAir()) {
+            player.sendMessage(ChatColor.RED + "You must hold an item.");
+            return true;
+        }
+        durabilityManager.setCustomDurability(item, current, max);
+        player.sendMessage(ChatColor.GREEN + "Set custom durability to " + current + "/" + max + ".");
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -43,6 +43,11 @@ commands:
     description: Admin command to set the durability of a player's held item
     usage: /setdurability <player> <durability>
     permission: continuity.admin
+
+  setcustomdurability:
+    description: Sets custom durability values on the held item
+    usage: /setcustomdurability <current> <max>
+    permission: continuity.admin
   forceworkcycle:
     description: Forces the villager work cycle timer to 1 second.
     usage: /<command>


### PR DESCRIPTION
## Summary
- implement `CustomDurabilityManager` for tracking custom item durability in persistent data
- add `/setcustomdurability` developer command
- register durability manager and command in plugin init
- update plugin.yml

## Testing
- `mvn -q -DskipTests package` *(fails: could not download maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_687b03ce731c8332a0b0bad961c05542