### PR TITLE
Refactor StatsCalculator to singleton and enhance stats GUI

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -63,6 +63,7 @@ import goat.minecraft.minecraftnew.utils.commands.StatsCommand;
 import goat.minecraft.minecraftnew.utils.commands.TogglePotionEffectsCommand;
 import goat.minecraft.minecraftnew.utils.developercommands.*;
 import goat.minecraft.minecraftnew.utils.developercommands.SetCustomDurabilityCommand;
+import goat.minecraft.minecraftnew.utils.stats.StatsCalculator;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
 import goat.minecraft.minecraftnew.utils.developercommands.AddTalentPointCommand;
 import goat.minecraft.minecraftnew.utils.devtools.*;
@@ -178,6 +179,8 @@ public class MinecraftNew extends JavaPlugin implements Listener {
     @Override
     public void onEnable() {
         instance = this;
+        // Initialize stats calculator singleton
+        StatsCalculator.getInstance(this);
         getServer().getPluginManager()
                 .registerEvents(new ResourcePackListener(), this);
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/FarmingEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/FarmingEvent.java
@@ -128,7 +128,7 @@ public class FarmingEvent implements Listener {
                 CropCountManager.getInstance(plugin).increment(player, blockType);
             }
 
-            StatsCalculator calc = new StatsCalculator(plugin);
+            StatsCalculator calc = StatsCalculator.getInstance(plugin);
             double chance = calc.getExtraCropChance(player);
             int extra = 0;
             while (chance >= 100.0) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
@@ -747,7 +747,7 @@ public class AnvilRepair implements Listener {
         }
         // Determine the type of repair material and set the repair amount accordingly
         if (billItem.getType() == Material.IRON_INGOT) {
-            StatsCalculator statsCalculator = new StatsCalculator(MinecraftNew.getInstance());
+            StatsCalculator statsCalculator = StatsCalculator.getInstance(MinecraftNew.getInstance());
             double quality = statsCalculator.getRepairQuality(player);
             double roll = quality;
             if (repairAmount > quality) {

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/StatsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/StatsCommand.java
@@ -29,7 +29,7 @@ public class StatsCommand implements CommandExecutor, Listener {
 
     public StatsCommand(JavaPlugin plugin) {
         this.plugin = plugin;
-        this.calculator = new StatsCalculator(plugin);
+        this.calculator = StatsCalculator.getInstance(plugin);
         Bukkit.getPluginManager().registerEvents(this, plugin);
     }
 
@@ -52,25 +52,43 @@ public class StatsCommand implements CommandExecutor, Listener {
     }
 
     private void openStatsGUI(Player player) {
-        Inventory inv = Bukkit.createInventory(null, 27, ChatColor.DARK_GREEN + "Player Stats");
+        Inventory inv = Bukkit.createInventory(null, 45, ChatColor.DARK_GREEN + "Player Stats");
 
-        addStatItem(inv, 0, Material.REDSTONE, "Health", String.format("%.1f", calculator.getHealth(player)));
-        addStatItem(inv, 1, Material.IRON_SWORD, "Damage +%", String.format("%.1f%%", calculator.getDamageIncrease(player)));
-        addStatItem(inv, 2, Material.BOW, "Arrow Damage +%", String.format("%.1f%%", calculator.getArrowDamageIncrease(player)));
-        addStatItem(inv, 3, Material.SHIELD, "Resistance", String.format("%.1f%%", calculator.getResistance(player)));
-        addStatItem(inv, 4, Material.ELYTRA, "Flight Distance", String.format("%.2f km", calculator.getFlightDistance(player)));
-        addStatItem(inv, 5, Material.SOUL_TORCH, "Grave Chance", String.format("%.3f%%", calculator.getGraveChance(player)));
-        addStatItem(inv, 6, Material.NAUTILUS_SHELL, "Sea Creature Chance", String.format("%.2f%%", calculator.getSeaCreatureChance(player)));
-        addStatItem(inv, 7, Material.CHEST, "Treasure Chance", String.format("%.2f%%", calculator.getTreasureChance(player)));
-        addStatItem(inv, 8, Material.SOUL_LANTERN, "Spirit Chance", String.format("%.2f%%", calculator.getSpiritChance(player)));
-        addStatItem(inv, 9, Material.EMERALD, "Discount", String.format("%.2f%%", calculator.getDiscount(player)));
-        addStatItem(inv, 10, Material.FEATHER, "Speed", String.format("%.1f%%", calculator.getSpeed(player)));
-        addStatItem(inv, 11, Material.POTION, "Brew Time Reduction", String.format("%.1f%%", calculator.getBrewTimeReduction(player)));
-        addStatItem(inv, 12, Material.DIAMOND_ORE, "Double Ore Chance", String.format("%.1f%%", calculator.getDoubleOreChance(player)));
-        addStatItem(inv, 13, Material.OAK_LOG, "Double Log Chance", String.format("%.1f%%", calculator.getDoubleLogChance(player)));
-        addStatItem(inv, 14, Material.WHEAT, "Double Crop Chance", String.format("%.1f%%", calculator.getDoubleCropChance(player)));
-        addStatItem(inv, 15, Material.ANVIL, "Repair Amount", String.format("%.1f", calculator.getRepairAmount(player)));
-        addStatItem(inv, 16, Material.ENCHANTED_BOOK, "Repair Quality", String.format("%.1f", calculator.getRepairQuality(player)));
+        ItemStack filler = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
+        ItemMeta fmeta = filler.getItemMeta();
+        if (fmeta != null) {
+            fmeta.setDisplayName(" ");
+            filler.setItemMeta(fmeta);
+        }
+
+        for (int i = 0; i < 9; i++) {
+            inv.setItem(i, filler);
+            inv.setItem(36 + i, filler);
+        }
+        for (int r = 1; r < 4; r++) {
+            inv.setItem(r * 9, filler);
+            inv.setItem(r * 9 + 8, filler);
+        }
+
+        int[] slots = {10,11,12,13,14,15,16,19,20,21,22,23,24,25,28,29,30,31,32,33,34};
+        int index = 0;
+        addStatItem(inv, slots[index++], Material.REDSTONE, "Health", String.format("%.1f", calculator.getHealth(player)));
+        addStatItem(inv, slots[index++], Material.IRON_SWORD, "Damage +%", String.format("%.1f%%", calculator.getDamageIncrease(player)));
+        addStatItem(inv, slots[index++], Material.BOW, "Arrow Damage +%", String.format("%.1f%%", calculator.getArrowDamageIncrease(player)));
+        addStatItem(inv, slots[index++], Material.SHIELD, "Resistance", String.format("%.1f%%", calculator.getResistance(player)));
+        addStatItem(inv, slots[index++], Material.ELYTRA, "Flight Distance", String.format("%.2f km", calculator.getFlightDistance(player)));
+        addStatItem(inv, slots[index++], Material.SOUL_TORCH, "Grave Chance", String.format("%.3f%%", calculator.getGraveChance(player)));
+        addStatItem(inv, slots[index++], Material.NAUTILUS_SHELL, "Sea Creature Chance", String.format("%.2f%%", calculator.getSeaCreatureChance(player)));
+        addStatItem(inv, slots[index++], Material.CHEST, "Treasure Chance", String.format("%.2f%%", calculator.getTreasureChance(player)));
+        addStatItem(inv, slots[index++], Material.SOUL_LANTERN, "Spirit Chance", String.format("%.2f%%", calculator.getSpiritChance(player)));
+        addStatItem(inv, slots[index++], Material.EMERALD, "Discount", String.format("%.2f%%", calculator.getDiscount(player)));
+        addStatItem(inv, slots[index++], Material.FEATHER, "Speed", String.format("%.1f%%", calculator.getSpeed(player)));
+        addStatItem(inv, slots[index++], Material.POTION, "Brew Time Reduction", String.format("%.1f%%", calculator.getBrewTimeReduction(player)));
+        addStatItem(inv, slots[index++], Material.DIAMOND_ORE, "Double Ore Chance", String.format("%.1f%%", calculator.getDoubleOreChance(player)));
+        addStatItem(inv, slots[index++], Material.OAK_LOG, "Double Log Chance", String.format("%.1f%%", calculator.getDoubleLogChance(player)));
+        addStatItem(inv, slots[index++], Material.WHEAT, "Double Crop Chance", String.format("%.1f%%", calculator.getDoubleCropChance(player)));
+        addStatItem(inv, slots[index++], Material.ANVIL, "Repair Amount", String.format("%.1f", calculator.getRepairAmount(player)));
+        addStatItem(inv, slots[index++], Material.ENCHANTED_BOOK, "Repair Quality", String.format("%.1f", calculator.getRepairQuality(player)));
 
         player.openInventory(inv);
     }
@@ -82,6 +100,7 @@ public class StatsCommand implements CommandExecutor, Listener {
             meta.setDisplayName(ChatColor.GOLD + name);
             List<String> lore = new ArrayList<>();
             lore.add(ChatColor.YELLOW + value);
+            lore.add(ChatColor.DARK_GRAY + "Calculated via StatsCalculator");
             meta.setLore(lore);
             item.setItemMeta(meta);
         }

--- a/src/main/java/goat/minecraft/minecraftnew/utils/stats/StatsCalculator.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/stats/StatsCalculator.java
@@ -28,10 +28,33 @@ import org.bukkit.plugin.java.JavaPlugin;
  */
 public class StatsCalculator {
 
+    private static StatsCalculator instance;
     private final JavaPlugin plugin;
 
-    public StatsCalculator(JavaPlugin plugin) {
+    private StatsCalculator(JavaPlugin plugin) {
         this.plugin = plugin;
+    }
+
+    /**
+     * Initialize the calculator singleton.
+     * Subsequent calls simply return the existing instance.
+     */
+    public static synchronized StatsCalculator getInstance(JavaPlugin plugin) {
+        if (instance == null) {
+            instance = new StatsCalculator(plugin);
+        }
+        return instance;
+    }
+
+    /**
+     * Get the already initialised instance.
+     * @throws IllegalStateException if init has not yet been called
+     */
+    public static StatsCalculator getInstance() {
+        if (instance == null) {
+            throw new IllegalStateException("StatsCalculator not initialised");
+        }
+        return instance;
     }
 
     /** Calculate max health using HealthManager. */


### PR DESCRIPTION
## Summary
- convert `StatsCalculator` to a singleton
- initialise it in `MinecraftNew`
- use the singleton from farming and smithing systems
- overhaul the `/stats` GUI with borders and more info
- show calculated method in item lore

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6885c528cd788332a085262f77ad29b9