### PR TITLE
Add enchantment toggle GUI

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -53,6 +53,7 @@ import goat.minecraft.minecraftnew.utils.commands.DiscsCommand;
 import goat.minecraft.minecraftnew.utils.commands.MeritCommand;
 import goat.minecraft.minecraftnew.utils.commands.SkillsCommand;
 import goat.minecraft.minecraftnew.utils.commands.AuraCommand;
+import goat.minecraft.minecraftnew.utils.commands.ToggleCustomEnchantmentsCommand;
 import goat.minecraft.minecraftnew.utils.developercommands.*;
 import goat.minecraft.minecraftnew.utils.developercommands.SetCustomDurabilityCommand;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
@@ -92,6 +93,7 @@ import goat.minecraft.minecraftnew.other.structureblocks.StructureBlockManager;
 import goat.minecraft.minecraftnew.other.structureblocks.GetStructureBlockCommand;
 import goat.minecraft.minecraftnew.other.structureblocks.SetStructureBlockPowerCommand;
 import goat.minecraft.minecraftnew.other.warpgate.WarpGateManager;
+import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentPreferences;
 
 import goat.minecraft.minecraftnew.subsystems.music.PigStepArena;
 import goat.minecraft.minecraftnew.other.realms.Tropic;
@@ -357,6 +359,9 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         TrinketManager.init(this);
         StructureBlockManager.init(this);
         //getServer().getPluginManager().registerEvents(new GamblingTable(this), this);
+
+        CustomEnchantmentPreferences.init(this);
+        getServer().getPluginManager().registerEvents(new CustomEnchantmentPreferences(), this);
 
         forestryPetManager = new ForestryPetManager(this);
 
@@ -673,6 +678,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getCommand("repairall").setExecutor(new RepairAllCommand());
         getCommand("finishbrews").setExecutor(new FinishBrewsCommand(this));
         getCommand("openvillagertrademenu").setExecutor(new OpenVillagerTradeMenuCommand(this));
+        getCommand("togglecustomenchantments").setExecutor(new ToggleCustomEnchantmentsCommand(this));
 
         getServer().getPluginManager().registerEvents(new MusicDiscManager(this), this);
 
@@ -790,6 +796,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         if (swiftStepMasteryBonus != null) {
             swiftStepMasteryBonus.removeAllBonuses();
         }
