### PR TITLE
Buff spiders and zombies

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatSubsystemManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatSubsystemManager.java
@@ -9,6 +9,7 @@ import goat.minecraft.minecraftnew.subsystems.combat.damage.strategies.PowerCata
 import goat.minecraft.minecraftnew.subsystems.combat.damage.strategies.RangedDamageStrategy;
 import goat.minecraft.minecraftnew.subsystems.combat.damage.strategies.CorpseLevelDamageStrategy;
 import goat.minecraft.minecraftnew.subsystems.combat.damage.strategies.SwordTalentDamageStrategy;
+import goat.minecraft.minecraftnew.subsystems.combat.damage.strategies.SpiderDamageStrategy;
 import goat.minecraft.minecraftnew.subsystems.combat.commands.CombatReloadCommand;
 import goat.minecraft.minecraftnew.subsystems.combat.hostility.HostilityGUIController;
 import goat.minecraft.minecraftnew.subsystems.combat.hostility.HostilityService;
@@ -249,6 +250,7 @@ public class CombatSubsystemManager implements CommandExecutor {
                 new MonsterLevelDamageStrategy(configuration.getDamageConfig()));
             damageCalculationService.registerStrategy(
                 new CorpseLevelDamageStrategy(configuration.getDamageConfig()));
+            damageCalculationService.registerStrategy(new SpiderDamageStrategy());
         }
         
         // Register catalyst damage strategies (always enabled)

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/KillMonster.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/KillMonster.java
@@ -116,21 +116,17 @@ public class KillMonster implements Listener {
                 } else {
                     allowNormalDrops = random.nextInt(100) < 20;
                 }
-                if (!allowNormalDrops && entity instanceof Zombie zombie) {
-                    ItemStack main = zombie.getEquipment().getItemInMainHand();
-                    if (main != null && main.getType() != Material.AIR && !main.getType().name().endsWith("_SWORD")) {
-                        zombie.getWorld().dropItemNaturally(zombie.getLocation(), main.clone());
-                    }
-                    ItemStack off = zombie.getEquipment().getItemInOffHand();
-                    if (off != null && off.getType() != Material.AIR && !off.getType().name().endsWith("_SWORD")) {
-                        zombie.getWorld().dropItemNaturally(zombie.getLocation(), off.clone());
-                    }
-                }
                 if (allowNormalDrops) {
-                    return; // Allow normal drops
-                } else {
-                    e.getDrops().clear();
+                    // Remove vanilla weapon drops
+                    e.getDrops().removeIf(item ->
+                            item.getType() == Material.IRON_SHOVEL ||
+                            item.getType() == Material.IRON_SWORD ||
+                            item.getType() == Material.BOW);
+                    return; // Allow other normal drops
                 }
+
+                // No normal drops allowed
+                e.getDrops().clear();
             }
         }
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SpawnMonsters.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/SpawnMonsters.java
@@ -276,9 +276,15 @@ public class SpawnMonsters implements Listener {
 
     //weapon mutation
     public void equipRandomWeapon(LivingEntity entity) {
+        EntityEquipment equipment = entity.getEquipment();
+        if (entity instanceof Zombie) {
+            // Zombies always wield an iron sword
+            equipment.setItemInMainHand(new ItemStack(Material.IRON_SWORD));
+            return;
+        }
+
         Random random = new Random();
         Material weaponMaterial = random.nextBoolean() ? Material.IRON_SWORD : Material.IRON_SHOVEL;
-        EntityEquipment equipment = entity.getEquipment();
         equipment.setItemInMainHand(new ItemStack(weaponMaterial));
     }
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/damage/strategies/SpiderDamageStrategy.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/damage/strategies/SpiderDamageStrategy.java
@@ -1,0 +1,49 @@
+package goat.minecraft.minecraftnew.subsystems.combat.damage.strategies;
+
+import goat.minecraft.minecraftnew.subsystems.combat.damage.DamageCalculationContext;
+import goat.minecraft.minecraftnew.subsystems.combat.damage.DamageCalculationResult;
+import goat.minecraft.minecraftnew.subsystems.combat.damage.DamageCalculationStrategy;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+
+/**
+ * Simple damage multiplier for spiders to keep them competitive
+ * with skeletons in raw damage output.
+ */
+public class SpiderDamageStrategy implements DamageCalculationStrategy {
+
+    private static final double MULTIPLIER = 1.5; // +50% damage
+
+    @Override
+    public DamageCalculationResult calculateDamage(DamageCalculationContext context) {
+        if (!isApplicable(context)) {
+            return DamageCalculationResult.noChange(context.getBaseDamage());
+        }
+        double original = context.getBaseDamage();
+        double finalDamage = original * MULTIPLIER;
+        return DamageCalculationResult.withModifier(original, finalDamage,
+                DamageCalculationResult.DamageModifier.multiplicative(
+                        "Spider Damage Buff", MULTIPLIER, "+50% Damage"));
+    }
+
+    @Override
+    public boolean isApplicable(DamageCalculationContext context) {
+        Entity attacker = context.getAttacker();
+        if (!(context.getTarget() instanceof Player)) return false;
+        if (!(attacker instanceof LivingEntity)) return false;
+        EntityType type = attacker.getType();
+        return type == EntityType.SPIDER || type == EntityType.CAVE_SPIDER;
+    }
+
+    @Override
+    public int getPriority() {
+        return 65; // after monster level scaling
+    }
+
+    @Override
+    public String getName() {
+        return "Spider Damage Buff";
+    }
+}


### PR DESCRIPTION
## Summary
- adjust zombie weapon spawn to always use iron swords
- prevent iron sword/shovel/bow drops
- boost spider melee damage via new strategy
- register the new damage strategy

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688441895fc88332bd6eb36d68827bd9