### PR TITLE
Implement smithing foundations anvil protection

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
@@ -1710,15 +1710,34 @@ public class AnvilRepair implements Listener {
         }
 
         double chance = 0.0;
+        double degradeChance = 100.0; // chance for the anvil to take damage
         if (mgr != null) {
             UUID uid = player.getUniqueId();
             switch (next) {
-                case TIER_1 -> chance += mgr.getTalentLevel(uid, Skill.SMITHING, Talent.NOVICE_SMITH) * 25;
-                case TIER_2 -> chance += mgr.getTalentLevel(uid, Skill.SMITHING, Talent.APPRENTICE_SMITH) * 25;
-                case TIER_3 -> chance += mgr.getTalentLevel(uid, Skill.SMITHING, Talent.JOURNEYMAN_SMITH) * 25;
-                case TIER_4 -> chance += mgr.getTalentLevel(uid, Skill.SMITHING, Talent.EXPERT_SMITH) * 25;
-                case TIER_5 -> chance += mgr.getTalentLevel(uid, Skill.SMITHING, Talent.MASTER_SMITH) * 25;
+                case TIER_1 -> {
+                    chance += mgr.getTalentLevel(uid, Skill.SMITHING, Talent.NOVICE_SMITH) * 25;
+                    degradeChance -= mgr.getTalentLevel(uid, Skill.SMITHING, Talent.NOVICE_FOUNDATIONS) * 25;
+                }
+                case TIER_2 -> {
+                    chance += mgr.getTalentLevel(uid, Skill.SMITHING, Talent.APPRENTICE_SMITH) * 25;
+                    degradeChance -= mgr.getTalentLevel(uid, Skill.SMITHING, Talent.APPRENTICE_FOUNDATIONS) * 25;
+                }
+                case TIER_3 -> {
+                    chance += mgr.getTalentLevel(uid, Skill.SMITHING, Talent.JOURNEYMAN_SMITH) * 25;
+                    degradeChance -= mgr.getTalentLevel(uid, Skill.SMITHING, Talent.JOURNEYMAN_FOUNDATIONS) * 25;
+                }
+                case TIER_4 -> {
+                    chance += mgr.getTalentLevel(uid, Skill.SMITHING, Talent.EXPERT_SMITH) * 25;
+                    degradeChance -= mgr.getTalentLevel(uid, Skill.SMITHING, Talent.EXPERT_FOUNDATIONS) * 25;
+                }
+                case TIER_5 -> {
+                    chance += mgr.getTalentLevel(uid, Skill.SMITHING, Talent.MASTER_SMITH) * 25;
+                    degradeChance -= mgr.getTalentLevel(uid, Skill.SMITHING, Talent.MASTER_FOUNDATIONS) * 25;
+                }
             }
+        }
+        if (degradeChance < 0) {
+            degradeChance = 0;
         }
 
         mats.setAmount(mats.getAmount() - matsCount);
@@ -1731,7 +1750,7 @@ public class AnvilRepair implements Listener {
             int maxD = CustomDurabilityManager.getInstance().getMaxDurability(item);
             CustomDurabilityManager.getInstance().applyDamage(player, item, maxD / 2);
             Block anvilBlock = getNearestAnvil(player, 5);
-            if (anvilBlock != null) {
+            if (anvilBlock != null && Math.random() * 100 < degradeChance) {
                 switch (anvilBlock.getType()) {
                     case ANVIL -> anvilBlock.setType(Material.CHIPPED_ANVIL);
                     case CHIPPED_ANVIL -> anvilBlock.setType(Material.DAMAGED_ANVIL);


### PR DESCRIPTION
## Summary
- use Foundations talents to reduce anvil damage chance on failed reforges
- only degrade the anvil when a random check meets the remaining chance

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6885c5f309088332a502b911745d42e8