### PR TITLE
Add /stats command with GUI

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -54,6 +54,7 @@ import goat.minecraft.minecraftnew.utils.commands.MeritCommand;
 import goat.minecraft.minecraftnew.utils.commands.SkillsCommand;
 import goat.minecraft.minecraftnew.utils.commands.AuraCommand;
 import goat.minecraft.minecraftnew.utils.commands.ToggleCustomEnchantmentsCommand;
+import goat.minecraft.minecraftnew.utils.commands.StatsCommand;
 import goat.minecraft.minecraftnew.utils.developercommands.*;
 import goat.minecraft.minecraftnew.utils.developercommands.SetCustomDurabilityCommand;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
@@ -514,6 +515,9 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         SkillsCommand skillsCommand = new SkillsCommand(xpManager);
         this.getCommand("skills").setExecutor(skillsCommand);
         getServer().getPluginManager().registerEvents(skillsCommand, this);
+        StatsCommand statsCommand = new StatsCommand(this);
+        this.getCommand("stats").setExecutor(statsCommand);
+        getServer().getPluginManager().registerEvents(statsCommand, this);
         new SetSkillLevelCommand(this, xpManager);
 
         SkillTreeManager.init(this);

--- a/src/main/java/goat/minecraft/minecraftnew/other/resistance/PlayerResistanceManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/resistance/PlayerResistanceManager.java
@@ -1,0 +1,93 @@
+package goat.minecraft.minecraftnew.other.resistance;
+
+import goat.minecraft.minecraftnew.other.beacon.BeaconPassivesGUI;
+import goat.minecraft.minecraftnew.other.additionalfunctionality.BlessingUtils;
+import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
+import goat.minecraft.minecraftnew.subsystems.pets.PetTrait;
+import goat.minecraft.minecraftnew.subsystems.smithing.tierreforgelisteners.ReforgeManager;
+import goat.minecraft.minecraftnew.subsystems.smithing.tierreforgelisteners.ReforgeManager.ReforgeTier;
+import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentManager;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Computes total damage reduction for a player from various systems.
+ */
+public class PlayerResistanceManager {
+
+    private static PlayerResistanceManager instance;
+    private final JavaPlugin plugin;
+
+    private static final double MAX_ENCHANT_REDUCTION = 16.0;
+    private static final double MAX_REFORGE_REDUCTION = 20.0;
+
+    private PlayerResistanceManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public static synchronized PlayerResistanceManager getInstance(JavaPlugin plugin) {
+        if (instance == null) {
+            instance = new PlayerResistanceManager(plugin);
+        }
+        return instance;
+    }
+
+    public static PlayerResistanceManager getInstance(JavaPlugin pluginIfAbsent) {
+        if (instance == null) {
+            instance = new PlayerResistanceManager(pluginIfAbsent);
+        }
+        return instance;
+    }
+
+    public double computeTotalResistance(Player player) {
+        double reduction = 0.0;
+
+        // Beacon passive
+        if (BeaconPassivesGUI.hasBeaconPassives(player) &&
+                BeaconPassivesGUI.hasPassiveEnabled(player, "sturdy")) {
+            reduction += 15.0;
+        }
+
+        // Monolith full set bonus grants resistance effect
+        if (BlessingUtils.hasFullSetBonus(player, "Monolith")) {
+            reduction += 20.0;
+        }
+
+        // Potion effect
+        PotionEffect effect = player.getPotionEffect(PotionEffectType.DAMAGE_RESISTANCE);
+        if (effect != null) {
+            reduction += (effect.getAmplifier() + 1) * 20.0;
+        }
+
+        // Armor enchantments - Physical Protection
+        int enchantPieces = 0;
+        for (ItemStack piece : player.getInventory().getArmorContents()) {
+            if (CustomEnchantmentManager.hasEnchantment(piece, "Physical Protection")) {
+                enchantPieces++;
+            }
+        }
+        reduction += Math.min(enchantPieces * 1.0, MAX_ENCHANT_REDUCTION);
+
+        // Reforge armor reduction
+        ReforgeManager rm = new ReforgeManager();
+        double reforge = 0.0;
+        for (ItemStack piece : player.getInventory().getArmorContents()) {
+            if (rm.isArmor(piece)) {
+                ReforgeTier tier = rm.getReforgeTierByTier(rm.getReforgeTier(piece));
+                reforge += tier.getArmorDamageReduction();
+            }
+        }
+        reduction += Math.min(reforge, MAX_REFORGE_REDUCTION);
+
+        // Pet traits that give damage reduction
+        PetManager.Pet pet = PetManager.getInstance(plugin).getActivePet(player);
+        if (pet != null && pet.getTrait() == PetTrait.RESILIENT) {
+            reduction += pet.getTrait().getValueForRarity(pet.getTraitRarity());
+        }
+
+        return reduction;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/StatsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/StatsCommand.java
@@ -1,0 +1,92 @@
+package goat.minecraft.minecraftnew.utils.commands;
+
+import goat.minecraft.minecraftnew.utils.stats.StatsCalculator;
+import goat.minecraft.minecraftnew.utils.stats.PlayerResistanceManager; // ensure loaded
+import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Opens a GUI displaying various aggregated player statistics.
+ */
+public class StatsCommand implements CommandExecutor, Listener {
+
+    private final JavaPlugin plugin;
+    private final StatsCalculator calculator;
+
+    public StatsCommand(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.calculator = new StatsCalculator(plugin);
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player)) return;
+        if (ChatColor.stripColor(event.getView().getTitle()).equals("Player Stats")) {
+            event.setCancelled(true);
+        }
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+        openStatsGUI(player);
+        return true;
+    }
+
+    private void openStatsGUI(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, ChatColor.DARK_GREEN + "Player Stats");
+
+        addStatItem(inv, 0, Material.REDSTONE, "Health", String.format("%.1f", calculator.getHealth(player)));
+        addStatItem(inv, 1, Material.IRON_SWORD, "Damage +%", String.format("%.1f%%", calculator.getDamageIncrease(player)));
+        addStatItem(inv, 2, Material.BOW, "Arrow Damage +%", String.format("%.1f%%", calculator.getArrowDamageIncrease(player)));
+        addStatItem(inv, 3, Material.SHIELD, "Resistance", String.format("%.1f%%", calculator.getResistance(player)));
+        addStatItem(inv, 4, Material.ELYTRA, "Flight Distance", String.format("%.2f km", calculator.getFlightDistance(player)));
+        addStatItem(inv, 5, Material.SOUL_TORCH, "Grave Chance", String.format("%.3f%%", calculator.getGraveChance(player)));
+        addStatItem(inv, 6, Material.NAUTILUS_SHELL, "Sea Creature Chance", String.format("%.2f%%", calculator.getSeaCreatureChance(player)));
+        addStatItem(inv, 7, Material.CHEST, "Treasure Chance", String.format("%.2f%%", calculator.getTreasureChance(player)));
+        addStatItem(inv, 8, Material.SOUL_LANTERN, "Spirit Chance", String.format("%.2f%%", calculator.getSpiritChance(player)));
+        addStatItem(inv, 9, Material.EMERALD, "Discount", String.format("%.2f%%", calculator.getDiscount(player)));
+        addStatItem(inv, 10, Material.FEATHER, "Speed", String.format("%.1f%%", calculator.getSpeed(player)));
+        addStatItem(inv, 11, Material.POTION, "Brew Time Reduction", String.format("%.1f%%", calculator.getBrewTimeReduction(player)));
+        addStatItem(inv, 12, Material.DIAMOND_ORE, "Double Ore Chance", String.format("%.1f%%", calculator.getDoubleOreChance(player)));
+        addStatItem(inv, 13, Material.OAK_LOG, "Double Log Chance", String.format("%.1f%%", calculator.getDoubleLogChance(player)));
+        addStatItem(inv, 14, Material.WHEAT, "Double Crop Chance", String.format("%.1f%%", calculator.getDoubleCropChance(player)));
+        addStatItem(inv, 15, Material.ANVIL, "Repair Amount", String.format("%.1f", calculator.getRepairAmount(player)));
+        addStatItem(inv, 16, Material.ENCHANTED_BOOK, "Repair Quality", String.format("%.1f", calculator.getRepairQuality(player)));
+
+        player.openInventory(inv);
+    }
+
+    private void addStatItem(Inventory inv, int slot, Material mat, String name, String value) {
+        ItemStack item = new ItemStack(mat);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.GOLD + name);
+            List<String> lore = new ArrayList<>();
+            lore.add(ChatColor.YELLOW + value);
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+        }
+        inv.setItem(slot, item);
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/stats/StatsCalculator.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/stats/StatsCalculator.java
@@ -1,0 +1,309 @@
+package goat.minecraft.minecraftnew.utils.stats;
+
+import goat.minecraft.minecraftnew.other.health.HealthManager;
+import goat.minecraft.minecraftnew.other.beacon.BeaconPassivesGUI;
+import goat.minecraft.minecraftnew.other.additionalfunctionality.BlessingUtils;
+import goat.minecraft.minecraftnew.other.beacon.Catalyst;
+import goat.minecraft.minecraftnew.other.beacon.CatalystManager;
+import goat.minecraft.minecraftnew.other.beacon.CatalystType;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
+import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
+import goat.minecraft.minecraftnew.subsystems.pets.PetTrait;
+import goat.minecraft.minecraftnew.subsystems.pets.TraitRarity;
+import goat.minecraft.minecraftnew.subsystems.smithing.tierreforgelisteners.ReforgeManager;
+import goat.minecraft.minecraftnew.subsystems.smithing.tierreforgelisteners.ReforgeManager.ReforgeTier;
+import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentManager;
+import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Utility class to aggregate various player statistics for display.
+ */
+public class StatsCalculator {
+
+    private final JavaPlugin plugin;
+
+    public StatsCalculator(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /** Calculate max health using HealthManager. */
+    public double getHealth(Player player) {
+        return HealthManager.getInstance(plugin).computeMaxHealth(player);
+    }
+
+    /** Approximate melee damage increase percent from reforges, talents and catalysts. */
+    public double getDamageIncrease(Player player) {
+        double bonus = 0.0;
+        // Strength mastery talent
+        if (SkillTreeManager.getInstance() != null &&
+                SkillTreeManager.getInstance().hasTalent(player, Talent.STRENGTH_MASTERY)) {
+            bonus += 5.0;
+        }
+        // Weapon reforge bonus
+        ReforgeManager rm = new ReforgeManager();
+        ItemStack weapon = player.getInventory().getItemInMainHand();
+        if (rm.isSword(weapon)) {
+            ReforgeTier tier = rm.getReforgeTierByTier(rm.getReforgeTier(weapon));
+            bonus += tier.getWeaponDamageIncrease();
+        }
+        // Power catalyst
+        CatalystManager cm = CatalystManager.getInstance();
+        if (cm != null && cm.isNearCatalyst(player.getLocation(), CatalystType.POWER)) {
+            Catalyst cat = cm.findNearestCatalyst(player.getLocation(), CatalystType.POWER);
+            if (cat != null) {
+                int t = cm.getCatalystTier(cat);
+                bonus += (0.25 + t * 0.05) * 100.0;
+            }
+        }
+        return bonus;
+    }
+
+    /** Arrow damage increase percent from talents, potions and reforges. */
+    public double getArrowDamageIncrease(Player player) {
+        double bonus = 0.0;
+        if (SkillTreeManager.getInstance() != null) {
+            int bowLevel = SkillTreeManager.getInstance()
+                    .getTalentLevel(player.getUniqueId(), Skill.COMBAT, Talent.BOW_MASTERY);
+            bonus += bowLevel * 8.0;
+            if (SkillTreeManager.getInstance().hasTalent(player, Talent.RECURVE_MASTERY)) {
+                bonus += 5.0;
+            }
+        }
+        if (CustomEnchantmentManager.getEnchantmentLevel(player.getInventory().getItemInMainHand(), "Call of the Void") > 0) {
+            bonus += CustomEnchantmentManager.getEnchantmentLevel(player.getInventory().getItemInMainHand(), "Call of the Void");
+        }
+        if (PetManager.getInstance(plugin).getActivePet(player) != null &&
+                PetManager.getInstance(plugin).getActivePet(player).hasPerk(PetManager.PetPerk.SHOTCALLING)) {
+            int lvl = PetManager.getInstance(plugin).getActivePet(player).getLevel();
+            bonus += lvl * 0.5;
+        }
+        ReforgeManager rm = new ReforgeManager();
+        ItemStack bow = player.getInventory().getItemInMainHand();
+        if (rm.isBow(bow)) {
+            ReforgeTier tier = rm.getReforgeTierByTier(rm.getReforgeTier(bow));
+            bonus += tier.getBowDamageIncrease();
+        }
+        if (PetManager.getInstance(plugin).getActivePet(player) != null &&
+                PetManager.getInstance(plugin).getActivePet(player).getTrait() == PetTrait.PRECISE) {
+            TraitRarity rarity = PetManager.getInstance(plugin).getActivePet(player).getTraitRarity();
+            bonus += PetTrait.PRECISE.getValueForRarity(rarity);
+        }
+        return bonus;
+    }
+
+    /** Calculate total resistance percentage from various sources. */
+    public double getResistance(Player player) {
+        return PlayerResistanceManager.getInstance(plugin).computeTotalResistance(player);
+    }
+
+    /** Maximum flight distance in km from pet perks and merits. */
+    public double getFlightDistance(Player player) {
+        PetManager.Pet pet = PetManager.getInstance(plugin).getActivePet(player);
+        double distance = 0.0;
+        if (pet != null && pet.hasPerk(PetManager.PetPerk.FLIGHT)) {
+            distance = pet.getLevel() / 100.0; // scales to 1km at level 100
+            PlayerMeritManager merits = PlayerMeritManager.getInstance(plugin);
+            if (merits.hasPerk(player.getUniqueId(), "Icarus")) {
+                distance *= 2;
+            }
+        }
+        return distance;
+    }
+
+    /** Grave spawning chance from talents and pet traits. */
+    public double getGraveChance(Player player) {
+        double chance = 0.0;
+        if (SkillTreeManager.getInstance() != null) {
+            int lvl = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.TERRAFORMING, Talent.GRAVE_INTUITION);
+            chance += lvl * 0.001;
+        }
+        PetManager.Pet pet = PetManager.getInstance(plugin).getActivePet(player);
+        if (pet != null && pet.getTrait() == PetTrait.PARANORMAL) {
+            chance += pet.getTrait().getValueForRarity(pet.getTraitRarity());
+        }
+        return chance * 100.0;
+    }
+
+    /** Sea creature chance using same logic as command. */
+    public double getSeaCreatureChance(Player player) {
+        double total = 0.0;
+        int instinctLevel = SkillTreeManager.getInstance()
+                .getTalentLevel(player.getUniqueId(), Skill.FISHING, Talent.ANGLERS_INSTINCT);
+        total += instinctLevel * 0.25;
+        if (CustomEnchantmentManager.getEnchantmentLevel(player.getInventory().getItemInMainHand(), "Call of the Void") > 0) {
+            total += CustomEnchantmentManager.getEnchantmentLevel(player.getInventory().getItemInMainHand(), "Call of the Void");
+        }
+        if (PetManager.getInstance(plugin).getActivePet(player) != null) {
+            PetManager.Pet p = PetManager.getInstance(plugin).getActivePet(player);
+            if (p.hasPerk(PetManager.PetPerk.ANGLER)) total += 5;
+            if (p.hasPerk(PetManager.PetPerk.HEART_OF_THE_SEA)) total += 10;
+            if (p.getTrait() == PetTrait.NAUTICAL) {
+                total += p.getTrait().getValueForRarity(p.getTraitRarity());
+            }
+        }
+        CatalystManager cm = CatalystManager.getInstance();
+        if (cm != null && cm.isNearCatalyst(player.getLocation(), CatalystType.DEPTH)) {
+            Catalyst cat = cm.findNearestCatalyst(player.getLocation(), CatalystType.DEPTH);
+            if (cat != null) {
+                total += 5 + cm.getCatalystTier(cat);
+            }
+        }
+        return total;
+    }
+
+    /** Treasure chance calculation similar to command. */
+    public double getTreasureChance(Player player) {
+        double chance = 5.0; // base
+        int upgrade = CustomEnchantmentManager.getEnchantmentLevel(player.getInventory().getItemInMainHand(), "Piracy");
+        chance += upgrade;
+        PetManager.Pet pet = PetManager.getInstance(plugin).getActivePet(player);
+        if (pet != null && pet.hasPerk(PetManager.PetPerk.TREASURE_HUNTER)) {
+            chance += pet.getLevel() * 0.1;
+        }
+        if (pet != null && pet.getTrait() == PetTrait.TREASURED) {
+            chance += pet.getTrait().getValueForRarity(pet.getTraitRarity());
+        }
+        CatalystManager cm = CatalystManager.getInstance();
+        if (cm != null && cm.isNearCatalyst(player.getLocation(), CatalystType.DEPTH)) {
+            Catalyst cat = cm.findNearestCatalyst(player.getLocation(), CatalystType.DEPTH);
+            if (cat != null) {
+                chance += 5 + cm.getCatalystTier(cat);
+            }
+        }
+        return chance;
+    }
+
+    /** Spirit chance calculation simplified. */
+    public double getSpiritChance(Player player) {
+        double chance = 0.01; // base
+        int upgrade = CustomEnchantmentManager.getEnchantmentLevel(player.getInventory().getItemInMainHand(), "Effigy Yield");
+        chance += upgrade * 0.000333;
+        PetManager.Pet pet = PetManager.getInstance(plugin).getActivePet(player);
+        if (pet != null && pet.getTrait() == PetTrait.HAUNTED) {
+            chance += pet.getTrait().getValueForRarity(pet.getTraitRarity()) / 100.0;
+        }
+        CatalystManager cm = CatalystManager.getInstance();
+        if (cm != null && cm.isNearCatalyst(player.getLocation(), CatalystType.INSANITY)) {
+            Catalyst cat = cm.findNearestCatalyst(player.getLocation(), CatalystType.INSANITY);
+            if (cat != null) {
+                chance += 0.0005 + (cm.getCatalystTier(cat) * 0.0005);
+            }
+        }
+        return chance * 100.0;
+    }
+
+    /** Discount percent from traits, pet perks and bartering talents. */
+    public double getDiscount(Player player) {
+        double discount = 0.0;
+        if (SkillTreeManager.getInstance() != null) {
+            int level = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.BARTERING, Talent.BARTER_DISCOUNT);
+            discount += level * 4.0;
+            if (SkillTreeManager.getInstance().hasTalent(player, Talent.CHARISMA_MASTERY)) {
+                discount += 5.0;
+            }
+        }
+        PetManager.Pet pet = PetManager.getInstance(plugin).getActivePet(player);
+        if (pet != null && pet.getTrait() == PetTrait.FINANCIAL) {
+            discount += pet.getTrait().getValueForRarity(pet.getTraitRarity());
+        }
+        return discount;
+    }
+
+    /** Speed percent relative to normal walk speed. */
+    public double getSpeed(Player player) {
+        float speed = player.getWalkSpeed();
+        return ((speed / 0.2f) - 1.0f) * 100.0f;
+    }
+
+    /** Brew time reduction percent from pet perks. */
+    public double getBrewTimeReduction(Player player) {
+        double reduction = 0.0;
+        PetManager.Pet pet = PetManager.getInstance(plugin).getActivePet(player);
+        if (pet != null && pet.hasPerk(PetManager.PetPerk.SPLASH_POTION)) {
+            reduction += pet.getLevel() / 2.0;
+        }
+        return reduction;
+    }
+
+    /** Double ore chance from talent and catalysts. */
+    public double getDoubleOreChance(Player player) {
+        double chance = 0.0;
+        if (SkillTreeManager.getInstance() != null) {
+            int lvl = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.MINING, Talent.RICH_VEINS);
+            chance += lvl * 4.0;
+        }
+        CatalystManager cm = CatalystManager.getInstance();
+        if (cm != null && cm.isNearCatalyst(player.getLocation(), CatalystType.PROSPERITY)) {
+            Catalyst cat = cm.findNearestCatalyst(player.getLocation(), CatalystType.PROSPERITY);
+            if (cat != null) {
+                int t = cm.getCatalystTier(cat);
+                chance = Math.max(chance, 40 + t * 10);
+            }
+        }
+        return chance;
+    }
+
+    /** Double log chance from forestry talent and catalysts. */
+    public double getDoubleLogChance(Player player) {
+        double chance = 0.0;
+        if (SkillTreeManager.getInstance() != null) {
+            int lvl = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.FORESTRY, Talent.DOUBLE_LOGS);
+            chance += lvl * 10.0;
+        }
+        CatalystManager cm = CatalystManager.getInstance();
+        if (cm != null && cm.isNearCatalyst(player.getLocation(), CatalystType.PROSPERITY)) {
+            Catalyst cat = cm.findNearestCatalyst(player.getLocation(), CatalystType.PROSPERITY);
+            if (cat != null) {
+                int t = cm.getCatalystTier(cat);
+                chance = Math.max(chance, 40 + t * 10);
+            }
+        }
+        return chance;
+    }
+
+    /** Double crop chance from talents and catalysts. */
+    public double getDoubleCropChance(Player player) {
+        double chance = 0.0;
+        if (SkillTreeManager.getInstance() != null) {
+            int lvl = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.FARMING, Talent.BOUNTIFUL_HARVEST);
+            chance += lvl * 4.0;
+        }
+        CatalystManager cm = CatalystManager.getInstance();
+        if (cm != null && cm.isNearCatalyst(player.getLocation(), CatalystType.PROSPERITY)) {
+            Catalyst cat = cm.findNearestCatalyst(player.getLocation(), CatalystType.PROSPERITY);
+            if (cat != null) {
+                int t = cm.getCatalystTier(cat);
+                chance = Math.max(chance, 40 + t * 10);
+            }
+        }
+        return chance;
+    }
+
+    /** Repair amount from smithing talents. */
+    public double getRepairAmount(Player player) {
+        double amount = 25.0; // base
+        if (SkillTreeManager.getInstance() != null) {
+            int l1 = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.REPAIR_MASTERY_I);
+            amount += l1 * 1;
+            int l2 = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.REPAIR_MASTERY_II);
+            amount += l2 * 2;
+            int l3 = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.REPAIR_MASTERY_III);
+            amount += l3 * 3;
+            int l4 = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.REPAIR_MASTERY_IV);
+            amount += l4 * 4;
+        }
+        return amount;
+    }
+
+    /** Repair quality stat not yet implemented, returns zero. */
+    public double getRepairQuality(Player player) {
+        return 0.0;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -237,6 +237,10 @@ commands:
     description: Displays your total Spirit Chance
     usage: /spiritchance
     default: true
+  stats:
+    description: Shows a GUI of your overall stats
+    usage: /stats
+    default: true
   stripreforge:
     description: Removes the reforge from the item in your hand
     usage: /stripreforge


### PR DESCRIPTION
## Summary
- introduce `StatsCommand` to show player stats in a GUI
- implement `StatsCalculator` utility to gather stats from various systems
- create `PlayerResistanceManager` for calculating damage reduction
- register `/stats` command in plugin startup and in plugin.yml

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_687c267392208332959c91996a2023ac