### PR TITLE
Add potion effect toggles and remove riptide potion

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -54,6 +54,7 @@ import goat.minecraft.minecraftnew.utils.commands.MeritCommand;
 import goat.minecraft.minecraftnew.utils.commands.SkillsCommand;
 import goat.minecraft.minecraftnew.utils.commands.AuraCommand;
 import goat.minecraft.minecraftnew.utils.commands.ToggleCustomEnchantmentsCommand;
+import goat.minecraft.minecraftnew.utils.commands.TogglePotionEffectsCommand;
 import goat.minecraft.minecraftnew.utils.developercommands.*;
 import goat.minecraft.minecraftnew.utils.developercommands.SetCustomDurabilityCommand;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
@@ -250,7 +251,6 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new PotionOfOxygenRecovery(), this);
         getServer().getPluginManager().registerEvents(new PotionOfSolarFury(), this);
         getServer().getPluginManager().registerEvents(new PotionOfNightVision(), this);
-        getServer().getPluginManager().registerEvents(new PotionOfRiptide(), this);
         getServer().getPluginManager().registerEvents(new PotionOfCharismaticBartering(), this);
         getServer().getPluginManager().registerEvents(new PotionOfMetalDetection(), this);
 
@@ -362,6 +362,8 @@ public class MinecraftNew extends JavaPlugin implements Listener {
 
         CustomEnchantmentPreferences.init(this);
         getServer().getPluginManager().registerEvents(new CustomEnchantmentPreferences(), this);
+        PotionEffectPreferences.init(this);
+        getServer().getPluginManager().registerEvents(new PotionEffectPreferences(), this);
 
         forestryPetManager = new ForestryPetManager(this);
 
@@ -681,6 +683,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getCommand("finishbrews").setExecutor(new FinishBrewsCommand(this));
         getCommand("openvillagertrademenu").setExecutor(new OpenVillagerTradeMenuCommand(this));
         getCommand("togglecustomenchantments").setExecutor(new ToggleCustomEnchantmentsCommand(this));
+        getCommand("togglepotioneffects").setExecutor(new TogglePotionEffectsCommand(this));
         getCommand("stripreforge").setExecutor(new StripReforgeCommand());
         getCommand("applyreforge").setExecutor(new ApplyReforgeCommand());
 
@@ -801,6 +804,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
             swiftStepMasteryBonus.removeAllBonuses();
         }
         CustomEnchantmentPreferences.saveAll();
+        PotionEffectPreferences.saveAll();
         BeaconPassivesGUI.saveAllPassives();
         if (CatalystManager.getInstance() != null) {
             CatalystManager.getInstance().shutdown();

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
@@ -372,14 +372,6 @@ public class PotionBrewingSubsystem implements Listener {
                 new PotionRecipe("Potion of Solar Fury", solarFuryIngredients, 60*10, new ItemStack(Material.POTION), solarFuryColor, solarFuryLore)
         );
 
-        // Potion of Riptide
-        List<String> riptideIngredients = Arrays.asList("Glass Bottle", "Nether Wart", "Tide");
-        List<String> riptideLore = Arrays.asList("Boosts riptide velocity", "Base Duration of " + 60*30);
-        Color riptideColor = Color.fromRGB(173, 216, 230);
-        recipeRegistry.add(
-                new PotionRecipe("Potion of Riptide", riptideIngredients, 60*10, new ItemStack(Material.POTION), riptideColor, riptideLore)
-        );
-
         // Potion of Night Vision
         List<String> nightVisionIngredients = Arrays.asList("Glass Bottle", "Nether Wart", "Starlight");
         List<String> nightVisionLore = Arrays.asList("Grants Night Vision while moving", "Base Duration of " + 60*30);
@@ -420,6 +412,13 @@ public class PotionBrewingSubsystem implements Listener {
             }
         }
         return null;
