### PR TITLE
Add new Culinary talents

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -383,6 +383,50 @@ public class SkillTreeManager implements Listener {
                 return ChatColor.YELLOW + "-" + (level * 3) + " Reforge Mats";
             case MASTER_FOUNDATIONS:
                 return ChatColor.YELLOW + "-" + (level * 25) + "% Anvil Degrade Chance";
+            case SATIATION_MASTERY_I:
+            case SATIATION_MASTERY_II:
+            case SATIATION_MASTERY_III:
+            case SATIATION_MASTERY_IV:
+            case SATIATION_MASTERY_V:
+                return ChatColor.YELLOW + "+" + level + " Bonus Saturation";
+            case CUTTING_BOARD_I:
+            case CUTTING_BOARD_II:
+            case CUTTING_BOARD_III:
+            case CUTTING_BOARD_IV:
+            case CUTTING_BOARD_V:
+                double cutChance = level * 4;
+                return ChatColor.YELLOW + "+" + cutChance + "% Chance For Double Culinary Yield";
+            case LUNCH_RUSH_I:
+            case LUNCH_RUSH_II:
+            case LUNCH_RUSH_III:
+            case LUNCH_RUSH_IV:
+            case LUNCH_RUSH_V:
+                double rushReduce = level * 4;
+                return ChatColor.YELLOW + "-" + rushReduce + "% Cook time";
+            case SWEET_TOOTH:
+                double fruitBonus = level * 10;
+                return ChatColor.YELLOW + "+" + fruitBonus + "% Fruits Gains";
+            case GOLDEN_APPLE:
+                int regen = level * 3;
+                return ChatColor.YELLOW + "+" + regen + "s Regeneration I when eating";
+            case GRAINS_GAINS:
+                double grainBonus = level * 10;
+                return ChatColor.YELLOW + "+" + grainBonus + "% Grains Gains";
+            case PORTAL_PANTRY:
+                double pantryChance = level * 20;
+                return ChatColor.YELLOW + "+" + pantryChance + "% Chance to automatically grab ingredient";
+            case AXE_BODY_SPRAY:
+                double proteinBonus = level * 10;
+                return ChatColor.YELLOW + "+" + proteinBonus + "% Protein Gains";
+            case I_DO_NOT_NEED_A_SNACK:
+                double refundChance = level * 5;
+                return ChatColor.YELLOW + "+" + refundChance + "% Chance to Refund eaten items";
+            case RABBIT:
+                double veggieBonus = level * 10;
+                return ChatColor.YELLOW + "+" + veggieBonus + "% Veggie Gains";
+            case PANTRY_OF_PLENTY:
+                double satChance = level * 4;
+                return ChatColor.YELLOW + "+" + satChance + "% Chance to gain 20 Saturation when eating Culinary Delights";
             case SATIATION_MASTERY:
                 return ChatColor.YELLOW + "+" + level + " " + ChatColor.GRAY + "Saturation on eat";
             case FEASTING_CHANCE:

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -606,6 +606,213 @@ public enum Talent {
             80,
             Material.NETHERITE_BLOCK
     ),
+    // =============================================================
+    // Culinary Talents
+    // =============================================================
+    SATIATION_MASTERY_I(
+            "Satiation Mastery I",
+            ChatColor.GRAY + "Cooked meals keep you fuller",
+            ChatColor.YELLOW + "+1 Bonus Saturation",
+            1,
+            1,
+            Material.COOKED_BEEF
+    ),
+    CUTTING_BOARD_I(
+            "Cutting Board I",
+            ChatColor.GRAY + "Hone your knife skills",
+            ChatColor.YELLOW + "+4% Chance For Double Culinary Yield",
+            5,
+            1,
+            Material.STONECUTTER
+    ),
+    LUNCH_RUSH_I(
+            "Lunch Rush I",
+            ChatColor.GRAY + "Serve dishes faster",
+            ChatColor.YELLOW + "-4% Cook time",
+            5,
+            1,
+            Material.FURNACE
+    ),
+    SWEET_TOOTH(
+            "Sweet Tooth",
+            ChatColor.GRAY + "Fruits taste even sweeter",
+            ChatColor.YELLOW + "+10% Fruits Gains",
+            4,
+            1,
+            Material.SWEET_BERRIES
+    ),
+    GOLDEN_APPLE(
+            "Golden Apple",
+            ChatColor.GRAY + "Healthy snacks for heroes",
+            ChatColor.YELLOW + "+3s Regeneration I when eating",
+            5,
+            1,
+            Material.GOLDEN_APPLE
+    ),
+
+    SATIATION_MASTERY_II(
+            "Satiation Mastery II",
+            ChatColor.GRAY + "Cooked meals keep you fuller",
+            ChatColor.YELLOW + "+1 Bonus Saturation",
+            1,
+            20,
+            Material.COOKED_BEEF
+    ),
+    CUTTING_BOARD_II(
+            "Cutting Board II",
+            ChatColor.GRAY + "Hone your knife skills",
+            ChatColor.YELLOW + "+4% Chance For Double Culinary Yield",
+            5,
+            20,
+            Material.STONECUTTER
+    ),
+    LUNCH_RUSH_II(
+            "Lunch Rush II",
+            ChatColor.GRAY + "Serve dishes faster",
+            ChatColor.YELLOW + "-4% Cook time",
+            5,
+            20,
+            Material.FURNACE
+    ),
+    GRAINS_GAINS(
+            "Grains Gains",
+            ChatColor.GRAY + "Breads fill your belly",
+            ChatColor.YELLOW + "+10% Grains Gains",
+            4,
+            20,
+            Material.BREAD
+    ),
+    PORTAL_PANTRY(
+            "Portal Pantry",
+            ChatColor.GRAY + "Grab ingredients from afar",
+            ChatColor.YELLOW + "+20% Chance to automatically grab ingredient",
+            5,
+            20,
+            Material.ENDER_CHEST
+    ),
+
+    SATIATION_MASTERY_III(
+            "Satiation Mastery III",
+            ChatColor.GRAY + "Cooked meals keep you fuller",
+            ChatColor.YELLOW + "+1 Bonus Saturation",
+            1,
+            40,
+            Material.COOKED_BEEF
+    ),
+    CUTTING_BOARD_III(
+            "Cutting Board III",
+            ChatColor.GRAY + "Hone your knife skills",
+            ChatColor.YELLOW + "+4% Chance For Double Culinary Yield",
+            5,
+            40,
+            Material.STONECUTTER
+    ),
+    LUNCH_RUSH_III(
+            "Lunch Rush III",
+            ChatColor.GRAY + "Serve dishes faster",
+            ChatColor.YELLOW + "-4% Cook time",
+            5,
+            40,
+            Material.FURNACE
+    ),
+    AXE_BODY_SPRAY(
+            "Axe Body Spray",
+            ChatColor.GRAY + "Protein-packed musk",
+            ChatColor.YELLOW + "+10% Protein Gains",
+            4,
+            40,
+            Material.IRON_AXE
+    ),
+    I_DO_NOT_NEED_A_SNACK(
+            "I Do Not Need A Snack",
+            ChatColor.GRAY + "Save your provisions",
+            ChatColor.YELLOW + "+5% Chance to Refund eaten items",
+            5,
+            40,
+            Material.BOWL
+    ),
+
+    SATIATION_MASTERY_IV(
+            "Satiation Mastery IV",
+            ChatColor.GRAY + "Cooked meals keep you fuller",
+            ChatColor.YELLOW + "+1 Bonus Saturation",
+            1,
+            60,
+            Material.COOKED_BEEF
+    ),
+    CUTTING_BOARD_IV(
+            "Cutting Board IV",
+            ChatColor.GRAY + "Hone your knife skills",
+            ChatColor.YELLOW + "+4% Chance For Double Culinary Yield",
+            5,
+            60,
+            Material.STONECUTTER
+    ),
+    LUNCH_RUSH_IV(
+            "Lunch Rush IV",
+            ChatColor.GRAY + "Serve dishes faster",
+            ChatColor.YELLOW + "-4% Cook time",
+            5,
+            60,
+            Material.FURNACE
+    ),
+    RABBIT(
+            "Rabbit",
+            ChatColor.GRAY + "Veggies fuel your bounce",
+            ChatColor.YELLOW + "+10% Veggie Gains",
+            4,
+            60,
+            Material.CARROT
+    ),
+    PANTRY_OF_PLENTY(
+            "Pantry of Plenty",
+            ChatColor.GRAY + "Stocked for any feast",
+            ChatColor.YELLOW + "+4% Chance to gain 20 Saturation when eating Culinary Delights",
+            5,
+            60,
+            Material.CHEST
+    ),
+
+    SATIATION_MASTERY_V(
+            "Satiation Mastery V",
+            ChatColor.GRAY + "Cooked meals keep you fuller",
+            ChatColor.YELLOW + "+1 Bonus Saturation",
+            1,
+            80,
+            Material.COOKED_BEEF
+    ),
+    CUTTING_BOARD_V(
+            "Cutting Board V",
+            ChatColor.GRAY + "Hone your knife skills",
+            ChatColor.YELLOW + "+4% Chance For Double Culinary Yield",
+            5,
+            80,
+            Material.STONECUTTER
+    ),
+    LUNCH_RUSH_V(
+            "Lunch Rush V",
+            ChatColor.GRAY + "Serve dishes faster",
+            ChatColor.YELLOW + "-4% Cook time",
+            5,
+            80,
+            Material.FURNACE
+    ),
+    CAVITY(
+            "Cavity",
+            ChatColor.GRAY + "Sugar rush supreme",
+            ChatColor.YELLOW + "+10% Sugar Gains",
+            4,
+            80,
+            Material.SUGAR
+    ),
+    CHEFS_KISS(
+            "Chef's Kiss",
+            ChatColor.GRAY + "Perfection in every recipe",
+            ChatColor.YELLOW + "+20% Chance to Refund Recipe Papers",
+            5,
+            80,
+            Material.PAPER
+    ),
     SATIATION_MASTERY(
             "Satiation Mastery",
             ChatColor.GRAY + "Cooked meals keep you fuller",

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -108,11 +108,35 @@ public final class TalentRegistry {
         SKILL_TALENTS.put(
                 Skill.CULINARY,
                 Arrays.asList(
-                        Talent.SATIATION_MASTERY,
+                        Talent.SATIATION_MASTERY_I,
+                        Talent.CUTTING_BOARD_I,
+                        Talent.LUNCH_RUSH_I,
+                        Talent.SWEET_TOOTH,
+                        Talent.GOLDEN_APPLE,
+                        Talent.SATIATION_MASTERY_II,
+                        Talent.CUTTING_BOARD_II,
+                        Talent.LUNCH_RUSH_II,
+                        Talent.GRAINS_GAINS,
+                        Talent.PORTAL_PANTRY,
+                        Talent.SATIATION_MASTERY_III,
+                        Talent.CUTTING_BOARD_III,
+                        Talent.LUNCH_RUSH_III,
+                        Talent.AXE_BODY_SPRAY,
+                        Talent.I_DO_NOT_NEED_A_SNACK,
+                        Talent.SATIATION_MASTERY_IV,
+                        Talent.CUTTING_BOARD_IV,
+                        Talent.LUNCH_RUSH_IV,
+                        Talent.RABBIT,
+                        Talent.PANTRY_OF_PLENTY,
+                        Talent.SATIATION_MASTERY_V,
+                        Talent.CUTTING_BOARD_V,
+                        Talent.LUNCH_RUSH_V,
+                        Talent.CAVITY,
+                        Talent.CHEFS_KISS,
                         Talent.FEASTING_CHANCE,
                         Talent.MASTER_CHEF
-                  )
-          );
+                )
+        );
         SKILL_TALENTS.put(
                 Skill.BARTERING,
                 Arrays.asList(

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/culinary/CulinarySubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/culinary/CulinarySubsystem.java
@@ -563,7 +563,12 @@ public class CulinarySubsystem implements Listener {
 
         SkillTreeManager manager = SkillTreeManager.getInstance();
         if (manager != null) {
-            int satLevel = manager.getTalentLevel(player.getUniqueId(), Skill.CULINARY, Talent.SATIATION_MASTERY);
+            int satLevel = 0;
+            satLevel += manager.getTalentLevel(player.getUniqueId(), Skill.CULINARY, Talent.SATIATION_MASTERY_I);
+            satLevel += manager.getTalentLevel(player.getUniqueId(), Skill.CULINARY, Talent.SATIATION_MASTERY_II);
+            satLevel += manager.getTalentLevel(player.getUniqueId(), Skill.CULINARY, Talent.SATIATION_MASTERY_III);
+            satLevel += manager.getTalentLevel(player.getUniqueId(), Skill.CULINARY, Talent.SATIATION_MASTERY_IV);
+            satLevel += manager.getTalentLevel(player.getUniqueId(), Skill.CULINARY, Talent.SATIATION_MASTERY_V);
             if (satLevel > 0) {
                 new BukkitRunnable() {
                     @Override
@@ -1115,7 +1120,12 @@ public class CulinarySubsystem implements Listener {
         if (player != null) {
             SkillTreeManager manager = SkillTreeManager.getInstance();
             if (manager != null) {
-                int level = manager.getTalentLevel(player.getUniqueId(), Skill.CULINARY, Talent.MASTER_CHEF);
+                int level = 0;
+                level += manager.getTalentLevel(player.getUniqueId(), Skill.CULINARY, Talent.CUTTING_BOARD_I);
+                level += manager.getTalentLevel(player.getUniqueId(), Skill.CULINARY, Talent.CUTTING_BOARD_II);
+                level += manager.getTalentLevel(player.getUniqueId(), Skill.CULINARY, Talent.CUTTING_BOARD_III);
+                level += manager.getTalentLevel(player.getUniqueId(), Skill.CULINARY, Talent.CUTTING_BOARD_IV);
+                level += manager.getTalentLevel(player.getUniqueId(), Skill.CULINARY, Talent.CUTTING_BOARD_V);
                 if (level > 0 && random.nextDouble() < level * 0.04) {
                     for (int i = 0; i < yield; i++) {
                         session.tableLocation.getWorld().dropItem(session.tableLocation.clone().add(0.5, 1, 0.5), result.clone());


### PR DESCRIPTION
## Summary
- add new Culinary talent entries with level requirements
- register the new talents for the Culinary skill
- compute bonuses for new Satiation Mastery and Cutting Board talents
- provide dynamic descriptions for new talents

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6886c552936c8332a52fb2d6bdb8d3c1