### PR TITLE
Add custom durability system

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -54,6 +54,7 @@ import goat.minecraft.minecraftnew.utils.commands.MeritCommand;
 import goat.minecraft.minecraftnew.utils.commands.SkillsCommand;
 import goat.minecraft.minecraftnew.utils.commands.AuraCommand;
 import goat.minecraft.minecraftnew.utils.developercommands.*;
+import goat.minecraft.minecraftnew.utils.developercommands.SetCustomDurabilityCommand;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
 import goat.minecraft.minecraftnew.utils.developercommands.AddTalentPointCommand;
 import goat.minecraft.minecraftnew.utils.devtools.*;
@@ -85,6 +86,7 @@ import goat.minecraft.minecraftnew.other.armorsets.ThunderforgeSetBonus;
 import goat.minecraft.minecraftnew.other.armorsets.LostLegionSetBonus;
 import goat.minecraft.minecraftnew.other.armorsets.CountershotSetBonus;
 import goat.minecraft.minecraftnew.other.armorsets.StriderSetBonus;
+import goat.minecraft.minecraftnew.other.durability.CustomDurabilityManager;
 import goat.minecraft.minecraftnew.other.skilltree.SwiftStepMasteryBonus;
 import goat.minecraft.minecraftnew.other.structureblocks.StructureBlockManager;
 import goat.minecraft.minecraftnew.other.structureblocks.GetStructureBlockCommand;
