### PR TITLE
Add failure feedback for reforge

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
@@ -1876,6 +1876,10 @@ public class AnvilRepair implements Listener {
         } else {
             int maxD = CustomDurabilityManager.getInstance().getMaxDurability(item);
             CustomDurabilityManager.getInstance().applyDamage(player, item, maxD / 2);
+            // Provide feedback for the failed reforge attempt
+            player.playSound(player.getLocation(), Sound.ENTITY_ITEM_BREAK, 1.0f, 1.0f);
+            player.getWorld().spawnParticle(Particle.SMOKE, player.getLocation().add(0, 1, 0),
+                    20, 0.5, 0.5, 0.5, 0.05);
             Block anvilBlock = getNearestAnvil(player, 5);
             if (anvilBlock != null && Math.random() * 100 < degradeChance) {
                 switch (anvilBlock.getType()) {


### PR DESCRIPTION
## Summary
- add broken item sound and smoke particles when a reforge attempt fails

## Testing
- `mvn -q test` *(fails: Could not resolve Maven plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6885cb8557cc8332ac59215f180e4def