+        CustomEnchantmentPreferences.saveAll();
         BeaconPassivesGUI.saveAllPassives();
         if (CatalystManager.getInstance() != null) {
             CatalystManager.getInstance().shutdown();

--- a/src/main/java/goat/minecraft/minecraftnew/other/enchanting/CustomEnchantmentManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/enchanting/CustomEnchantmentManager.java
@@ -287,6 +287,17 @@ public class CustomEnchantmentManager {
         return 0;
     }
 
+    /**
+     * Returns a mapping of all registered enchantments to their max level.
+     */
+    public static Map<String, Integer> getRegisteredEnchantmentMaxLevels() {
+        Map<String, Integer> map = new LinkedHashMap<>();
+        for (CustomEnchantment enchantment : enchantments.values()) {
+            map.put(enchantment.getName(), enchantment.getMaxLevel());
+        }
+        return map;
+    }
+
     private static String formatEnchantment(String name, int level) {
         String numeral = toRomanNumeral(level);
         return ChatColor.GRAY + name + " " + numeral;

--- a/src/main/java/goat/minecraft/minecraftnew/other/enchanting/CustomEnchantmentPreferences.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/enchanting/CustomEnchantmentPreferences.java
@@ -1,0 +1,102 @@
+package goat.minecraft.minecraftnew.other.enchanting;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Manages per-player preferences for enabling or disabling custom enchantments.
+ */
+public class CustomEnchantmentPreferences implements Listener {
+
+    private static final Map<UUID, Map<String, Boolean>> prefs = new HashMap<>();
+    private static File prefFile;
+    private static FileConfiguration prefConfig;
+
+    public static void init(JavaPlugin plugin) {
+        prefFile = new File(plugin.getDataFolder(), "customenchantmentpreferences.yml");
+        if (!prefFile.exists()) {
+            try {
+                plugin.getDataFolder().mkdirs();
+                prefFile.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        prefConfig = YamlConfiguration.loadConfiguration(prefFile);
+        for (String key : prefConfig.getKeys(false)) {
+            try {
+                UUID id = UUID.fromString(key);
+                ConfigurationSection sec = prefConfig.getConfigurationSection(key);
+                if (sec != null) {
+                    Map<String, Boolean> map = new HashMap<>();
+                    for (String ench : sec.getKeys(false)) {
+                        map.put(ench, sec.getBoolean(ench, true));
+                    }
+                    prefs.put(id, map);
+                }
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+    }
+
+    public static boolean isEnabled(Player player, String enchant) {
+        Map<String, Boolean> map = prefs.get(player.getUniqueId());
+        if (map == null) return true;
+        return map.getOrDefault(normalize(enchant), true);
+    }
+
+    public static void toggle(Player player, String enchant) {
+        Map<String, Boolean> map = prefs.computeIfAbsent(player.getUniqueId(), k -> new HashMap<>());
+        String key = normalize(enchant);
+        boolean newVal = !map.getOrDefault(key, true);
+        map.put(key, newVal);
+        savePlayer(player.getUniqueId());
+    }
+
+    private static void savePlayer(UUID id) {
+        Map<String, Boolean> map = prefs.get(id);
+        if (map == null) return;
+        prefConfig.set(id.toString(), null);
+        for (Map.Entry<String, Boolean> e : map.entrySet()) {
+            prefConfig.set(id.toString() + "." + e.getKey(), e.getValue());
+        }
+        try {
+            prefConfig.save(prefFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void saveAll() {
+        for (UUID id : prefs.keySet()) {
+            savePlayer(id);
+        }
+    }
+
+    private static String normalize(String name) {
+        return name.toLowerCase().replace(" ", "_");
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        prefs.computeIfAbsent(event.getPlayer().getUniqueId(), k -> new HashMap<>());
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        savePlayer(event.getPlayer().getUniqueId());
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/ToggleCustomEnchantmentsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/ToggleCustomEnchantmentsCommand.java
@@ -1,0 +1,156 @@
+package goat.minecraft.minecraftnew.utils.commands;
+
+import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentManager;
+import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentPreferences;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.*;
+
+/**
+ * GUI command allowing players to toggle custom enchantment effects.
+ */
+public class ToggleCustomEnchantmentsCommand implements CommandExecutor, Listener {
+
+    private static final String GUI_TITLE = ChatColor.DARK_PURPLE + "Custom Enchantments";
+    private final JavaPlugin plugin;
+
+    // Basic descriptions for known enchantments
+    private final Map<String, List<String>> descriptions = new HashMap<>();
+
+    public ToggleCustomEnchantmentsCommand(JavaPlugin plugin) {
+        this.plugin = plugin;
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+        populateDescriptions();
+    }
+
+    private void populateDescriptions() {
+        descriptions.put("Alchemy", Arrays.asList(
+                "4% * level chance to upgrade ores",
+                "into their block form.",
+                "Costs 1 durability per use."));
+        descriptions.put("Feed", Arrays.asList(
+                "Chance to restore hunger when",
+                "damaging a mob.",
+                "Consumes 1 durability."));
+        descriptions.put("Rappel", Arrays.asList(
+                "Right click to teleport to the",
+                "highest block above you.",
+                "Costs durability equal to level."));
+        descriptions.put("Stun", Arrays.asList(
+                "Arrows apply extreme slowness",
+                "for 10 seconds.",
+                "Costs 1 durability."));
+        descriptions.put("Lethal Reaction", Arrays.asList(
+                "Crossbow arrows become fireballs",
+                "with power based on level.",
+                "Costs durability."));
+        descriptions.put("Aspect of the Journey", Arrays.asList(
+                "Sneak right click to dash forward",
+                "6 blocks. Overuse drains hunger",
+                "or deals damage.",
+                "Consumes durability."));
+        descriptions.put("Preservation", Arrays.asList(
+                "Prevents items from breaking",
+                "and stores them safely."));
+        descriptions.put("Composter", Arrays.asList(
+                "4% * level chance to convert",
+                "excess materials into Organic Soil."));
+        descriptions.put("Forge", Arrays.asList(
+                "20% * level chance to auto-smelt",
+                "broken blocks."));
+        descriptions.put("Accelerate", Arrays.asList(
+                "Adds deterioration stacks equal",
+                "to level * 5 when hitting mobs."));
+        descriptions.put("Velocity", Arrays.asList(
+                "Projectiles fly 25% faster per",
+                "enchantment level."));
+        descriptions.put("Defenestration", Arrays.asList(
+                "Arrows shatter glass for a short",
+                "time on impact."));
+        descriptions.put("Merit", Arrays.asList(
+                "10% chance to earn a merit point",
+                "when mining diamond ore."));
+        descriptions.put("Cleaver", Arrays.asList(
+                "Small chance to decapitate mobs",
+                "dropping their head.",
+                "Consumes durability."));
+        descriptions.put("Experience", Arrays.asList(
+                "Drops extra XP when killing mobs,",
+                "amount scales with level.",
+                "Costs 1 durability."));
+        descriptions.put("Water Aspect", Arrays.asList(
+                "Deals bonus damage to certain",
+                "mobs like guardians or endermen."));
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players can use this command.");
+            return true;
+        }
+        openGUI(player);
+        return true;
+    }
+
+    private void openGUI(Player player) {
+        Map<String, Integer> enchants = CustomEnchantmentManager.getRegisteredEnchantmentMaxLevels();
+        int size = ((enchants.size() / 9) + 1) * 9;
+        Inventory gui = Bukkit.createInventory(null, size, GUI_TITLE);
+        int slot = 0;
+        for (Map.Entry<String, Integer> entry : enchants.entrySet()) {
+            String name = entry.getKey();
+            int max = entry.getValue();
+            boolean enabled = CustomEnchantmentPreferences.isEnabled(player, name);
+            ItemStack item = new ItemStack(Material.ENCHANTED_BOOK);
+            ItemMeta meta = item.getItemMeta();
+            meta.setDisplayName((enabled ? ChatColor.GREEN : ChatColor.RED) + name);
+            List<String> lore = new ArrayList<>();
+            lore.add("");
+            List<String> desc = descriptions.getOrDefault(name, Collections.singletonList("No description available."));
+            for (String line : desc) {
+                lore.add(ChatColor.GRAY + line);
+            }
+            lore.add("");
+            lore.add(ChatColor.YELLOW + "Max Level: " + max);
+            lore.add("");
+            if (enabled) {
+                lore.add(ChatColor.GREEN + "✓ ENABLED");
+                lore.add(ChatColor.GRAY + "Left click to disable");
+            } else {
+                lore.add(ChatColor.RED + "✗ DISABLED");
+                lore.add(ChatColor.GRAY + "Left click to enable");
+            }
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+            gui.setItem(slot++, item);
+        }
+        player.openInventory(gui);
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) return;
+        if (!event.getView().getTitle().equals(GUI_TITLE)) return;
+        event.setCancelled(true);
+        ItemStack clicked = event.getCurrentItem();
+        if (clicked == null || !clicked.hasItemMeta()) return;
+        String name = ChatColor.stripColor(clicked.getItemMeta().getDisplayName());
+        if (name.isEmpty()) return;
+        CustomEnchantmentPreferences.toggle(player, name);
+        openGUI(player);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -163,6 +163,10 @@ commands:
     description: Opens a villager trade menu for testing
     usage: /openVillagerTradeMenu <profession> <tier>
     permission: continuity.admin
+  togglecustomenchantments:
+    description: Toggle your custom enchantments on or off
+    usage: /togglecustomenchantments
+    default: true
   setskilllevel:
     description: Sets a player's skill level
     usage: /setskilllevel <player> <skill> <level>


### PR DESCRIPTION
## Summary
- add storage for per-player enchantment preferences
- expose registered enchantments list
- command `/togglecustomenchantments` opens a GUI to enable/disable enchantments
- register command and persistence logic in plugin
- document command in `plugin.yml`

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:2.6)*

------
https://chatgpt.com/codex/tasks/task_e_687b16feb56c8332928fffc41306eea6