### PR TITLE
Add /i dev command

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -495,6 +495,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.other.qol.FastAscend(), this);
 
         this.getCommand("givecustomitem").setExecutor(new GiveCustomItem());
+        this.getCommand("i").setExecutor(new ItemCommand());
 
 
         getCommand("testskill").setExecutor(new TestSkillMessageCommand(xpManager));

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/ItemCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/ItemCommand.java
@@ -1,0 +1,74 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+/**
+ * Developer command that gives a custom item by name.
+ * Usage: /i <item name> [amount]
+ */
+public class ItemCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command!");
+            return true;
+        }
+
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You do not have permission to use this command!");
+            return true;
+        }
+
+        if (args.length < 1) {
+            player.sendMessage(ChatColor.RED + "Usage: /" + label + " <item_name> [amount]");
+            return true;
+        }
+
+        int amount = 1;
+        String itemName;
+
+        // If the last argument is a number, treat it as the amount
+        try {
+            if (args.length > 1) {
+                amount = Integer.parseInt(args[args.length - 1]);
+                if (amount <= 0) {
+                    player.sendMessage(ChatColor.RED + "Amount must be a positive number.");
+                    return true;
+                }
+                String[] nameParts = new String[args.length - 1];
+                System.arraycopy(args, 0, nameParts, 0, args.length - 1);
+                itemName = String.join("_", nameParts);
+            } else {
+                itemName = String.join("_", args);
+            }
+        } catch (NumberFormatException e) {
+            // Amount wasn't provided; treat all args as part of the name
+            itemName = String.join("_", args);
+            amount = 1;
+        }
+
+        ItemStack customItem = ItemRegistry.getItemByName(itemName);
+        if (customItem == null) {
+            player.sendMessage(ChatColor.RED + "Item not found: " + itemName.replace("_", " "));
+            return true;
+        }
+
+        customItem.setAmount(amount);
+        ItemMeta meta = customItem.getItemMeta();
+        player.getInventory().addItem(customItem);
+
+        if (meta != null) {
+            player.sendMessage(ChatColor.GREEN + "You have received: " + meta.getDisplayName()
+                    + ChatColor.GREEN + " (x" + amount + ")");
+        }
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -101,6 +101,10 @@ commands:
     description: Gives a predefined custom item to the player.
     usage: /givecustomitem <customitem>
     permission: givecustomitem.use
+  i:
+    description: Gives a predefined custom item to the player.
+    usage: /i <item_name> [amount]
+    permission: continuity.admin
   villager:
     description: Summon a villager with no AI
   xp:


### PR DESCRIPTION
## Summary
- implement `ItemCommand` for `/i` dev command with optional amount
- register `/i` in `MinecraftNew` plugin
- document new `/i` command in `plugin.yml`

## Testing
- `mvn -q -DskipTests package` *(fails: could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688531bd7fa08332b34237c213f95ede