### PR TITLE
Add reforge management commands

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -679,6 +679,8 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getCommand("finishbrews").setExecutor(new FinishBrewsCommand(this));
         getCommand("openvillagertrademenu").setExecutor(new OpenVillagerTradeMenuCommand(this));
         getCommand("togglecustomenchantments").setExecutor(new ToggleCustomEnchantmentsCommand(this));
+        getCommand("stripreforge").setExecutor(new StripReforgeCommand());
+        getCommand("applyreforge").setExecutor(new ApplyReforgeCommand());
 
         getServer().getPluginManager().registerEvents(new MusicDiscManager(this), this);
 

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/ApplyReforgeCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/ApplyReforgeCommand.java
@@ -1,0 +1,78 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import goat.minecraft.minecraftnew.subsystems.smithing.tierreforgelisteners.ReforgeManager;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Developer command that applies a reforge tier to the held item.
+ * Usage: /applyreforge <reforgename> <rarity>
+ */
+public class ApplyReforgeCommand implements CommandExecutor {
+    private final ReforgeManager reforgeManager = new ReforgeManager();
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You don't have permission to use this command.");
+            return true;
+        }
+
+        if (args.length != 2) {
+            player.sendMessage(ChatColor.RED + "Usage: /applyreforge <reforgename> <rarity>");
+            return true;
+        }
+
+        ItemStack item = player.getInventory().getItemInMainHand();
+        if (item == null || item.getType() == Material.AIR) {
+            player.sendMessage(ChatColor.RED + "You must be holding an item.");
+            return true;
+        }
+
+        String type = args[0].toLowerCase();
+        boolean matches = switch (type) {
+            case "sword" -> reforgeManager.isSword(item);
+            case "armor" -> reforgeManager.isArmor(item);
+            case "tool" -> reforgeManager.isTool(item);
+            case "bow" -> reforgeManager.isBow(item);
+            default -> false;
+        };
+
+        if (!matches) {
+            player.sendMessage(ChatColor.RED + "Held item is not a " + type + ".");
+            return true;
+        }
+
+        ReforgeManager.ReforgeTier tier = parseTier(args[1]);
+        if (tier == null) {
+            player.sendMessage(ChatColor.RED + "Unknown rarity. Use common, uncommon, rare, epic or legendary.");
+            return true;
+        }
+
+        reforgeManager.applyReforge(item, tier);
+        player.sendMessage(ChatColor.GREEN + "Applied " + args[1].toLowerCase() + " reforge.");
+        return true;
+    }
+
+    private ReforgeManager.ReforgeTier parseTier(String arg) {
+        return switch (arg.toLowerCase()) {
+            case "common", "1" -> ReforgeManager.ReforgeTier.TIER_1;
+            case "uncommon", "2" -> ReforgeManager.ReforgeTier.TIER_2;
+            case "rare", "3" -> ReforgeManager.ReforgeTier.TIER_3;
+            case "epic", "4" -> ReforgeManager.ReforgeTier.TIER_4;
+            case "legendary", "5" -> ReforgeManager.ReforgeTier.TIER_5;
+            case "0" -> ReforgeManager.ReforgeTier.TIER_0;
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/StripReforgeCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/StripReforgeCommand.java
@@ -1,0 +1,45 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import goat.minecraft.minecraftnew.subsystems.smithing.tierreforgelisteners.ReforgeManager;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Developer command to remove any reforge from the item in the player's hand.
+ */
+public class StripReforgeCommand implements CommandExecutor {
+    private final ReforgeManager reforgeManager = new ReforgeManager();
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You don't have permission to use this command.");
+            return true;
+        }
+
+        ItemStack item = player.getInventory().getItemInMainHand();
+        if (item == null || item.getType() == Material.AIR) {
+            player.sendMessage(ChatColor.RED + "You must be holding an item.");
+            return true;
+        }
+
+        if (reforgeManager.getReforgeTier(item) == 0) {
+            player.sendMessage(ChatColor.YELLOW + "That item has no reforge.");
+            return true;
+        }
+
+        reforgeManager.stripReforge(item);
+        player.sendMessage(ChatColor.GREEN + "Reforge removed.");
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -237,3 +237,11 @@ commands:
     description: Displays your total Spirit Chance
     usage: /spiritchance
     default: true
+  stripreforge:
+    description: Removes the reforge from the item in your hand
+    usage: /stripreforge
+    permission: continuity.admin
+  applyreforge:
+    description: Applies a reforge to the item in your hand
+    usage: /applyreforge <reforgename> <rarity>
+    permission: continuity.admin


### PR DESCRIPTION
## Summary
- allow stripping reforge data from items
- add developer command to apply reforges directly
- register the new commands
- document commands in `plugin.yml`

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687b1e0cd0e48332bd1e2c9ac993fd26