### PR TITLE
Add durability bonus from Unbreaking and iron repairs

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/enchanting/CustomEnchantmentManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/enchanting/CustomEnchantmentManager.java
@@ -1,6 +1,7 @@
 package goat.minecraft.minecraftnew.other.enchanting;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.other.durability.CustomDurabilityManager;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import org.bukkit.ChatColor;
 import org.bukkit.Particle;
@@ -165,6 +166,7 @@ public class CustomEnchantmentManager {
 
         List<String> lore = meta.hasLore() ? meta.getLore() : new ArrayList<>();
 
+        boolean alreadyHad = hasEnchantment(item, enchantmentName);
         // Remove existing enchantment if present
         removeEnchantmentLore(lore, enchantment);
 
@@ -176,6 +178,13 @@ public class CustomEnchantmentManager {
         item.setItemMeta(meta);
         billItem.setAmount(billItem.getAmount() - 1);
         xpManager.addXP(player, "Smithing", 200);
+
+        if ("Unbreaking".equalsIgnoreCase(enchantmentName) && !alreadyHad) {
+            CustomDurabilityManager mgr = CustomDurabilityManager.getInstance();
+            if (mgr != null) {
+                mgr.addMaxDurabilityBonus(item, 100);
+            }
+        }
         return item;
     }
 
@@ -201,6 +210,7 @@ public class CustomEnchantmentManager {
 
         List<String> lore = meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
 
+        boolean alreadyHad = hasEnchantment(item, enchantmentName);
         // Remove existing enchantment if present
         removeEnchantmentLore(lore, enchantment);
 
@@ -210,6 +220,13 @@ public class CustomEnchantmentManager {
 
         meta.setLore(lore);
         item.setItemMeta(meta);
+
+        if ("Unbreaking".equalsIgnoreCase(enchantmentName) && !alreadyHad) {
+            CustomDurabilityManager mgr = CustomDurabilityManager.getInstance();
+            if (mgr != null) {
+                mgr.addMaxDurabilityBonus(item, 100);
+            }
+        }
         return item;
     }
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
@@ -2,6 +2,7 @@ package goat.minecraft.minecraftnew.subsystems.smithing;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentManager;
+import goat.minecraft.minecraftnew.other.durability.CustomDurabilityManager;
 import goat.minecraft.minecraftnew.subsystems.mining.MiningGemManager;
 import goat.minecraft.minecraftnew.subsystems.smithing.tierreforgelisteners.ReforgeManager;
 import goat.minecraft.minecraftnew.other.enchanting.EnchantmentUtils;
@@ -727,6 +728,11 @@ public class AnvilRepair implements Listener {
             repairAmount = roll;
             xpManager.addXP(player, "Smithing", roll);
             anvilPitch = getAnvilPitch(roll);
+
+            CustomDurabilityManager mgr = CustomDurabilityManager.getInstance();
+            if (mgr != null) {
+                mgr.addMaxDurabilityBonus(repairee, 1);
+            }
         } else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.LIGHT_PURPLE + "Shallow Shell")){
             repairAmount = 100;
             xpManager.addXP(player, "Smithing", 100.0);


### PR DESCRIPTION
## Summary
- support additional durability bonuses in `CustomDurabilityManager`
- grant +100 max durability when the custom Unbreaking enchantment is first applied
- increment max durability by 1 when repairing with an Iron Ingot

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_687b0b750b9883329544d64e630a9c82