### PR TITLE
Add automatic lore formatting utility

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/durability/CustomDurabilityManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/durability/CustomDurabilityManager.java
@@ -204,6 +204,7 @@ public class CustomDurabilityManager implements Listener {
         }
         meta.setLore(lore);
         item.setItemMeta(meta);
+        goat.minecraft.minecraftnew.utils.devtools.ItemLoreFormatter.formatLore(item);
     }
 
     private void updateVanillaDamage(ItemStack item, int current, int max) {

--- a/src/main/java/goat/minecraft/minecraftnew/other/enchanting/CustomEnchantmentManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/enchanting/CustomEnchantmentManager.java
@@ -74,6 +74,7 @@ public class CustomEnchantmentManager {
 
         meta.setLore(lore);
         item.setItemMeta(meta);
+        goat.minecraft.minecraftnew.utils.devtools.ItemLoreFormatter.formatLore(item);
 
         // 4) Decrement the billItem by 1 if it's not null
         if (billItem != null && billItem.getAmount() > 0) {
@@ -177,6 +178,7 @@ public class CustomEnchantmentManager {
 
         meta.setLore(lore);
         item.setItemMeta(meta);
+        goat.minecraft.minecraftnew.utils.devtools.ItemLoreFormatter.formatLore(item);
         billItem.setAmount(billItem.getAmount() - 1);
         xpManager.addXP(player, "Smithing", 200);
 
@@ -221,6 +223,7 @@ public class CustomEnchantmentManager {
 
         meta.setLore(lore);
         item.setItemMeta(meta);
+        goat.minecraft.minecraftnew.utils.devtools.ItemLoreFormatter.formatLore(item);
 
         if ("Unbreaking".equalsIgnoreCase(enchantmentName) && !alreadyHad) {
             CustomDurabilityManager mgr = CustomDurabilityManager.getInstance();
@@ -253,6 +256,7 @@ public class CustomEnchantmentManager {
         if (removed) {
             meta.setLore(lore.isEmpty() ? null : lore);
             item.setItemMeta(meta);
+            goat.minecraft.minecraftnew.utils.devtools.ItemLoreFormatter.formatLore(item);
         }
         return item;
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
@@ -12,6 +12,7 @@ import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
 import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
 import goat.minecraft.minecraftnew.utils.devtools.TalismanManager;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import goat.minecraft.minecraftnew.utils.devtools.ItemLoreFormatter;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -22,6 +23,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.inventory.*;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.*;
 import org.bukkit.inventory.meta.Damageable;
@@ -640,6 +642,16 @@ public class AnvilRepair implements Listener {
             // Prevent moving items in other slots of the GUI
             if (slot < clickedInventory.getSize()) {
                 event.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void formatAfterClick(InventoryClickEvent event) {
+        if (event.getView().getTitle().equals("Anvil Repair")) {
+            ItemStack stack = event.getInventory().getItem(10);
+            if (stack != null) {
+                ItemLoreFormatter.formatLore(stack);
             }
         }
     }

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemLoreFormatter.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemLoreFormatter.java
@@ -1,0 +1,135 @@
+package goat.minecraft.minecraftnew.utils.devtools;
+
+import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentManager;
+import org.bukkit.ChatColor;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.*;
+import java.util.regex.Pattern;
+
+/**
+ * Utility class to normalize item lore ordering across the plugin.
+ */
+public class ItemLoreFormatter {
+    private static final Pattern ROMAN = Pattern.compile("[IVXLCDM]+$");
+    private static final Set<String> VANILLA_NAMES;
+
+    static {
+        Set<String> names = new HashSet<>();
+        for (Enchantment e : Enchantment.values()) {
+            names.add(capitalize(e.getKey().getKey().replace('_', ' ')));
+        }
+        VANILLA_NAMES = names;
+    }
+
+    private ItemLoreFormatter() {}
+
+    /**
+     * Reorders the lore of the given item to the standard format.
+     */
+    public static void formatLore(ItemStack item) {
+        if (item == null) return;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        List<String> lore = meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
+
+        String power = null;
+        String bar = null;
+        String cap = null;
+        String trim = null;
+        String bless = null;
+        String durability = null;
+        List<String> vanilla = new ArrayList<>();
+        List<String> custom = new ArrayList<>();
+        List<String> talismans = new ArrayList<>();
+        List<String> reforge = new ArrayList<>();
+        List<String> other = new ArrayList<>();
+
+        for (String line : lore) {
+            String stripped = ChatColor.stripColor(line);
+            if (stripped.startsWith("Gemstone Power") || stripped.startsWith("Angler Energy") ||
+                    stripped.startsWith("Soul Power") || stripped.startsWith("Spirit Energy")) {
+                power = line;
+            } else if (stripped.startsWith("Power Cap") || stripped.startsWith("Spirit Cap") || stripped.startsWith("Enhanced Power Cap")) {
+                cap = line;
+            } else if (stripped.contains("[") && stripped.contains("|") && stripped.contains("]")) {
+                bar = line;
+            } else if (stripped.startsWith("Trim:")) {
+                trim = line;
+            } else if (stripped.startsWith("Talisman:")) {
+                talismans.add(line);
+            } else if (stripped.startsWith("Damage Increase") || stripped.startsWith("Damage Reduction") ||
+                       stripped.startsWith("Chance to repair durability") || stripped.startsWith("Max Durability")) {
+                reforge.add(line);
+            } else if (stripped.startsWith("Durability:")) {
+                durability = line;
+            } else if (stripped.contains("Blessed")) {
+                bless = line;
+            } else if (isEnchantmentLine(stripped)) {
+                String name = stripped.replaceAll(" [IVXLCDM]+$", "");
+                if (VANILLA_NAMES.contains(name)) {
+                    vanilla.add(line);
+                } else {
+                    custom.add(line);
+                }
+            } else {
+                other.add(line);
+            }
+        }
+
+        List<String> newLore = new ArrayList<>();
+        // Keep other lore (like descriptions) before formatted sections
+        newLore.addAll(other);
+
+        if (power != null) {
+            newLore.add(power);
+            if (bar != null) newLore.add(bar);
+            if (cap != null) newLore.add(cap);
+        }
+
+        if (isArmor(item) && trim != null) {
+            newLore.add(trim);
+        }
+
+        newLore.addAll(vanilla);
+        newLore.addAll(custom);
+        newLore.addAll(talismans);
+        newLore.addAll(reforge);
+        if (isArmor(item) && bless != null) {
+            newLore.add(bless);
+        }
+        if (durability != null) {
+            newLore.add(durability);
+        }
+
+        meta.setLore(newLore);
+        item.setItemMeta(meta);
+    }
+
+    private static boolean isEnchantmentLine(String stripped) {
+        int lastSpace = stripped.lastIndexOf(' ');
+        if (lastSpace == -1) return false;
+        String numeral = stripped.substring(lastSpace + 1);
+        return ROMAN.matcher(numeral).matches();
+    }
+
+    private static boolean isArmor(ItemStack item) {
+        if (item == null) return false;
+        String n = item.getType().name();
+        return n.endsWith("_HELMET") || n.endsWith("_CHESTPLATE") || n.endsWith("_LEGGINGS") || n.endsWith("_BOOTS");
+    }
+
+    private static String capitalize(String text) {
+        String[] parts = text.split(" ");
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < parts.length; i++) {
+            if (parts[i].isEmpty()) continue;
+            sb.append(Character.toUpperCase(parts[i].charAt(0)))
+              .append(parts[i].substring(1).toLowerCase());
+            if (i < parts.length - 1) sb.append(' ');
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## Summary
- add `ItemLoreFormatter` to organize item lore consistently
- call lore formatter whenever custom durability updates
- ensure reforged items in an anvil run the formatter after clicks
- format enchantment methods to use the new formatter

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_687b27b9d5ec83329e4fededc7e91c16