### PR TITLE
Add red vignette command

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -417,6 +417,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         new CulinaryCauldron(this);
         CustomNutritionManager.init(this);
         getCommand("nutrients").setExecutor(new NutritionCommand());
+        getCommand("redvignette").setExecutor(new RedVignetteCommand(this));
 
         getLogger().info("MyPlugin has been enabled!");
 

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/RedVignetteCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/RedVignetteCommand.java
@@ -1,0 +1,42 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.WorldBorder;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Command: /redvignette
+ * Gives the executing player a temporary red vignette effect by showing
+ * a very small world border centered on them.
+ */
+public class RedVignetteCommand implements CommandExecutor {
+    private final JavaPlugin plugin;
+
+    public RedVignetteCommand(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        // Create a personal world border centered on the player
+        WorldBorder border = Bukkit.createWorldBorder();
+        border.setCenter(player.getLocation());
+        border.setSize(1); // Very small to force the vignette overlay
+        player.setWorldBorder(border);
+
+        // Remove the border after 5 seconds (100 ticks)
+        Bukkit.getScheduler().runTaskLater(plugin, () -> player.setWorldBorder(null), 100L);
+        player.sendMessage(ChatColor.GRAY + "You feel the world closing in around you...");
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -261,3 +261,8 @@ commands:
     description: View your nutrition levels
     usage: /nutrients
     default: true
+
+  redvignette:
+    description: Gives you a brief red world-border vignette
+    usage: /redvignette
+    default: true


### PR DESCRIPTION
## Summary
- add `/redvignette` command implementation
- register new command in plugin.yml
- hook command in plugin startup

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688431dbd8e083328a3392ba520d8b97