### PR TITLE
Update bloodlust stack display and invulnerability

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodlust/BloodlustListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/bloodlust/BloodlustListener.java
@@ -27,8 +27,8 @@ public class BloodlustListener implements Listener {
 
     @EventHandler
     public void onHit(EntityDamageByEntityEvent event) {
-        if (event.getDamager() instanceof Player player) {
-            manager.handleHit(player);
+        if (event.getDamager() instanceof Player player && event.getEntity() instanceof org.bukkit.entity.LivingEntity target) {
+            manager.handleHit(player, target);
         }
     }
 }


### PR DESCRIPTION
## Summary
- boss bar progress now reflects bloodlust stacks and shows remaining duration as the title
- reduce hit entity invulnerability time based on the attacker's bloodlust level

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688323fd6cf083329a30d50c7e9aa1d3