### PR TITLE
Implement smithing talent overhaul and basic reforging

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -319,18 +319,70 @@ public class SkillTreeManager implements Listener {
             case VAMPIRIC_STRIKE:
                 double vampChance = level;
                 return ChatColor.YELLOW + "+" + vampChance + "% " + ChatColor.GRAY + "Soul Orb chance";
-            case REPAIR_ONE:
-                int repair1 = level * 1;
-                return ChatColor.GREEN + "+" + repair1 + ChatColor.GRAY + " Repair Amount";
-            case REPAIR_TWO:
-                int repair2 = level * 2;
-                return ChatColor.GREEN + "+" + repair2 + ChatColor.GRAY + " Repair Amount";
-            case REPAIR_THREE:
-                int repair3 = level * 3;
-                return ChatColor.GREEN + "+" + repair3 + ChatColor.GRAY + " Repair Amount";
-            case REPAIR_FOUR:
-                int repair4 = level * 4;
-                return ChatColor.GREEN + "+" + repair4 + ChatColor.GRAY + " Repair Amount";
+            case REPAIR_AMOUNT_I:
+                return ChatColor.GREEN + "+" + (level * 3) + ChatColor.GRAY + " Repair Amount";
+            case QUALITY_MATERIALS_I:
+                return ChatColor.GREEN + "+" + (level * 1) + ChatColor.GRAY + " Repair Quality";
+            case ALLOY_I:
+                return ChatColor.YELLOW + "+" + (level * 1.5) + "% Max Durability Chance";
+            case NOVICE_SMITH:
+                return ChatColor.YELLOW + "+" + (level * 25) + "% Common Reforge Chance";
+            case SCRAPS_I:
+                return ChatColor.YELLOW + "-" + (level * 3) + " Reforge Mats";
+            case NOVICE_FOUNDATIONS:
+                return ChatColor.YELLOW + "-" + (level * 25) + "% Anvil Degrade Chance";
+
+            case REPAIR_AMOUNT_II:
+                return ChatColor.GREEN + "+" + (level * 4) + ChatColor.GRAY + " Repair Amount";
+            case QUALITY_MATERIALS_II:
+                return ChatColor.GREEN + "+" + (level * 2) + ChatColor.GRAY + " Repair Quality";
+            case ALLOY_II:
+                return ChatColor.YELLOW + "+" + (level * 1.5) + "% Max Durability Chance";
+            case APPRENTICE_SMITH:
+                return ChatColor.YELLOW + "+" + (level * 25) + "% Uncommon Reforge Chance";
+            case SCRAPS_II:
+                return ChatColor.YELLOW + "-" + (level * 3) + " Reforge Mats";
+            case APPRENTICE_FOUNDATIONS:
+                return ChatColor.YELLOW + "-" + (level * 25) + "% Anvil Degrade Chance";
+
+            case REPAIR_AMOUNT_III:
+                return ChatColor.GREEN + "+" + (level * 5) + ChatColor.GRAY + " Repair Amount";
+            case QUALITY_MATERIALS_III:
+                return ChatColor.GREEN + "+" + (level * 3) + ChatColor.GRAY + " Repair Quality";
+            case ALLOY_III:
+                return ChatColor.YELLOW + "+" + (level * 1.5) + "% Max Durability Chance";
+            case JOURNEYMAN_SMITH:
+                return ChatColor.YELLOW + "+" + (level * 25) + "% Rare Reforge Chance";
+            case SCRAPS_III:
+                return ChatColor.YELLOW + "-" + (level * 3) + " Reforge Mats";
+            case JOURNEYMAN_FOUNDATIONS:
+                return ChatColor.YELLOW + "-" + (level * 25) + "% Anvil Degrade Chance";
+
+            case REPAIR_AMOUNT_IV:
+                return ChatColor.GREEN + "+" + (level * 6) + ChatColor.GRAY + " Repair Amount";
+            case QUALITY_MATERIALS_IV:
+                return ChatColor.GREEN + "+" + (level * 4) + ChatColor.GRAY + " Repair Quality";
+            case ALLOY_IV:
+                return ChatColor.YELLOW + "+" + (level * 1.5) + "% Max Durability Chance";
+            case EXPERT_SMITH:
+                return ChatColor.YELLOW + "+" + (level * 25) + "% Epic Reforge Chance";
+            case SCRAPS_IV:
+                return ChatColor.YELLOW + "-" + (level * 3) + " Reforge Mats";
+            case EXPERT_FOUNDATIONS:
+                return ChatColor.YELLOW + "-" + (level * 25) + "% Anvil Degrade Chance";
+
+            case REPAIR_AMOUNT_V:
+                return ChatColor.GREEN + "+" + (level * 7) + ChatColor.GRAY + " Repair Amount";
+            case QUALITY_MATERIALS_V:
+                return ChatColor.GREEN + "+" + (level * 5) + ChatColor.GRAY + " Repair Quality";
+            case ALLOY_V:
+                return ChatColor.YELLOW + "+" + (level * 0.5) + "% Max Durability Chance";
+            case MASTER_SMITH:
+                return ChatColor.YELLOW + "+" + (level * 25) + "% Legendary Reforge Chance";
+            case SCRAPS_V:
+                return ChatColor.YELLOW + "-" + (level * 3) + " Reforge Mats";
+            case MASTER_FOUNDATIONS:
+                return ChatColor.YELLOW + "-" + (level * 25) + "% Anvil Degrade Chance";
             case SATIATION_MASTERY:
                 return ChatColor.YELLOW + "+" + level + " " + ChatColor.GRAY + "Saturation on eat";
             case FEASTING_CHANCE:

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -361,38 +361,251 @@ public enum Talent {
             80,
             Material.CLOCK
     ),
-    REPAIR_ONE(
-            "Repair Mastery I",
+    // Smithing rework talents
+    REPAIR_AMOUNT_I(
+            "Repair Amount I",
             ChatColor.GRAY + "Improve basic repair techniques",
-            ChatColor.GREEN + "+(1*level) " + ChatColor.GRAY + "Repair Amount",
-            10,
+            ChatColor.GREEN + "+3 Repair Amount",
+            3,
             1,
             Material.ANVIL
     ),
-    REPAIR_TWO(
-            "Repair Mastery II",
-            ChatColor.GRAY + "Further hone repair skills",
-            ChatColor.GREEN + "+(2*level) " + ChatColor.GRAY + "Repair Amount",
-            10,
-            30,
+    QUALITY_MATERIALS_I(
+            "Quality Materials I",
+            ChatColor.GRAY + "Use better components",
+            ChatColor.GREEN + "+1 Repair Quality",
+            3,
+            1,
+            Material.IRON_INGOT
+    ),
+    ALLOY_I(
+            "Alloy I",
+            ChatColor.GRAY + "Chance to improve durability",
+            ChatColor.YELLOW + "+1.5% Chance for +1 Max Durability",
+            4,
+            1,
+            Material.COPPER_INGOT
+    ),
+    NOVICE_SMITH(
+            "Novice Smith",
+            ChatColor.GRAY + "Practice basic reforging",
+            ChatColor.YELLOW + "+25% Common Reforge Chance",
+            3,
+            1,
+            Material.STONE_PICKAXE
+    ),
+    SCRAPS_I(
+            "Scraps I",
+            ChatColor.GRAY + "Reuse leftover materials",
+            ChatColor.YELLOW + "-3 Reforge Mats",
+            3,
+            1,
+            Material.COBBLESTONE
+    ),
+    NOVICE_FOUNDATIONS(
+            "Novice Foundations",
+            ChatColor.GRAY + "Protect your anvil",
+            ChatColor.YELLOW + "-25% Anvil Degrade Chance",
+            4,
+            1,
+            Material.STONE_BRICKS
+    ),
+
+    REPAIR_AMOUNT_II(
+            "Repair Amount II",
+            ChatColor.GRAY + "Refine repair methods",
+            ChatColor.GREEN + "+4 Repair Amount",
+            3,
+            20,
             Material.ANVIL
     ),
-    REPAIR_THREE(
-            "Repair Mastery III",
-            ChatColor.GRAY + "Advanced repair expertise",
-            ChatColor.GREEN + "+(3*level) " + ChatColor.GRAY + "Repair Amount",
-            10,
-            50,
+    QUALITY_MATERIALS_II(
+            "Quality Materials II",
+            ChatColor.GRAY + "Stronger alloys",
+            ChatColor.GREEN + "+2 Repair Quality",
+            3,
+            20,
+            Material.IRON_BLOCK
+    ),
+    ALLOY_II(
+            "Alloy II",
+            ChatColor.GRAY + "Chance to add durability",
+            ChatColor.YELLOW + "+1.5% Chance for +2 Max Durability",
+            4,
+            20,
+            Material.GOLD_INGOT
+    ),
+    APPRENTICE_SMITH(
+            "Apprentice Smith",
+            ChatColor.GRAY + "Improved reforging",
+            ChatColor.YELLOW + "+25% Uncommon Reforge Chance",
+            3,
+            20,
+            Material.IRON_PICKAXE
+    ),
+    SCRAPS_II(
+            "Scraps II",
+            ChatColor.GRAY + "Reduce material waste",
+            ChatColor.YELLOW + "-3 Reforge Mats",
+            3,
+            20,
+            Material.IRON_NUGGET
+    ),
+    APPRENTICE_FOUNDATIONS(
+            "Apprentice Foundations",
+            ChatColor.GRAY + "Reinforce anvils",
+            ChatColor.YELLOW + "-25% Anvil Degrade Chance",
+            4,
+            20,
+            Material.IRON_BLOCK
+    ),
+
+    REPAIR_AMOUNT_III(
+            "Repair Amount III",
+            ChatColor.GRAY + "Skilled repair work",
+            ChatColor.GREEN + "+5 Repair Amount",
+            3,
+            40,
             Material.ANVIL
     ),
-    REPAIR_FOUR(
-            "Repair Mastery IV",
-            ChatColor.GRAY + "Masterful repair proficiency",
-            ChatColor.GREEN + "+(4*level) " + ChatColor.GRAY + "Repair Amount",
-            10,
-            70,
+    QUALITY_MATERIALS_III(
+            "Quality Materials III",
+            ChatColor.GRAY + "Expert material handling",
+            ChatColor.GREEN + "+3 Repair Quality",
+            3,
+            40,
+            Material.GOLD_INGOT
+    ),
+    ALLOY_III(
+            "Alloy III",
+            ChatColor.GRAY + "Superior alloys",
+            ChatColor.YELLOW + "+1.5% Chance for +3 Max Durability",
+            4,
+            40,
+            Material.GOLD_BLOCK
+    ),
+    JOURNEYMAN_SMITH(
+            "Journeyman Smith",
+            ChatColor.GRAY + "Reliable reforging",
+            ChatColor.YELLOW + "+25% Rare Reforge Chance",
+            3,
+            40,
+            Material.GOLDEN_PICKAXE
+    ),
+    SCRAPS_III(
+            "Scraps III",
+            ChatColor.GRAY + "Efficient recycling",
+            ChatColor.YELLOW + "-3 Reforge Mats",
+            3,
+            40,
+            Material.GOLD_NUGGET
+    ),
+    JOURNEYMAN_FOUNDATIONS(
+            "Journeyman Foundations",
+            ChatColor.GRAY + "Stabilise anvils",
+            ChatColor.YELLOW + "-25% Anvil Degrade Chance",
+            4,
+            40,
+            Material.GOLD_BLOCK
+    ),
+
+    REPAIR_AMOUNT_IV(
+            "Repair Amount IV",
+            ChatColor.GRAY + "Expert repair work",
+            ChatColor.GREEN + "+6 Repair Amount",
+            3,
+            60,
             Material.ANVIL
-      ),
+    ),
+    QUALITY_MATERIALS_IV(
+            "Quality Materials IV",
+            ChatColor.GRAY + "Masterwork materials",
+            ChatColor.GREEN + "+4 Repair Quality",
+            3,
+            60,
+            Material.DIAMOND
+    ),
+    ALLOY_IV(
+            "Alloy IV",
+            ChatColor.GRAY + "Rare alloys",
+            ChatColor.YELLOW + "+1.5% Chance for +4 Max Durability",
+            4,
+            60,
+            Material.AMETHYST_SHARD
+    ),
+    EXPERT_SMITH(
+            "Expert Smith",
+            ChatColor.GRAY + "Advanced reforging",
+            ChatColor.YELLOW + "+25% Epic Reforge Chance",
+            3,
+            60,
+            Material.DIAMOND_PICKAXE
+    ),
+    SCRAPS_IV(
+            "Scraps IV",
+            ChatColor.GRAY + "Minimal waste",
+            ChatColor.YELLOW + "-3 Reforge Mats",
+            3,
+            60,
+            Material.DIAMOND
+    ),
+    EXPERT_FOUNDATIONS(
+            "Expert Foundations",
+            ChatColor.GRAY + "Fortified anvils",
+            ChatColor.YELLOW + "-25% Anvil Degrade Chance",
+            4,
+            60,
+            Material.DIAMOND_BLOCK
+    ),
+
+    REPAIR_AMOUNT_V(
+            "Repair Amount V",
+            ChatColor.GRAY + "Legendary repair mastery",
+            ChatColor.GREEN + "+7 Repair Amount",
+            3,
+            80,
+            Material.NETHERITE_INGOT
+    ),
+    QUALITY_MATERIALS_V(
+            "Quality Materials V",
+            ChatColor.GRAY + "Flawless materials",
+            ChatColor.GREEN + "+5 Repair Quality",
+            4,
+            80,
+            Material.NETHERITE_BLOCK
+    ),
+    ALLOY_V(
+            "Alloy V",
+            ChatColor.GRAY + "Miraculous alloys",
+            ChatColor.YELLOW + "+0.5% Chance for +100 Max Durability",
+            3,
+            80,
+            Material.NETHERITE_SCRAP
+    ),
+    MASTER_SMITH(
+            "Master Smith",
+            ChatColor.GRAY + "Perfect reforging",
+            ChatColor.YELLOW + "+25% Legendary Reforge Chance",
+            3,
+            80,
+            Material.NETHERITE_PICKAXE
+    ),
+    SCRAPS_V(
+            "Scraps V",
+            ChatColor.GRAY + "Zero waste",
+            ChatColor.YELLOW + "-3 Reforge Mats",
+            3,
+            80,
+            Material.NETHERITE_SCRAP
+    ),
+    MASTER_FOUNDATIONS(
+            "Master Foundations",
+            ChatColor.GRAY + "Ultimate anvil care",
+            ChatColor.YELLOW + "-25% Anvil Degrade Chance",
+            4,
+            80,
+            Material.NETHERITE_BLOCK
+    ),
     SATIATION_MASTERY(
             "Satiation Mastery",
             ChatColor.GRAY + "Cooked meals keep you fuller",

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -69,12 +69,42 @@ public final class TalentRegistry {
         SKILL_TALENTS.put(
                 Skill.SMITHING,
                 Arrays.asList(
-                        Talent.REPAIR_ONE,
-                        Talent.REPAIR_TWO,
-                        Talent.REPAIR_THREE,
-                        Talent.REPAIR_FOUR
-                  )
-          );
+                        Talent.REPAIR_AMOUNT_I,
+                        Talent.QUALITY_MATERIALS_I,
+                        Talent.ALLOY_I,
+                        Talent.NOVICE_SMITH,
+                        Talent.SCRAPS_I,
+                        Talent.NOVICE_FOUNDATIONS,
+
+                        Talent.REPAIR_AMOUNT_II,
+                        Talent.QUALITY_MATERIALS_II,
+                        Talent.ALLOY_II,
+                        Talent.APPRENTICE_SMITH,
+                        Talent.SCRAPS_II,
+                        Talent.APPRENTICE_FOUNDATIONS,
+
+                        Talent.REPAIR_AMOUNT_III,
+                        Talent.QUALITY_MATERIALS_III,
+                        Talent.ALLOY_III,
+                        Talent.JOURNEYMAN_SMITH,
+                        Talent.SCRAPS_III,
+                        Talent.JOURNEYMAN_FOUNDATIONS,
+
+                        Talent.REPAIR_AMOUNT_IV,
+                        Talent.QUALITY_MATERIALS_IV,
+                        Talent.ALLOY_IV,
+                        Talent.EXPERT_SMITH,
+                        Talent.SCRAPS_IV,
+                        Talent.EXPERT_FOUNDATIONS,
+
+                        Talent.REPAIR_AMOUNT_V,
+                        Talent.QUALITY_MATERIALS_V,
+                        Talent.ALLOY_V,
+                        Talent.MASTER_SMITH,
+                        Talent.SCRAPS_V,
+                        Talent.MASTER_FOUNDATIONS
+                )
+        );
         SKILL_TALENTS.put(
                 Skill.CULINARY,
                 Arrays.asList(

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -210,17 +210,12 @@ public class VillagerTradeManager implements Listener {
         weaponsmithPurchases.add(createTradeMap("IRON_INGOT", 1, 4, 1));    // item, quantity, emeralds, level, experience
         weaponsmithPurchases.add(createTradeMap("COAL", 4, 2, 1));
 
-        weaponsmithPurchases.add(createTradeMap("UNCOMMON_SWORD_REFORGE", 1, 64, 2)); // ItemRegistry.getUncommonSwordReforge()
 
         weaponsmithPurchases.add(createTradeMap("BELL", 1, 63, 3));
-        weaponsmithPurchases.add(createTradeMap("WEAPONSMITH_REFORGE", 1, 64, 3)); // ItemRegistry.getWeaponsmithReforge()
-        weaponsmithPurchases.add(createTradeMap("WEAPONSMITH_REFORGE_TWO", 1, 128, 3)); // ItemRegistry.getWeaponsmithReforgeTwo()
 
-        weaponsmithPurchases.add(createTradeMap("RARE_SWORD_REFORGE", 1, 128, 3)); // ItemRegistry.getRareSwordReforge()
         weaponsmithPurchases.add(createTradeMap("WATER_ASPECT_ENCHANT", 1, 128, 3)); // ItemRegistry.getRareSwordReforge()
 
         weaponsmithPurchases.add(createTradeMap("WEAPONSMITH_SHARPNESS", 1, 64, 4)); // ItemRegistry.getWeaponsmithSharpness()
-        weaponsmithPurchases.add(createTradeMap("EPIC_SWORD_REFORGE", 1, 256, 4)); // ItemRegistry.getEpicSwordReforge()
 
         weaponsmithPurchases.add(createTradeMap("WEAPONSMITH_SWEEPING_EDGE", 1, 63, 4)); // ItemRegistry.getWeaponsmithSweepingEdge()
         weaponsmithPurchases.add(createTradeMap("WEAPONSMITH_LOOTING", 1, 64, 4)); // ItemRegistry.getWeaponsmithLooting()
@@ -229,7 +224,6 @@ public class VillagerTradeManager implements Listener {
         weaponsmithPurchases.add(createTradeMap("WEAPONSMITH_SMITE", 1, 64, 4)); // ItemRegistry.getWeaponsmithSmite()
         weaponsmithPurchases.add(createTradeMap("WEAPONSMITH_BANE_OF_ARTHROPODS", 1, 64, 4)); // ItemRegistry.getWeaponsmithBaneofAnthropods()
 
-        weaponsmithPurchases.add(createTradeMap("LEGENDARY_SWORD_REFORGE", 1, 512, 5)); // ItemRegistry.getLegendarySwordReforge()
         weaponsmithPurchases.add(createTradeMap("BLUE_LANTERN", 1, 512, 5)); // Custom Item
 
         defaultConfig.set("WEAPONSMITH.purchases", weaponsmithPurchases);
@@ -439,22 +433,16 @@ public class VillagerTradeManager implements Listener {
 
         toolsmithPurchases.add(createTradeMap("SHIELD", 1, 10, 2)); // Material
         toolsmithPurchases.add(createTradeMap("CAULDRON", 1, 5, 2)); // Material
-        toolsmithPurchases.add(createTradeMap("UNCOMMON_TOOL_REFORGE", 1, 8, 2)); // Custom Item
 
-        toolsmithPurchases.add(createTradeMap("TOOLSMITH_REFORGE", 1, 64, 3)); // Custom Item
-
-        toolsmithPurchases.add(createTradeMap("RARE_TOOL_REFORGE", 1, 16, 3)); // Custom Item
 
         toolsmithPurchases.add(createTradeMap("TOOLSMITH_EFFICIENCY", 1, 64, 4)); // Custom Item
         toolsmithPurchases.add(createTradeMap("TOOLSMITH_UNBREAKING", 1, 64, 4)); // Custom Item
-        toolsmithPurchases.add(createTradeMap("EPIC_TOOL_REFORGE", 1, 32, 4)); // Custom Item
 
         toolsmithPurchases.add(createTradeMap("ANCIENT_DEBRIS", 1, 64, 5)); // Material
         toolsmithPurchases.add(createTradeMap("TOOLSMITH_ENCHANT", 1, 64, 3)); // Custom Item
         toolsmithPurchases.add(createTradeMap("TOOLSMITH_ENCHANT_TWO", 1, 128, 3)); // Custom Item
         toolsmithPurchases.add(createTradeMap("LYNCH_ENCHANT", 1, 64, 4)); // Custom Item
         toolsmithPurchases.add(createTradeMap("UNBREAKABLE_SHEARS", 1, 128, 3)); // Custom Item
-        toolsmithPurchases.add(createTradeMap("LEGENDARY_TOOL_REFORGE", 1, 64, 5)); // Custom Item
         toolsmithPurchases.add(createTradeMap("POWER_CRYSTAL", 1, 512, 5)); // Custom Item
         toolsmithPurchases.add(createTradeMap("COMPOSTER_ENCHANT", 1, 32, 3)); // Custom Item
 
@@ -478,13 +466,10 @@ public class VillagerTradeManager implements Listener {
         armorerPurchases.add(createTradeMap("CONTINGENCY", 1, 64, 1)); // Custom Item
 
         armorerPurchases.add(createTradeMap("ANVIL", 1, 24, 2)); // Material
-        armorerPurchases.add(createTradeMap("UNCOMMON_ARMOR_REFORGE", 1, 16, 2)); // Custom Item
 
         armorerPurchases.add(createTradeMap("GOLD_ORE", 4, 6, 3)); // Material
-        armorerPurchases.add(createTradeMap("RARE_ARMOR_REFORGE", 1, 32, 3)); // Custom Item
 
         armorerPurchases.add(createTradeMap("NETHERITE_UPGRADE_SMITHING_TEMPLATE", 2, 32, 2)); // Material
-        armorerPurchases.add(createTradeMap("EPIC_ARMOR_REFORGE", 1, 64, 4)); // Custom Item
 
         armorerPurchases.add(createTradeMap("RANDOM_ARMOR_TRIM", 1, 64, 4)); // Custom Item
         armorerPurchases.add(createTradeMap("ARMOR_SMITH_PROTECTION", 1, 64, 4)); // Custom Item
@@ -494,9 +479,6 @@ public class VillagerTradeManager implements Listener {
         armorerPurchases.add(createTradeMap("ARMORER_ENCHANT", 1, 16, 4)); // Custom Item
         armorerPurchases.add(createTradeMap("BLESSING_ARTIFACT", 1, 64, 4)); // Custom Item
 
-        armorerPurchases.add(createTradeMap("LEGENDARY_ARMOR_REFORGE", 1, 128, 5)); // Custom Item
-        armorerPurchases.add(createTradeMap("ARMORSMITH_REFORGE", 1, 32, 5)); // Custom Item
-        armorerPurchases.add(createTradeMap("ARMORSMITH_REFORGE_TWO", 1, 64, 5)); // Custom Item
 
         armorerPurchases.add(createTradeMap("ANCIENT_DEBRIS", 1, 64, 5)); // Material
 
@@ -548,7 +530,6 @@ public class VillagerTradeManager implements Listener {
         fishermanPurchases.add(createTradeMap("LAPIS_LAZULI", 4, 8, 2)); // Material
         fishermanPurchases.add(createTradeMap("SHALLOW_SHELL", 1, 8, 2)); // Custom Item
         fishermanPurchases.add(createTradeMap("SHELL", 1, 12, 3)); // Custom Item
-        fishermanPurchases.add(createTradeMap("FISHERMAN_REFORGE", 1, 64, 3)); // Custom Item
         fishermanPurchases.add(createTradeMap("PEARL_OF_THE_DEEP", 1, 512, 3)); // Custom Item
         fishermanPurchases.add(createTradeMap("CAMPFIRE", 2, 12, 3)); // Material
         fishermanPurchases.add(createTradeMap("DEEP_SHELL", 1, 24, 4)); // Custom Item

--- a/src/main/java/goat/minecraft/minecraftnew/utils/stats/StatsCalculator.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/stats/StatsCalculator.java
@@ -313,20 +313,27 @@ public class StatsCalculator {
     public double getRepairAmount(Player player) {
         double amount = 25.0; // base
         if (SkillTreeManager.getInstance() != null) {
-            int l1 = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.REPAIR_ONE);
-            amount += l1 * 1;
-            int l2 = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.REPAIR_TWO);
-            amount += l2 * 2;
-            int l3 = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.REPAIR_THREE);
-            amount += l3 * 3;
-            int l4 = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.REPAIR_FOUR);
-            amount += l4 * 4;
+            SkillTreeManager mgr = SkillTreeManager.getInstance();
+            amount += mgr.getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.REPAIR_AMOUNT_I) * 3;
+            amount += mgr.getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.REPAIR_AMOUNT_II) * 4;
+            amount += mgr.getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.REPAIR_AMOUNT_III) * 5;
+            amount += mgr.getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.REPAIR_AMOUNT_IV) * 6;
+            amount += mgr.getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.REPAIR_AMOUNT_V) * 7;
         }
         return amount;
     }
 
-    /** Repair quality stat not yet implemented, returns zero. */
+    /** Repair quality from smithing talents. */
     public double getRepairQuality(Player player) {
-        return 0.0;
+        double quality = 0.0;
+        if (SkillTreeManager.getInstance() != null) {
+            SkillTreeManager mgr = SkillTreeManager.getInstance();
+            quality += mgr.getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.QUALITY_MATERIALS_I) * 1;
+            quality += mgr.getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.QUALITY_MATERIALS_II) * 2;
+            quality += mgr.getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.QUALITY_MATERIALS_III) * 3;
+            quality += mgr.getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.QUALITY_MATERIALS_IV) * 4;
+            quality += mgr.getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.QUALITY_MATERIALS_V) * 5;
+        }
+        return quality;
     }
 }


### PR DESCRIPTION
## Summary
- overhaul smithing talent tree and registry
- calculate repair amount and quality from new talents
- rework anvil GUI with Reforge button
- implement simple reforging attempt logic
- drop old reforge items from villager trades

## Testing
- `mvn -q test` *(fails: Plugin resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_6885ba58af088332b2f8fa09e508b49d