### PR TITLE
Modify Fast Farmer ability

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/ignoreme
+++ b/src/main/java/goat/minecraft/minecraftnew/ignoreme
@@ -469,7 +469,7 @@ Common:
 Extra Crop Chance I: +8% per level, Max level 3
 For The Streets: +20% Chance to till a 9x9 area, Max level 5
 Reaper I: -1% Crop Count Requirement for Harvest Rewards, Max level 5
-Fast Farmer: +20% Movement Speed on Soil, Max level 5
+Fast Farmer: +20% Movement Speed when holding an Axe or Hoe, Max level 5
 Harvest Festival: +50% Chance to Gain +5s of Haste II when breaking Crops, Max level 2
 
 Uncommon:

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/FastFarmerBonus.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/FastFarmerBonus.java
@@ -40,8 +40,9 @@ public class FastFarmerBonus implements Listener {
     private void checkPlayer(Player player) {
         int level = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.FARMING, Talent.FAST_FARMER);
         UUID id = player.getUniqueId();
-        boolean onSoil = player.getLocation().getBlock().getType() == Material.FARMLAND;
-        if (level > 0 && onSoil) {
+        boolean holdingTool = isAxeOrHoe(player.getInventory().getItemInMainHand().getType()) ||
+                isAxeOrHoe(player.getInventory().getItemInOffHand().getType());
+        if (level > 0 && holdingTool) {
             baseSpeed.putIfAbsent(id, player.getWalkSpeed());
             float newSpeed = baseSpeed.get(id) * (1.0f + 0.20f * level);
             player.setWalkSpeed(Math.min(newSpeed, 1.0f));
@@ -49,6 +50,12 @@ public class FastFarmerBonus implements Listener {
             player.setWalkSpeed(baseSpeed.get(id));
             baseSpeed.remove(id);
         }
+    }
+
+    private boolean isAxeOrHoe(Material material) {
+        if (material == null || material == Material.AIR) return false;
+        String name = material.name();
+        return name.endsWith("_AXE") || name.endsWith("_HOE");
     }
 
     public void removeAll() {

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -568,8 +568,8 @@ public enum Talent {
     ),
     FAST_FARMER(
             "Fast Farmer",
-            ChatColor.GRAY + "Move faster on farmland",
-            ChatColor.YELLOW + "+(20*level)% " + ChatColor.GRAY + "Speed on soil",
+            ChatColor.GRAY + "Move faster when holding an axe or hoe",
+            ChatColor.YELLOW + "+(20*level)% " + ChatColor.GRAY + "Speed while holding tools",
             5,
             1,
             Material.LEATHER_BOOTS


### PR DESCRIPTION
## Summary
- trigger Fast Farmer when the player holds an axe or hoe
- update Fast Farmer talent description and docs

## Testing
- `mvn -q test` *(fails: Plugin resolution due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6884862317808332ad356baf15b63f78