### PR TITLE
Add Crop Count tracking and update farming system

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/CropCountManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/CropCountManager.java
@@ -1,0 +1,155 @@
+package goat.minecraft.minecraftnew.subsystems.farming;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
+import goat.minecraft.minecraftnew.subsystems.pets.PetRegistry;
+import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
+import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.Sound;
+
+import java.io.File;
+import java.io.IOException;
+
+public class CropCountManager {
+    private static CropCountManager instance;
+    private final JavaPlugin plugin;
+    private final File file;
+    private YamlConfiguration config;
+    private final XPManager xpManager;
+
+    private CropCountManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.file = new File(plugin.getDataFolder(), "cropCount.yml");
+        if (!file.exists()) {
+            try { file.createNewFile(); } catch (IOException ignored) {}
+        }
+        this.config = YamlConfiguration.loadConfiguration(file);
+        this.xpManager = new XPManager(plugin);
+    }
+
+    public static CropCountManager getInstance(JavaPlugin plugin) {
+        if (instance == null) {
+            instance = new CropCountManager(plugin);
+        }
+        return instance;
+    }
+
+    private void save() {
+        try {
+            config.save(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private String key(Material mat) {
+        switch (mat) {
+            case WHEAT: return "wheat";
+            case CARROTS: return "carrots";
+            case POTATOES: return "potatoes";
+            case BEETROOTS: return "beetroots";
+            case PUMPKIN: return "pumpkins";
+            case MELON: return "melons";
+            case COCOA: return "cocoa";
+            default: return null;
+        }
+    }
+
+    public void increment(Player player, Material crop) {
+        String k = key(crop);
+        if (k == null) return;
+        String uuid = player.getUniqueId().toString();
+        int c = config.getInt(uuid + "." + k, 0) + 1;
+        config.set(uuid + "." + k, c);
+        int total = config.getInt(uuid + ".cropsHarvested", 0) + 1;
+        config.set(uuid + ".cropsHarvested", total);
+        save();
+        handleRewards(player, crop, c, total);
+    }
+
+    private void handleRewards(Player player, Material crop, int cropCount, int total) {
+        checkPetThresholds(player, total);
+        if (cropCount % 500 == 0) {
+            switch (crop) {
+                case WHEAT:
+                    player.getInventory().addItem(ItemRegistry.getWheatSeeder());
+                    break;
+                case CARROTS:
+                    player.getInventory().addItem(ItemRegistry.getCarrotSeeder());
+                    break;
+                case POTATOES:
+                    player.getInventory().addItem(ItemRegistry.getPotatoSeeder());
+                    break;
+                case BEETROOTS:
+                    player.getInventory().addItem(ItemRegistry.getBeetrootSeeder());
+                    break;
+                case PUMPKIN:
+                    player.getInventory().addItem(ItemRegistry.getJackOLantern());
+                    break;
+                case MELON:
+                    player.getInventory().addItem(ItemRegistry.getWatermelon());
+                    break;
+                default:
+                    break;
+            }
+            xpManager.addXP(player, "Farming", 100);
+            player.playSound(player.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1.0f, 1.0f);
+        }
+    }
+
+    public void checkPetThresholds(Player player) {
+        int total = config.getInt(player.getUniqueId().toString() + ".cropsHarvested", 0);
+        checkPetThresholds(player, total);
+    }
+
+    private void checkPetThresholds(Player player, int total) {
+        String uuid = player.getUniqueId().toString();
+        if (total >= 4860 && !config.getBoolean(uuid + ".legendary", false)) {
+            grantPet(player, PetManager.Rarity.LEGENDARY);
+            config.set(uuid + ".legendary", true);
+        } else if (total >= 1620 && !config.getBoolean(uuid + ".epic", false)) {
+            grantPet(player, PetManager.Rarity.EPIC);
+            config.set(uuid + ".epic", true);
+        } else if (total >= 540 && !config.getBoolean(uuid + ".rare", false)) {
+            grantPet(player, PetManager.Rarity.RARE);
+            config.set(uuid + ".rare", true);
+        } else if (total >= 180 && !config.getBoolean(uuid + ".uncommon", false)) {
+            grantPet(player, PetManager.Rarity.UNCOMMON);
+            config.set(uuid + ".uncommon", true);
+        } else if (total >= 60 && !config.getBoolean(uuid + ".common", false)) {
+            grantPet(player, PetManager.Rarity.COMMON);
+            config.set(uuid + ".common", true);
+        } else {
+            return;
+        }
+        save();
+    }
+
+    private void grantPet(Player player, PetManager.Rarity rarity) {
+        PetRegistry petRegistry = new PetRegistry();
+        switch (rarity) {
+            case COMMON:
+                petRegistry.addPetByName(player, "Squirrel");
+                break;
+            case UNCOMMON:
+                petRegistry.addPetByName(player, "Sheep");
+                break;
+            case RARE:
+                petRegistry.addPetByName(player, "Cow");
+                break;
+            case EPIC:
+                petRegistry.addPetByName(player, "Mooshroom");
+                break;
+            case LEGENDARY:
+                petRegistry.addPetByName(player, "Pig");
+                break;
+            default:
+                break;
+        }
+        player.playSound(player.getLocation(), Sound.ENTITY_FIREWORK_ROCKET_LAUNCH, 1.0f, 1.0f);
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/AutoComposter.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/AutoComposter.java
@@ -129,15 +129,15 @@ public class AutoComposter {
         // 4) For each eligible crop, see how many conversions we can do
         for (Material crop : AUTO_COMPOSTER_ELIGIBLE_CROPS) {
             int playerCropCount = playerCropCounts.getOrDefault(crop, 0);
+            int weight = (crop == Material.PUMPKIN || crop == Material.MELON) ? 8 : 1;
 
-            if (playerCropCount >= requiredMaterialsOrganic) {
-                // Number of times we can convert to organic soil
-                int conversions = playerCropCount / requiredMaterialsOrganic;
+            int effective = playerCropCount * weight;
+            if (effective >= requiredMaterialsOrganic) {
+                int conversions = effective / requiredMaterialsOrganic;
+                int effectiveUsed = conversions * requiredMaterialsOrganic;
+                int itemsToRemove = (int) Math.ceil(effectiveUsed / (double) weight);
 
-                // Remove the used crops
-                subtractCrops(player, crop, requiredMaterialsOrganic * conversions);
-
-                // Give player the organic soil
+                subtractCrops(player, crop, itemsToRemove);
                 addOrganicSoil(player, conversions);
             }
         }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -620,10 +620,8 @@ public class VillagerTradeManager implements Listener {
         farmerPurchases.add(createTradeMap("MELON_SEEDS", 3, 32, 2)); // Level 2 trade
         farmerPurchases.add(createTradeMap("FARMER_ENCHANT", 1, 64, 2)); // Custom item
         farmerPurchases.add(createTradeMap("CAKE", 1, 8, 3)); // Level 3 trade
-        farmerPurchases.add(createTradeMap("WHEAT_SEEDER", 1, 64, 3)); // Custom item
-        farmerPurchases.add(createTradeMap("BEETROOT_SEEDER", 1, 64, 3)); // Custom item
-        farmerPurchases.add(createTradeMap("CARROT_SEEDER", 1, 64, 3)); // Custom item
-        farmerPurchases.add(createTradeMap("POTATO_SEEDER", 1, 64, 3)); // Custom item
+        // Seeder items now obtained via farming milestones
+        farmerPurchases.add(createTradeMap("JACK_O_LANTERN", 1, 3, 3));
         farmerPurchases.add(createTradeMap("MILK_BUCKET", 5, 15, 3)); // Level 3 trade
         farmerPurchases.add(createTradeMap("EGG", 12, 12, 3)); // Level 3 trade
         farmerPurchases.add(createTradeMap("GOLDEN_CARROT", 4, 3, 4)); // Level 4 trade
@@ -723,16 +721,8 @@ public class VillagerTradeManager implements Listener {
                 return ItemRegistry.getLoyaltyContract();
             case "BAIT":
                 return ItemRegistry.getBait();
-            case "WHEAT_SEEDER":
-                return ItemRegistry.getWheatSeeder();
-            case "BEETROOT_SEEDER":
-                return ItemRegistry.getBeetrootSeeder();
-            case "CARROT_SEEDER":
-                return ItemRegistry.getCarrotSeeder();
             case "COMPACT_STONE":
                 return ItemRegistry.getCompactStone();
-            case "POTATO_SEEDER":
-                return ItemRegistry.getPotatoSeeder();
             case "SWIM_TRUNKS":
                 return ItemRegistry.getSwiftSneak();
             case "FARMER_ENCHANT":

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -4531,6 +4531,36 @@ public class ItemRegistry {
                 ChatColor.DARK_PURPLE + "Smithing Item"
         ), 1, false, true);
     }
+
+    /** Smithing item that improves pumpkin harvests. */
+    public static ItemStack getJackOLantern() {
+        return createCustomItem(
+                Material.JACK_O_LANTERN,
+                ChatColor.YELLOW + "Jack o' Lantern",
+                Arrays.asList(
+                        ChatColor.GRAY + "Adds one level of Gourd.",
+                        ChatColor.DARK_PURPLE + "Smithing Item"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
+    /** Smithing item that improves melon harvests. */
+    public static ItemStack getWatermelon() {
+        return createCustomItem(
+                Material.MELON,
+                ChatColor.YELLOW + "Watermelon",
+                Arrays.asList(
+                        ChatColor.GRAY + "Adds one level of Clean Cut.",
+                        ChatColor.DARK_PURPLE + "Smithing Item"
+                ),
+                1,
+                false,
+                true
+        );
+    }
     /** Provides the Structure Block Charm for building assistance. */
     public static ItemStack getStructureBlockCharm() {
         StructureBlockManager manager = StructureBlockManager.getInstance();


### PR DESCRIPTION
## Summary
- add `CropCountManager` to persist harvest counts and manage rewards
- reward players every 500 crops with seeders or special smithing items
- grant farming pets based on crop count thresholds
- weight pumpkins and melons in AutoComposter to count as eight crops
- remove seeder drops and adjust farmer trades

## Testing
- `mvn -q -DskipTests package` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688458de81d883329c25a0a9f47415c1