+    }
+
+    /**
+     * Returns a copy of all registered potion recipes.
+     */
+    public static List<PotionRecipe> getPotionRecipes() {
+        return new ArrayList<>(recipeRegistry);
     }
 
     // ========================================================================

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionEffectPreferences.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionEffectPreferences.java
@@ -1,0 +1,103 @@
+package goat.minecraft.minecraftnew.subsystems.brewing;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Manages per-player preferences for enabling or disabling custom potion effects.
+ */
+public class PotionEffectPreferences implements Listener {
+
+    private static final Map<UUID, Map<String, Boolean>> prefs = new HashMap<>();
+    private static File prefFile;
+    private static FileConfiguration prefConfig;
+
+    public static void init(JavaPlugin plugin) {
+        prefFile = new File(plugin.getDataFolder(), "potioneffectpreferences.yml");
+        if (!prefFile.exists()) {
+            try {
+                plugin.getDataFolder().mkdirs();
+                prefFile.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        prefConfig = YamlConfiguration.loadConfiguration(prefFile);
+        for (String key : prefConfig.getKeys(false)) {
+            try {
+                UUID id = UUID.fromString(key);
+                ConfigurationSection sec = prefConfig.getConfigurationSection(key);
+                if (sec != null) {
+                    Map<String, Boolean> map = new HashMap<>();
+                    for (String eff : sec.getKeys(false)) {
+                        map.put(eff, sec.getBoolean(eff, true));
+                    }
+                    prefs.put(id, map);
+                }
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+    }
+
+    public static boolean isEnabled(Player player, String effect) {
+        Map<String, Boolean> map = prefs.get(player.getUniqueId());
+        if (map == null) return true;
+        return map.getOrDefault(normalize(effect), true);
+    }
+
+    public static void toggle(Player player, String effect) {
+        Map<String, Boolean> map = prefs.computeIfAbsent(player.getUniqueId(), k -> new HashMap<>());
+        String key = normalize(effect);
+        boolean newVal = !map.getOrDefault(key, true);
+        map.put(key, newVal);
+        savePlayer(player.getUniqueId());
+    }
+
+    private static void savePlayer(UUID id) {
+        Map<String, Boolean> map = prefs.get(id);
+        if (map == null) return;
+        prefConfig.set(id.toString(), null);
+        for (Map.Entry<String, Boolean> e : map.entrySet()) {
+            prefConfig.set(id.toString() + "." + e.getKey(), e.getValue());
+        }
+        try {
+            prefConfig.save(prefFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void saveAll() {
+        for (UUID id : prefs.keySet()) {
+            savePlayer(id);
+        }
+    }
+
+    private static String normalize(String name) {
+        return name.toLowerCase().replace(" ", "_");
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        prefs.computeIfAbsent(event.getPlayer().getUniqueId(), k -> new HashMap<>());
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        savePlayer(event.getPlayer().getUniqueId());
+    }
+}
+

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfNightVision.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfNightVision.java
@@ -2,6 +2,7 @@ package goat.minecraft.minecraftnew.subsystems.brewing.custompotions;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionEffectPreferences;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -44,7 +45,8 @@ public class PotionOfNightVision implements Listener {
     @EventHandler
     public void onPlayerMove(PlayerMoveEvent event) {
         Player player = event.getPlayer();
-        if (PotionManager.isActive("Potion of Night Vision", player)) {
+        if (PotionManager.isActive("Potion of Night Vision", player)
+                && PotionEffectPreferences.isEnabled(player, "Potion of Night Vision")) {
             player.addPotionEffect(new PotionEffect(PotionEffectType.NIGHT_VISION, 15 * 20, 0, false, false));
         }
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfSovereignty.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfSovereignty.java
@@ -2,6 +2,7 @@ package goat.minecraft.minecraftnew.subsystems.brewing.custompotions;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionEffectPreferences;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -73,7 +74,8 @@ public class PotionOfSovereignty implements Listener {
         if (!(event.getEntity() instanceof Player player)) {
             return;
         }
-        if(PotionManager.isActive("Potion of Sovereignty", player)) {
+        if(PotionManager.isActive("Potion of Sovereignty", player)
+                && PotionEffectPreferences.isEnabled(player, "Potion of Sovereignty")) {
             UUID uuid = player.getUniqueId();
             if(!activeDeflections.containsKey(uuid)){
                 int maxDeflections = 5;

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfStrength.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfStrength.java
@@ -2,6 +2,7 @@ package goat.minecraft.minecraftnew.subsystems.brewing.custompotions;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionEffectPreferences;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -53,7 +54,8 @@ public class PotionOfStrength implements Listener {
     public void onPlayerDamage(EntityDamageByEntityEvent event) {
         if (event.getDamager() instanceof Player) {
             Player player = (Player) event.getDamager();
-            if (PotionManager.isActive("Potion of Strength", player)) {
+            if (PotionManager.isActive("Potion of Strength", player)
+                    && PotionEffectPreferences.isEnabled(player, "Potion of Strength")) {
                 double extraDamage = event.getDamage() * 0.25;
                 event.setDamage(event.getDamage() + extraDamage);
             }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfSwiftStep.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfSwiftStep.java
@@ -2,6 +2,7 @@ package goat.minecraft.minecraftnew.subsystems.brewing.custompotions;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionEffectPreferences;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import goat.minecraft.minecraftnew.other.skilltree.Skill;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
@@ -52,7 +53,8 @@ public class PotionOfSwiftStep implements Listener {
     public void onPlayerMove(PlayerMoveEvent event) {
         Player player = event.getPlayer();
 
-        if (PotionManager.isActive("Potion of Swift Step", player)) {
+        if (PotionManager.isActive("Potion of Swift Step", player)
+                && PotionEffectPreferences.isEnabled(player, "Potion of Swift Step")) {
             player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 15 * 20, 1, false, false));
         }
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/FireDamageHandler.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/FireDamageHandler.java
@@ -3,6 +3,7 @@ package goat.minecraft.minecraftnew.subsystems.combat;
 import goat.minecraft.minecraftnew.other.additionalfunctionality.BlessingUtils;
 import goat.minecraft.minecraftnew.subsystems.combat.notification.DamageNotificationService;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionEffectPreferences;
 import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
@@ -88,7 +89,8 @@ public class FireDamageHandler implements Listener {
         int level = player.getInventory().getItemInMainHand().getEnchantmentLevel(Enchantment.FIRE_ASPECT);
         if (level > 0) {
             int amount = level * 5;
-            if (PotionManager.isActive("Potion of Solar Fury", player)) {
+            if (PotionManager.isActive("Potion of Solar Fury", player)
+                    && PotionEffectPreferences.isEnabled(player, "Potion of Solar Fury")) {
                 amount *= 2;
                 solarFuryTargets.put(target.getUniqueId(), true);
                 sendActionBar(player, ChatColor.GOLD + "Solar Fury: " + ChatColor.RED + "2x" + ChatColor.GOLD + " Fire Level!");

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/damage/strategies/RangedDamageStrategy.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/damage/strategies/RangedDamageStrategy.java
@@ -3,6 +3,7 @@ package goat.minecraft.minecraftnew.subsystems.combat.damage.strategies;
 import goat.minecraft.minecraftnew.other.additionalfunctionality.BlessingUtils;
 import goat.minecraft.minecraftnew.other.skilltree.Skill;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionEffectPreferences;
 import goat.minecraft.minecraftnew.subsystems.combat.config.CombatConfiguration;
 import goat.minecraft.minecraftnew.subsystems.combat.damage.DamageCalculationContext;
 import goat.minecraft.minecraftnew.subsystems.combat.damage.DamageCalculationResult;
@@ -61,7 +62,8 @@ public class RangedDamageStrategy implements DamageCalculationStrategy {
             }
             
             // Apply Potion of Recurve bonus if active
-            if (PotionManager.isActive("Potion of Recurve", shooter)) {
+            if (PotionManager.isActive("Potion of Recurve", shooter)
+                    && PotionEffectPreferences.isEnabled(shooter, "Potion of Recurve")) {
                 double potionMultiplier = config.getRecurveDamageBonus();
                 finalDamage *= potionMultiplier;
                 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/FishingEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/FishingEvent.java
@@ -7,6 +7,7 @@ import goat.minecraft.minecraftnew.other.beacon.CatalystManager;
 import goat.minecraft.minecraftnew.other.beacon.CatalystType;
 import goat.minecraft.minecraftnew.other.skilltree.Skill;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionEffectPreferences;
 import goat.minecraft.minecraftnew.subsystems.combat.HostilityManager;
 import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentManager;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
@@ -117,7 +118,8 @@ public class FishingEvent implements Listener {
         int callOfTheVoidLevel = CustomEnchantmentManager.getEnchantmentLevel(player.getInventory().getItemInMainHand(), "Call of the Void");
         seaCreatureChance += callOfTheVoidLevel;
 
-        if(PotionManager.isActive("Potion of Fountains", player)){
+        if(PotionManager.isActive("Potion of Fountains", player)
+                && PotionEffectPreferences.isEnabled(player, "Potion of Fountains")){
             seaCreatureChance += 10;
         }
         if(SkillTreeManager.getInstance().hasTalent(player, Talent.FOUNTAIN_MASTERY)){
@@ -514,7 +516,8 @@ public class FishingEvent implements Listener {
         if (petManager.getActivePet(player) != null && petManager.getActivePet(player).hasPerk(PetManager.PetPerk.TREASURE_HUNTER)) {
             treasureChance += (petLevel * 0.0010); // Scale to add 0.45 at pet level 100
         }
-        if(PotionManager.isActive("Potion of Liquid Luck", player)){
+        if(PotionManager.isActive("Potion of Liquid Luck", player)
+                && PotionEffectPreferences.isEnabled(player, "Potion of Liquid Luck")){
             treasureChance += 0.1;
         }
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureChanceCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/SeaCreatureChanceCommand.java
@@ -6,6 +6,7 @@ import goat.minecraft.minecraftnew.other.beacon.Catalyst;
 import goat.minecraft.minecraftnew.other.beacon.CatalystManager;
 import goat.minecraft.minecraftnew.other.beacon.CatalystType;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionEffectPreferences;
 import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentManager;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
 import goat.minecraft.minecraftnew.subsystems.pets.PetTrait;
@@ -51,7 +52,8 @@ public class SeaCreatureChanceCommand implements CommandExecutor {
         int callOfTheVoidLevel = CustomEnchantmentManager.getEnchantmentLevel(player.getInventory().getItemInMainHand(), "Call of the Void");
         double callOfTheVoidBonus = callOfTheVoidLevel;
 
-        double fountainBonus = PotionManager.isActive("Potion of Fountains", player) ? 10.0 : 0.0;
+        double fountainBonus = PotionManager.isActive("Potion of Fountains", player)
+                && PotionEffectPreferences.isEnabled(player, "Potion of Fountains") ? 10.0 : 0.0;
         double fountainMastery = SkillTreeManager.getInstance().hasTalent(player, Talent.FOUNTAIN_MASTERY) ? 5.0 : 0.0;
 
         CatalystManager catalystManager = CatalystManager.getInstance();

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/TreasureChanceCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/fishing/TreasureChanceCommand.java
@@ -2,6 +2,7 @@ package goat.minecraft.minecraftnew.subsystems.fishing;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionEffectPreferences;
 import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentManager;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
 import goat.minecraft.minecraftnew.other.beacon.Catalyst;
@@ -48,7 +49,8 @@ public class TreasureChanceCommand implements CommandExecutor {
             petBonus = activePet.getLevel() * 0.1;
         }
 
-        double potionBonus = PotionManager.isActive("Potion of Liquid Luck", player) ? 20.0 : 0.0;
+        double potionBonus = PotionManager.isActive("Potion of Liquid Luck", player)
+                && PotionEffectPreferences.isEnabled(player, "Potion of Liquid Luck") ? 20.0 : 0.0;
 
         int piracyLevel = CustomEnchantmentManager.getEnchantmentLevel(player.getInventory().getItemInMainHand(), "Piracy");
         double piracyBonus = piracyLevel;

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
@@ -5,6 +5,7 @@ import goat.minecraft.minecraftnew.subsystems.gravedigging.corpses.CorpseEvent;
 import net.citizensnpcs.api.CitizensAPI;
 import net.citizensnpcs.api.npc.NPC;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionEffectPreferences;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -119,7 +120,8 @@ public class Gravedigging implements Listener {
                 chance += activePet.getTrait().getValueForRarity(activePet.getTraitRarity());
             }
         }
-        if (PotionManager.isActive("Potion of Metal Detection", player)) {
+        if (PotionManager.isActive("Potion of Metal Detection", player)
+                && PotionEffectPreferences.isEnabled(player, "Potion of Metal Detection")) {
             chance += 0.01;
             if (SkillTreeManager.getInstance().hasTalent(player, Talent.METAL_DETECTION_MASTERY)) {
                 int level = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.BREWING, Talent.METAL_DETECTION_MASTERY);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/mining/PlayerOxygenManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/mining/PlayerOxygenManager.java
@@ -7,6 +7,7 @@ import goat.minecraft.minecraftnew.other.skilltree.Skill;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
 import goat.minecraft.minecraftnew.other.skilltree.Talent;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionEffectPreferences;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -70,7 +71,8 @@ public class PlayerOxygenManager implements Listener {
     private int recoveryCounter = 0; // Counts seconds for recovery pacing
 
     private int getRecoveryIntervalSeconds(Player player) {
-        if (PotionManager.isActive("Potion of Oxygen Recovery", player)) {
+        if (PotionManager.isActive("Potion of Oxygen Recovery", player)
+                && PotionEffectPreferences.isEnabled(player, "Potion of Oxygen Recovery")) {
             return 2;
         }
         return RECOVERY_INTERVAL_SECONDS;

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -12,6 +12,7 @@ import goat.minecraft.minecraftnew.utils.devtools.AFKDetector;
 import goat.minecraft.minecraftnew.utils.devtools.Speech;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionEffectPreferences;
 import goat.minecraft.minecraftnew.other.skilltree.Skill;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
 import goat.minecraft.minecraftnew.other.skilltree.Talent;
@@ -333,7 +334,6 @@ public class VillagerTradeManager implements Listener {
         clericPurchases.add(createTradeMap("SOVEREIGNTY", 1, 16, 2)); // Material
         clericPurchases.add(createTradeMap("LIQUID_LUCK", 1, 32, 2)); // Material
         clericPurchases.add(createTradeMap("FOUNTAINS", 1, 32, 2)); // Material
-        clericPurchases.add(createTradeMap("RIPTIDE", 1, 32, 2)); // Material
         clericPurchases.add(createTradeMap("SOLAR_FURY", 1, 32, 2)); // Material
         clericPurchases.add(createTradeMap("NIGHT_VISION", 1, 32, 2)); // Material
         clericPurchases.add(createTradeMap("METAL_DETECTION", 1, 32, 2)); // Material
@@ -707,8 +707,6 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getLiquidLuckRecipePaper();
             case "FOUNTAINS":
                 return ItemRegistry.getFountainsRecipePaper();
-            case "RIPTIDE":
-                return ItemRegistry.getRiptideRecipePaper();
             case "SOLAR_FURY":
                 return ItemRegistry.getSolarFuryRecipePaper();
             case "NIGHT_VISION":
@@ -911,8 +909,6 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getSunflare();
             case "STARLIGHT":
                 return ItemRegistry.getStarlight();
-            case "TIDE":
-                return ItemRegistry.getTide();
             case "SHINY_EMERALD":
                 return ItemRegistry.getShinyEmerald();
             case "DINOSAUR_BONES":
@@ -1163,7 +1159,8 @@ public class VillagerTradeManager implements Listener {
         }
         // No discount from Bartering level
 
-        if (PotionManager.isActive("Potion of Charismatic Bartering", player)) {
+        if (PotionManager.isActive("Potion of Charismatic Bartering", player)
+                && PotionEffectPreferences.isEnabled(player, "Potion of Charismatic Bartering")) {
             double discount = 0.20;
             if (SkillTreeManager.getInstance().hasTalent(player, Talent.CHARISMA_MASTERY)) {
                 int level = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.BREWING, Talent.CHARISMA_MASTERY);
@@ -1597,7 +1594,8 @@ public class VillagerTradeManager implements Listener {
 
         // --- Bartering discount logic removed ---
 
-        if (PotionManager.isActive("Potion of Charismatic Bartering", player)) {
+        if (PotionManager.isActive("Potion of Charismatic Bartering", player)
+                && PotionEffectPreferences.isEnabled(player, "Potion of Charismatic Bartering")) {
             double discount = 0.20;
             if (SkillTreeManager.getInstance().hasTalent(player, Talent.CHARISMA_MASTERY)) {
                 int level = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.BREWING, Talent.CHARISMA_MASTERY);

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/TogglePotionEffectsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/TogglePotionEffectsCommand.java
@@ -1,0 +1,97 @@
+package goat.minecraft.minecraftnew.utils.commands;
+
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionBrewingSubsystem;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionEffectPreferences;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionBrewingSubsystem.PotionRecipe;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.potion.PotionData;
+import org.bukkit.potion.PotionType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * GUI command allowing players to toggle custom potion effect benefits.
+ */
+public class TogglePotionEffectsCommand implements CommandExecutor, Listener {
+
+    private static final String GUI_TITLE = ChatColor.DARK_PURPLE + "Custom Potion Effects";
+    private final JavaPlugin plugin;
+
+    public TogglePotionEffectsCommand(JavaPlugin plugin) {
+        this.plugin = plugin;
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players can use this command.");
+            return true;
+        }
+        openGUI(player);
+        return true;
+    }
+
+    private void openGUI(Player player) {
+        List<PotionRecipe> recipes = PotionBrewingSubsystem.getPotionRecipes();
+        int size = ((recipes.size() / 9) + 1) * 9;
+        Inventory gui = Bukkit.createInventory(null, size, GUI_TITLE);
+        int slot = 0;
+        for (PotionRecipe recipe : recipes) {
+            String name = recipe.getName();
+            boolean enabled = PotionEffectPreferences.isEnabled(player, name);
+
+            ItemStack item = new ItemStack(Material.POTION);
+            PotionMeta meta = (PotionMeta) item.getItemMeta();
+            meta.setDisplayName((enabled ? ChatColor.GREEN : ChatColor.RED) + name);
+            meta.setColor(recipe.getFinalColor());
+            meta.setBasePotionData(new PotionData(PotionType.WATER));
+
+            List<String> lore = new ArrayList<>();
+            for (String line : recipe.getEffectLore()) {
+                lore.add(ChatColor.GRAY + line);
+            }
+            lore.add("");
+            if (enabled) {
+                lore.add(ChatColor.GREEN + "✓ ENABLED");
+                lore.add(ChatColor.GRAY + "Left click to disable");
+            } else {
+                lore.add(ChatColor.RED + "✗ DISABLED");
+                lore.add(ChatColor.GRAY + "Left click to enable");
+            }
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+
+            gui.setItem(slot++, item);
+        }
+        player.openInventory(gui);
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) return;
+        if (!event.getView().getTitle().equals(GUI_TITLE)) return;
+        event.setCancelled(true);
+        ItemStack clicked = event.getCurrentItem();
+        if (clicked == null || !clicked.hasItemMeta()) return;
+        String name = ChatColor.stripColor(clicked.getItemMeta().getDisplayName());
+        if (name.isEmpty()) return;
+        PotionEffectPreferences.toggle(player, name);
+        openGUI(player);
+    }
+}
+

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -587,7 +587,6 @@ public class ItemRegistry {
                 getVerdantRelicEntropySeed(),
                 getVerdantRelicSunflareSeed(),
                 getVerdantRelicStarlightSeed(),
-                getVerdantRelicTideSeed(),
                 getDinosaurBones(),
                 getVerdantRelicShinyEmeraldSeed()
         );

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -167,6 +167,10 @@ commands:
     description: Toggle your custom enchantments on or off
     usage: /togglecustomenchantments
     default: true
+  togglepotioneffects:
+    description: Toggle your custom potion effects on or off
+    usage: /togglepotioneffects
+    default: true
   setskilllevel:
     description: Sets a player's skill level
     usage: /setskilllevel <player> <skill> <level>


### PR DESCRIPTION
## Summary
- remove Potion of Riptide from brewing registry and villager trades
- add PotionEffectPreferences for per-player potion toggles
- add /togglepotioneffects command to manage potion effect toggles
- register new command and preference manager in plugin
- gate potion effect logic on both active status and toggle state

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_687c24046de883329f094976ad8c1f40