### PR TITLE
Nerf orchard perk and remove unused spirit upgrades

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/EffigyUpgradeSystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/EffigyUpgradeSystem.java
@@ -43,10 +43,7 @@ public class EffigyUpgradeSystem implements Listener {
         PAYOUT("Payout", "Sells stacks of logs for emeralds", Material.EMERALD, 4, 24),
         ORCHARD("Orchard", "Higher perfect apple droprate", Material.APPLE, 4, 29),
         GOLDEN_APPLE("Golden Apple", "Chance to drop enchanted apple", Material.ENCHANTED_GOLDEN_APPLE, 3, 30),
-        TRESPASSER("Trespasser", "+3 notoriety per level", Material.BARRIER, 6, 31),
-        HEADHUNTER("Headhunter", "+10% damage to forest spirits", Material.IRON_AXE, 5, 32),
-        SPECTRAL_ARMOR("Spectral Armor", "Damage reduction from spirits", Material.CHAINMAIL_CHESTPLATE, 5, 33),
-        ANCIENT_CONFUSION("Ancient Confusion", "Lowers spirit level", Material.FERMENTED_SPIDER_EYE, 4, 34);
+        TRESPASSER("Trespasser", "+3 notoriety per level", Material.BARRIER, 6, 31);
 
         private final String displayName;
         private final String description;
@@ -110,8 +107,7 @@ public class EffigyUpgradeSystem implements Listener {
         // Misc upgrades
         gui.setItem(27, createHeader(Material.GOLDEN_AXE, ChatColor.GOLD + "✨ Special"));
         for (UpgradeType t : Arrays.asList(UpgradeType.ORCHARD, UpgradeType.GOLDEN_APPLE,
-                UpgradeType.TRESPASSER, UpgradeType.HEADHUNTER,
-                UpgradeType.SPECTRAL_ARMOR, UpgradeType.ANCIENT_CONFUSION)) {
+                UpgradeType.TRESPASSER)) {
             gui.setItem(t.getSlot(), createUpgradeItem(t, axe, getUpgradeCost(t), available));
         }
 
@@ -263,7 +259,6 @@ public class EffigyUpgradeSystem implements Listener {
 
     private int getUpgradeCost(UpgradeType type) {
         switch (type) {
-            case ANCIENT_CONFUSION:
             case FEED:
             case OAK_YIELD:
             case SPRUCE_YIELD:
@@ -464,9 +459,6 @@ public class EffigyUpgradeSystem implements Listener {
             case ORCHARD: return "🍎";
             case GOLDEN_APPLE: return "🏆";
             case TRESPASSER: return "☠";
-            case HEADHUNTER: return "🗡";
-            case SPECTRAL_ARMOR: return "🛡";
-            case ANCIENT_CONFUSION: return "❓";
             default: return "⬡";
         }
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/ForestSpiritManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/ForestSpiritManager.java
@@ -137,12 +137,6 @@ public class ForestSpiritManager implements Listener {
         int tier = getSpiritTier(player);
         int level = getSpiritLevelForTier(tier);
 
-        ItemStack axe = player.getInventory().getItemInMainHand();
-        int confusion = EffigyUpgradeSystem.getUpgradeLevel(axe, EffigyUpgradeSystem.UpgradeType.ANCIENT_CONFUSION);
-        if (confusion > 0) {
-            level = Math.max(1, level - confusion * 10);
-        }
-
         SpawnMonsters spawnMonsters = SpawnMonsters.getInstance(xpManager);
         World world = loc.getWorld();
         if (world == null) return;
@@ -440,13 +434,7 @@ public class ForestSpiritManager implements Listener {
 
         if (entity.hasMetadata("forestSpirit") && damager instanceof Player) {
             Player player = (Player) damager;
-            ItemStack axe = player.getInventory().getItemInMainHand();
-            int headhunter = EffigyUpgradeSystem.getUpgradeLevel(axe, EffigyUpgradeSystem.UpgradeType.HEADHUNTER);
-            int confusion = EffigyUpgradeSystem.getUpgradeLevel(axe, EffigyUpgradeSystem.UpgradeType.ANCIENT_CONFUSION);
-
-            if (headhunter > 0) {
-                event.setDamage(event.getDamage() * (2 + headhunter * 0.10));
-            }
+            // Apply minor knock sound when damaging a spirit
 
             World world = entity.getWorld();
             Location loc = entity.getLocation();
@@ -455,7 +443,6 @@ public class ForestSpiritManager implements Listener {
 
         if (damager.hasMetadata("forestSpirit") && entity instanceof Player) {
             Player player = (Player) entity;
-            ItemStack axe = player.getInventory().getItemInMainHand();
             CatalystManager catalystManager = CatalystManager.getInstance();
             if (catalystManager == null) {
                 return;
@@ -478,10 +465,6 @@ public class ForestSpiritManager implements Listener {
             // Calculate spirit chance bonus: 5% + (tier * 1%)
             double damageReduction = BASE_DAMAGE_REDUCTION + (catalystTier * PER_TIER_BONUS);
             event.setDamage(event.getDamage() * (1 - damageReduction));
-            int spectral = EffigyUpgradeSystem.getUpgradeLevel(axe, EffigyUpgradeSystem.UpgradeType.SPECTRAL_ARMOR);
-            if (spectral > 0) {
-                event.setDamage(event.getDamage() * (1 - spectral * 0.10));
-            }
         }
     }
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/Forestry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/Forestry.java
@@ -538,7 +538,7 @@ public class Forestry implements Listener {
      * @param forestryLevel The player's forestry level.
      */
     public void processPerfectAppleChance(Player player, Block block, int forestryLevel, int orchardLevel) {
-        double chance = forestryLevel * 0.01 + orchardLevel * 1.0;
+        double chance = forestryLevel * 0.01 + orchardLevel * 0.1;
         if (random.nextDouble() * 100 < chance) {
             final Location dropLocation = block.getLocation().add(0.5, 0.5, 0.5);
             new BukkitRunnable() {


### PR DESCRIPTION
## Summary
- remove Headhunter, Spectral Armor and Ancient Confusion upgrades
- nerf orchard by reducing perfect apple bonus by 90%
- clean up no-longer-used logic

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_687db4a9df74833283072f8d17ee4d8a