@@ -213,6 +215,8 @@ public class MinecraftNew extends JavaPlugin implements Listener {
 
 
         new SetDurabilityCommand(this);
+        CustomDurabilityManager.init(this);
+        new SetCustomDurabilityCommand(this);
         this.getCommand("skin").setExecutor(new SkinCommand());
         PetManager petManager = PetManager.getInstance(this);
         this.getCommand("testpet").setExecutor(new PetTestCommand(petManager));

--- a/src/main/java/goat/minecraft/minecraftnew/other/durability/CustomDurabilityManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/durability/CustomDurabilityManager.java
@@ -1,0 +1,146 @@
+package goat.minecraft.minecraftnew.other.durability;
+
+import org.bukkit.ChatColor;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerItemDamageEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Manages custom durability values for items and intercepts vanilla
+ * durability loss events. Unbreaking is intentionally ignored for now.
+ */
+public class CustomDurabilityManager implements Listener {
+    private static CustomDurabilityManager instance;
+    private final JavaPlugin plugin;
+    private final NamespacedKey currentKey;
+    private final NamespacedKey maxKey;
+
+    private CustomDurabilityManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.currentKey = new NamespacedKey(plugin, "custom_durability");
+        this.maxKey = new NamespacedKey(plugin, "custom_max_durability");
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    public static void init(JavaPlugin plugin) {
+        if (instance == null) {
+            instance = new CustomDurabilityManager(plugin);
+        }
+    }
+
+    public static CustomDurabilityManager getInstance() {
+        return instance;
+    }
+
+    /**
+     * Sets custom durability values on the given item and updates its lore.
+     */
+    public void setCustomDurability(ItemStack item, int current, int max) {
+        if (item == null || max <= 0) return;
+        if (current < 0) current = 0;
+        if (current > max) current = max;
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+
+        PersistentDataContainer data = meta.getPersistentDataContainer();
+        data.set(currentKey, PersistentDataType.INTEGER, current);
+        data.set(maxKey, PersistentDataType.INTEGER, max);
+        item.setItemMeta(meta);
+
+        updateLore(item, current, max);
+        updateVanillaDamage(item, current, max);
+    }
+
+    /**
+     * Returns the current durability stored on the item.
+     */
+    public int getCurrentDurability(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return item.getType().getMaxDurability();
+        PersistentDataContainer data = meta.getPersistentDataContainer();
+        Integer value = data.get(currentKey, PersistentDataType.INTEGER);
+        if (value != null) return value;
+
+        int vanillaMax = item.getType().getMaxDurability();
+        if (meta instanceof Damageable damageable) {
+            return vanillaMax - damageable.getDamage();
+        }
+        return vanillaMax;
+    }
+
+    /**
+     * Returns the max durability stored on the item.
+     */
+    public int getMaxDurability(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return item.getType().getMaxDurability();
+        PersistentDataContainer data = meta.getPersistentDataContainer();
+        Integer value = data.get(maxKey, PersistentDataType.INTEGER);
+        if (value != null) return value;
+        return item.getType().getMaxDurability();
+    }
+
+    /**
+     * Applies damage using the custom durability system.
+     */
+    public void applyDamage(Player player, ItemStack item, int amount) {
+        int current = getCurrentDurability(item);
+        int max = getMaxDurability(item);
+        current -= amount;
+        if (current < 0) current = 0;
+        setCustomDurability(item, current, max);
+        if (current == 0 && player != null) {
+            item.setAmount(0);
+        }
+    }
+
+    @EventHandler
+    public void onItemDamage(PlayerItemDamageEvent event) {
+        ItemStack item = event.getItem();
+        if (item == null) return;
+
+        event.setCancelled(true); // Cancel vanilla durability handling
+        applyDamage(event.getPlayer(), item, event.getDamage());
+    }
+
+    private void updateLore(ItemStack item, int current, int max) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        List<String> lore = meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
+        String line = ChatColor.GRAY + "Durability: " + current + "/" + max;
+        if (!lore.isEmpty() && ChatColor.stripColor(lore.get(lore.size() - 1)).startsWith("Durability:")) {
+            lore.set(lore.size() - 1, line);
+        } else {
+            lore.add(line);
+        }
+        meta.setLore(lore);
+        item.setItemMeta(meta);
+    }
+
+    private void updateVanillaDamage(ItemStack item, int current, int max) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta instanceof Damageable damageable) {
+            int vanillaMax = item.getType().getMaxDurability();
+            if (vanillaMax > 0) {
+                double ratio = 1.0 - ((double) current / max);
+                int newDamage = (int) Math.round(ratio * vanillaMax);
+                if (newDamage < 0) newDamage = 0;
+                if (newDamage > vanillaMax) newDamage = vanillaMax;
+                damageable.setDamage(newDamage);
+                item.setItemMeta(meta);
+            }
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/SetCustomDurabilityCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/SetCustomDurabilityCommand.java
@@ -1,0 +1,61 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import goat.minecraft.minecraftnew.other.durability.CustomDurabilityManager;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Developer command to manually assign custom durability values to the item in
+ * the player's main hand. Usage: /setcustomdurability <current> <max>
+ */
+public class SetCustomDurabilityCommand implements CommandExecutor {
+    private final JavaPlugin plugin;
+
+    public SetCustomDurabilityCommand(JavaPlugin plugin) {
+        this.plugin = plugin;
+        plugin.getCommand("setcustomdurability").setExecutor(this);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You don't have permission to use this command.");
+            return true;
+        }
+
+        if (args.length < 2) {
+            player.sendMessage(ChatColor.RED + "Usage: /" + label + " <current> <max>");
+            return true;
+        }
+
+        int current;
+        int max;
+        try {
+            current = Integer.parseInt(args[0]);
+            max = Integer.parseInt(args[1]);
+        } catch (NumberFormatException e) {
+            player.sendMessage(ChatColor.RED + "Both values must be integers.");
+            return true;
+        }
+
+        ItemStack item = player.getInventory().getItemInMainHand();
+        if (item == null || item.getType().isAir()) {
+            player.sendMessage(ChatColor.RED + "You must be holding an item.");
+            return true;
+        }
+
+        CustomDurabilityManager.getInstance().setCustomDurability(item, current, max);
+        player.sendMessage(ChatColor.GREEN + "Custom durability set to " + current + "/" + max + ".");
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -43,6 +43,10 @@ commands:
     description: Admin command to set the durability of a player's held item
     usage: /setdurability <player> <durability>
     permission: continuity.admin
+  setcustomdurability:
+    description: Sets custom durability values on the held item
+    usage: /setcustomdurability <current> <max>
+    permission: continuity.admin
   forceworkcycle:
     description: Forces the villager work cycle timer to 1 second.
     usage: /<command>


### PR DESCRIPTION
## Summary
- create `CustomDurabilityManager` with PDC-based durability storage
- add dev command `/setcustomdurability` to assign custom durability values
- initialize durability manager and command in plugin
- register command in plugin.yml

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_687b03ce731c8332a0b0bad961c05542