### PR TITLE
Add repair methods and custom Unbreaking conversion

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -635,6 +635,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         CustomEnchantmentManager.registerEnchantment("Composter", 5, true);
         CustomEnchantmentManager.registerEnchantment("Piracy", 5, true);
         CustomEnchantmentManager.registerEnchantment("Shear", 5, true);
+        CustomEnchantmentManager.registerEnchantment("Unbreaking", 6, true);
         CustomEnchantmentManager.registerEnchantment("Physical Protection", 4, true);
         CustomEnchantmentManager.registerEnchantment("Alchemy", 4, true);
         CustomEnchantmentManager.registerEnchantment("Aspect of the Journey", 1, true);

--- a/src/main/java/goat/minecraft/minecraftnew/other/durability/CustomDurabilityManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/durability/CustomDurabilityManager.java
@@ -9,6 +9,8 @@ import org.bukkit.event.player.PlayerItemDamageEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.enchantments.Enchantment;
+import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentManager;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -96,6 +98,8 @@ public class CustomDurabilityManager implements Listener {
      * Applies damage using the custom durability system.
      */
     public void applyDamage(Player player, ItemStack item, int amount) {
+        convertVanillaUnbreaking(item);
+
         int current = getCurrentDurability(item);
         int max = getMaxDurability(item);
         current -= amount;
@@ -104,6 +108,27 @@ public class CustomDurabilityManager implements Listener {
         if (current == 0 && player != null) {
             item.setAmount(0);
         }
+    }
+
+    /**
+     * Repairs the given item by a specific amount.
+     */
+    public void repair(ItemStack item, int amount) {
+        if (item == null || amount <= 0) return;
+        int current = getCurrentDurability(item);
+        int max = getMaxDurability(item);
+        current += amount;
+        if (current > max) current = max;
+        setCustomDurability(item, current, max);
+    }
+
+    /**
+     * Fully repairs the given item to max durability.
+     */
+    public void repairFully(ItemStack item) {
+        if (item == null) return;
+        int max = getMaxDurability(item);
+        setCustomDurability(item, max, max);
     }
 
     @EventHandler
@@ -141,6 +166,21 @@ public class CustomDurabilityManager implements Listener {
                 damageable.setDamage(newDamage);
                 item.setItemMeta(meta);
             }
+        }
+    }
+
+    /**
+     * Converts vanilla Unbreaking enchantments to the custom variant.
+     */
+    private void convertVanillaUnbreaking(ItemStack item) {
+        int level = item.getEnchantmentLevel(Enchantment.UNBREAKING);
+        if (level > 0) {
+            ItemMeta meta = item.getItemMeta();
+            if (meta != null) {
+                meta.removeEnchant(Enchantment.UNBREAKING);
+                item.setItemMeta(meta);
+            }
+            CustomEnchantmentManager.addEnchantment(item, "Unbreaking", level);
         }
     }
 }

--- a/src/main/java/goat/minecraft/minecraftnew/other/enchanting/CustomEnchantmentManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/enchanting/CustomEnchantmentManager.java
@@ -150,7 +150,7 @@ public class CustomEnchantmentManager {
     }
 
     /**
-     * Applies a custom enchantment to an item. (Non-ultimate usage)
+     * Applies a custom enchantment to an item. (Non-ultimate usage with cost and XP)
      */
     public static ItemStack addEnchantment(Player player, ItemStack billItem, ItemStack item, String enchantmentName, int level) {
         XPManager xpManager = new XPManager(MinecraftNew.getInstance());
@@ -176,6 +176,40 @@ public class CustomEnchantmentManager {
         item.setItemMeta(meta);
         billItem.setAmount(billItem.getAmount() - 1);
         xpManager.addXP(player, "Smithing", 200);
+        return item;
+    }
+
+    /**
+     * Applies a custom enchantment to an item without consuming a bill item or
+     * awarding experience. Used internally for systems that need to modify
+     * enchantments directly.
+     *
+     * @param item            The item to enchant.
+     * @param enchantmentName The custom enchantment name.
+     * @param level           The level to apply.
+     * @return The enchanted item.
+     */
+    public static ItemStack addEnchantment(ItemStack item, String enchantmentName, int level) {
+        CustomEnchantment enchantment = getEnchantment(enchantmentName);
+        if (enchantment == null) return item;
+        if (level < 1 || level > enchantment.getMaxLevel()) {
+            return item;
+        }
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return item;
+
+        List<String> lore = meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
+
+        // Remove existing enchantment if present
+        removeEnchantmentLore(lore, enchantment);
+
+        // Add enchantment to lore
+        String enchantmentLine = formatEnchantment(enchantment.getName(), level);
+        lore.add(0, enchantmentLine);
+
+        meta.setLore(lore);
+        item.setItemMeta(meta);
         return item;
     }
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/music/MusicDiscManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/music/MusicDiscManager.java
@@ -18,6 +18,7 @@ import goat.minecraft.minecraftnew.other.trinkets.BankAccountManager;
 import goat.minecraft.minecraftnew.other.trinkets.TrinketManager;
 import goat.minecraft.minecraftnew.other.skilltree.Skill;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.durability.CustomDurabilityManager;
 import org.bukkit.*;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
@@ -1502,17 +1503,10 @@ public class MusicDiscManager implements Listener {
         short maxDurability = material.getMaxDurability();
 
         if (maxDurability > 0) {
-            // Item is damageable
-            short currentDurability = item.getDurability(); // Deprecated but works
-            short newDurability = (short) Math.max(currentDurability - repairAmount, 0);
-
-            // Debug messages
             plugin.getLogger().info("Item: " + material);
-            plugin.getLogger().info("Current Durability (Damage): " + currentDurability);
-            plugin.getLogger().info("Max Durability: " + maxDurability);
-            plugin.getLogger().info("Repairing " + material + " in " + slotInfo + " from damage " + currentDurability + " to " + newDurability);
+            plugin.getLogger().info("Repairing " + material + " in " + slotInfo + " by " + repairAmount + " points.");
 
-            item.setDurability(newDurability); // Deprecated but necessary here
+            CustomDurabilityManager.getInstance().repair(item, repairAmount);
         } else {
             plugin.getLogger().info(material + " in " + slotInfo + " is not damageable.");
         }

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/RepairAllCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/RepairAllCommand.java
@@ -34,8 +34,7 @@ public class RepairAllCommand implements CommandExecutor {
             }
             ItemMeta meta = item.getItemMeta();
             if (meta instanceof Damageable damageable && damageable.getDamage() > 0) {
-                damageable.setDamage(0);
-                item.setItemMeta(meta);
+                CustomDurabilityManager.getInstance().repairFully(item);
             }
         }
 

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/RepairCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/RepairCommand.java
@@ -40,15 +40,14 @@ public class RepairCommand implements CommandExecutor {
         }
 
         Damageable damageable = (Damageable) meta;
-        
+
         if (damageable.getDamage() == 0) {
             player.sendMessage(ChatColor.YELLOW + "This item is already at full durability!");
             return true;
         }
 
-        damageable.setDamage(0);
-        heldItem.setItemMeta(meta);
-        
+        CustomDurabilityManager.getInstance().repairFully(heldItem);
+
         player.sendMessage(ChatColor.GREEN + "✔ Item repaired to full durability!");
         return true;
     }


### PR DESCRIPTION
## Summary
- extend `CustomDurabilityManager` with repair methods
- convert vanilla Unbreaking to a new custom enchantment
- expose convenience method in `CustomEnchantmentManager`
- register the new `Unbreaking` enchantment
- update repair commands and music disc repairs to use custom durability

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_687b085b2c0c833284ddf0e87f623558