### PR TITLE
Fix seeder BFS ordering

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/RightClickArtifacts.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/RightClickArtifacts.java
@@ -529,7 +529,9 @@ public class RightClickArtifacts implements Listener {
                     return;
                 }
 
-                // Gather FARMLAND blocks using BFS
+                // Gather FARMLAND blocks using BFS. We traverse through all
+                // connected farmland blocks but only record those without crops
+                // on top so we don't waste the limit on already-planted blocks.
                 Queue<Block> queue = new LinkedList<>();
                 Set<Block> visited = new HashSet<>();
                 List<Block> farmlandBlocks = new ArrayList<>();
@@ -539,7 +541,11 @@ public class RightClickArtifacts implements Listener {
 
                 while (!queue.isEmpty() && farmlandBlocks.size() < 256) {
                     Block current = queue.poll();
-                    farmlandBlocks.add(current);
+
+                    // Only add farmland that doesn't already have a crop
+                    if (current.getRelative(BlockFace.UP).getType() == Material.AIR) {
+                        farmlandBlocks.add(current);
+                    }
 
                     // Iterate over adjacent blocks (North, South, East, West)
                     for (BlockFace face : new BlockFace[]{BlockFace.NORTH, BlockFace.SOUTH, BlockFace.EAST, BlockFace.WEST}) {


### PR DESCRIPTION
## Summary
- only enqueue farmland without crops when planting
- keep traversing across all farmland so farthest empty farmland gets planted first

## Testing
- `mvn -q test` *(fails: Could not resolve maven-resources-plugin)*
- `mvn -q -DskipTests package` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6884868880248332948c5578c1c3ac2d