### PR TITLE
Update bartering talents

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -415,6 +415,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         autoComposter = new AutoComposter(this);
         VillagerWorkCycleManager.getInstance(this);
         MarketTrendManager.getInstance(this);
+        new goat.minecraft.minecraftnew.subsystems.villagers.VillagerTalentListener();
 
         if (!getDataFolder().exists()) {
             getDataFolder().mkdirs();

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -433,18 +433,56 @@ public class SkillTreeManager implements Listener {
             case CHEFS_KISS:
                 double recipeRefund = level * 20;
                 return ChatColor.YELLOW + "+" + recipeRefund + "% Chance to Refund Recipe Papers";
-            case BARTER_DISCOUNT:
-                double discountPct = level * 4;
-                return ChatColor.YELLOW + "+" + discountPct + "% " + ChatColor.GOLD + "Trade Discount";
-            case FREE_TRANSACTION:
-                double freeChance = level;
-                return ChatColor.YELLOW + "+" + freeChance + "% " + ChatColor.GRAY + "Free purchase chance";
-            case SELL_PRICE_BOOST:
-                double sellBonus = level * 4;
-                return ChatColor.YELLOW + "+" + sellBonus + "% " + ChatColor.GOLD + "Sell Price";
-            case WORK_CYCLE_EFFICIENCY:
-                int reduce = level * 5;
-                return ChatColor.YELLOW + "-" + reduce + "s " + ChatColor.GRAY + "Workcycle time";
+            case HAGGLER_I:
+                return ChatColor.YELLOW + "+" + (level * 0.005) + " Discount";
+            case STONKS_I:
+                return ChatColor.YELLOW + "+" + (level * 2) + "% Emerald Gain when selling";
+            case SHUT_UP_AND_TAKE_MY_MONEY:
+                return ChatColor.YELLOW + "Right click purchases 2x";
+            case SWEATSHOP_SUPERVISOR:
+                return ChatColor.YELLOW + "-" + (level * 10) + "s Workcycle Cooldown";
+            case CORPORATE_BENEFITS:
+                return ChatColor.YELLOW + "-" + (level * 5) + "d Villager Tier Threshold";
+
+            case HAGGLER_II:
+                return ChatColor.YELLOW + "+" + (level * 0.01) + " Discount";
+            case STONKS_II:
+                return ChatColor.YELLOW + "+" + (level * 2) + "% Emerald Gain when selling";
+            case BULK:
+                return ChatColor.YELLOW + "-" + (level * 10) + "% cost for 20s";
+            case DEADLINE_DICTATOR:
+                return ChatColor.YELLOW + "-" + (level * 10) + "s Workcycle Cooldown";
+            case UNIFORM:
+                return ChatColor.YELLOW + "+" + (level * 10) + "% Villager Damage Resistance";
+
+            case HAGGLER_III:
+                return ChatColor.YELLOW + "+" + (level * 0.015) + " Discount";
+            case STONKS_III:
+                return ChatColor.YELLOW + "+" + (level * 2) + "% Emerald Gain when selling";
+            case INTEREST:
+                return ChatColor.YELLOW + "+" + (level) + "% chance for 1% bank interest";
+            case TASKMASTER_TYRANT:
+                return ChatColor.YELLOW + "-" + (level * 10) + "s Workcycle Cooldown";
+            case OVERSTOCKED:
+                return ChatColor.YELLOW + "+" + (level * 2) + "% Free purchase chance";
+
+            case HAGGLER_IV:
+                return ChatColor.YELLOW + "+" + (level * 0.02) + " Discount";
+            case STONKS_IV:
+                return ChatColor.YELLOW + "+" + (level * 2) + "% Emerald Gain when selling";
+            case OVERTIME_OVERLORD:
+                return ChatColor.YELLOW + "-" + (level * 10) + "s Workcycle Cooldown";
+            case ITS_ALIVE:
+                return ChatColor.YELLOW + "+" + (level * 20) + "% Transformation failure";
+
+            case HAGGLER_V:
+                return ChatColor.YELLOW + "+" + (level * 0.025) + " Discount";
+            case STONKS_V:
+                return ChatColor.YELLOW + "+" + (level * 2) + "% Emerald Gain when selling";
+            case SLAVE_DRIVER:
+                return ChatColor.YELLOW + "-" + (level * 10) + "s Workcycle Cooldown";
+            case BILLIONAIRE_DISCOUNT:
+                return ChatColor.YELLOW + "+" + (level * 5) + "% Discount";
             case DOUBLE_LOGS:
                 double dblChance = level * 10;
                 return ChatColor.YELLOW + "+" + dblChance + "% " + ChatColor.GRAY + "Double Log Chance";

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -814,38 +814,194 @@ public enum Talent {
             Material.PAPER
     ),
 
-    BARTER_DISCOUNT(
-            "Barter Discount",
-            ChatColor.GRAY + "Sharpen your haggling skills",
-            ChatColor.YELLOW + "+4% Discount per level",
-            10,
+    HAGGLER_I(
+            "Haggler I",
+            ChatColor.GRAY + "Basic bargaining tactics",
+            ChatColor.YELLOW + "+0.005 Discount",
+            3,
             1,
             Material.EMERALD
     ),
-    FREE_TRANSACTION(
-            "Free Transaction",
-            ChatColor.GRAY + "Occasionally pay nothing",
-            ChatColor.YELLOW + "1% chance per level for free purchase",
-            10,
+    STONKS_I(
+            "Stonks I",
+            ChatColor.GRAY + "Slightly better resale value",
+            ChatColor.YELLOW + "+2% Emerald Gain when selling",
+            5,
+            1,
+            Material.EMERALD
+    ),
+    SHUT_UP_AND_TAKE_MY_MONEY(
+            "Shut Up And Take My Money",
+            ChatColor.GRAY + "Right click to buy twice",
+            ChatColor.YELLOW + "Right click to purchase 2x",
+            2,
+            1,
+            Material.GOLD_INGOT
+    ),
+    SWEATSHOP_SUPERVISOR(
+            "Sweatshop Supervisor",
+            ChatColor.GRAY + "Reduce villager workcycle cooldown",
+            ChatColor.YELLOW + "-10s Villager Workcycle Cooldown",
+            5,
+            1,
+            Material.CLOCK
+    ),
+    CORPORATE_BENEFITS(
+            "Corporate Benefits",
+            ChatColor.GRAY + "Villagers rank up sooner",
+            ChatColor.YELLOW + "-5d Villager Tier Threshold",
+            5,
+            1,
+            Material.GOLD_NUGGET
+    ),
+
+    HAGGLER_II(
+            "Haggler II",
+            ChatColor.GRAY + "Improved bartering tactics",
+            ChatColor.YELLOW + "+0.01 Discount",
+            3,
             20,
+            Material.EMERALD
+    ),
+    STONKS_II(
+            "Stonks II",
+            ChatColor.GRAY + "Better resale value",
+            ChatColor.YELLOW + "+2% Emerald Gain when selling",
+            5,
+            20,
+            Material.EMERALD
+    ),
+    BULK(
+            "Bulk",
+            ChatColor.GRAY + "Buying reduces future cost",
+            ChatColor.YELLOW + "10% cost reduction for 20s",
+            2,
+            20,
+            Material.CHEST
+    ),
+    DEADLINE_DICTATOR(
+            "Deadline Dictator",
+            ChatColor.GRAY + "Further reduce workcycle cooldown",
+            ChatColor.YELLOW + "-10s Villager Workcycle Cooldown",
+            5,
+            20,
+            Material.CLOCK
+    ),
+    UNIFORM(
+            "Uniform",
+            ChatColor.GRAY + "Protect villagers while online",
+            ChatColor.YELLOW + "+10% Villager Damage Resistance",
+            5,
+            20,
+            Material.LEATHER_CHESTPLATE
+    ),
+
+    HAGGLER_III(
+            "Haggler III",
+            ChatColor.GRAY + "Advanced haggling techniques",
+            ChatColor.YELLOW + "+0.015 Discount",
+            3,
+            40,
+            Material.EMERALD
+    ),
+    STONKS_III(
+            "Stonks III",
+            ChatColor.GRAY + "Even better resale value",
+            ChatColor.YELLOW + "+2% Emerald Gain when selling",
+            5,
+            40,
+            Material.EMERALD
+    ),
+    INTEREST(
+            "Interest",
+            ChatColor.GRAY + "Occasional bank bonus",
+            ChatColor.YELLOW + "1% chance to add 1% more Emeralds to Bank",
+            2,
+            40,
             Material.EMERALD_BLOCK
     ),
-    SELL_PRICE_BOOST(
-            "Sell Price Boost",
-            ChatColor.GRAY + "Villagers pay more",
-            ChatColor.YELLOW + "+4% Sell Price per level",
-            20,
-            1,
+    TASKMASTER_TYRANT(
+            "Taskmaster Tyrant",
+            ChatColor.GRAY + "Further reduce workcycle cooldown",
+            ChatColor.YELLOW + "-10s Villager Workcycle Cooldown",
+            5,
+            40,
+            Material.CLOCK
+    ),
+    OVERSTOCKED(
+            "Overstocked",
+            ChatColor.GRAY + "Chance to buy for free",
+            ChatColor.YELLOW + "+2% Chance to buy an item for free",
+            5,
+            40,
+            Material.CHEST_MINECART
+    ),
+
+    HAGGLER_IV(
+            "Haggler IV",
+            ChatColor.GRAY + "Master negotiator",
+            ChatColor.YELLOW + "+0.02 Discount",
+            3,
+            60,
             Material.EMERALD
     ),
-    WORK_CYCLE_EFFICIENCY(
-            "Work Cycle Efficiency",
-            ChatColor.GRAY + "Reduce villager downtime",
-            ChatColor.YELLOW + "-5s Workcycle per level",
-            20,
-            10,
+    STONKS_IV(
+            "Stonks IV",
+            ChatColor.GRAY + "Excellent resale value",
+            ChatColor.YELLOW + "+2% Emerald Gain when selling",
+            5,
+            60,
+            Material.EMERALD
+    ),
+    OVERTIME_OVERLORD(
+            "Overtime Overlord",
+            ChatColor.GRAY + "Greatly reduce workcycle cooldown",
+            ChatColor.YELLOW + "-10s Villager Workcycle Cooldown",
+            7,
+            60,
             Material.CLOCK
-      ),
+    ),
+    ITS_ALIVE(
+            "It's Alive!",
+            ChatColor.GRAY + "Prevent villager mutations",
+            ChatColor.YELLOW + "+20% Chance to fail transformations",
+            5,
+            60,
+            Material.LIGHTNING_ROD
+    ),
+
+    HAGGLER_V(
+            "Haggler V",
+            ChatColor.GRAY + "Legendary bargainer",
+            ChatColor.YELLOW + "+0.025 Discount",
+            4,
+            80,
+            Material.EMERALD
+    ),
+    STONKS_V(
+            "Stonks V",
+            ChatColor.GRAY + "Best resale value",
+            ChatColor.YELLOW + "+2% Emerald Gain when selling",
+            5,
+            80,
+            Material.EMERALD
+    ),
+    SLAVE_DRIVER(
+            "Slave Driver",
+            ChatColor.GRAY + "Maximum workcycle reduction",
+            ChatColor.YELLOW + "-10s Villager Workcycle Cooldown",
+            5,
+            80,
+            Material.CLOCK
+    ),
+    BILLIONAIRE_DISCOUNT(
+            "Billionaire's Discount",
+            ChatColor.GRAY + "Massive trade discounts",
+            ChatColor.YELLOW + "+5% Discount",
+            6,
+            80,
+            Material.DIAMOND
+    ),
     DOUBLE_LOGS(
             "Double Logs",
             ChatColor.GRAY + "Chance for extra logs",

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -138,12 +138,35 @@ public final class TalentRegistry {
         SKILL_TALENTS.put(
                 Skill.BARTERING,
                 Arrays.asList(
-                        Talent.BARTER_DISCOUNT,
-                        Talent.FREE_TRANSACTION,
-                        Talent.SELL_PRICE_BOOST,
-                        Talent.WORK_CYCLE_EFFICIENCY
-                  )
-          );
+                        Talent.HAGGLER_I,
+                        Talent.STONKS_I,
+                        Talent.SHUT_UP_AND_TAKE_MY_MONEY,
+                        Talent.SWEATSHOP_SUPERVISOR,
+                        Talent.CORPORATE_BENEFITS,
+
+                        Talent.HAGGLER_II,
+                        Talent.STONKS_II,
+                        Talent.BULK,
+                        Talent.DEADLINE_DICTATOR,
+                        Talent.UNIFORM,
+
+                        Talent.HAGGLER_III,
+                        Talent.STONKS_III,
+                        Talent.INTEREST,
+                        Talent.TASKMASTER_TYRANT,
+                        Talent.OVERSTOCKED,
+
+                        Talent.HAGGLER_IV,
+                        Talent.STONKS_IV,
+                        Talent.OVERTIME_OVERLORD,
+                        Talent.ITS_ALIVE,
+
+                        Talent.HAGGLER_V,
+                        Talent.STONKS_V,
+                        Talent.SLAVE_DRIVER,
+                        Talent.BILLIONAIRE_DISCOUNT
+                )
+        );
         SKILL_TALENTS.put(
                 Skill.FORESTRY,
                 Arrays.asList(

--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/BankAccountManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/BankAccountManager.java
@@ -70,6 +70,10 @@ public class BankAccountManager {
         setBalance(id, bal + amount);
     }
 
+    public void addEmeralds(UUID id, int amount) {
+        addBalance(id, amount);
+    }
+
     public int depositAll(Player player) {
         int total = 0;
         Inventory inv = player.getInventory();

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTalentListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTalentListener.java
@@ -1,0 +1,53 @@
+package goat.minecraft.minecraftnew.subsystems.villagers;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityTransformEvent;
+
+public class VillagerTalentListener implements Listener {
+    public VillagerTalentListener() {
+        Bukkit.getPluginManager().registerEvents(this, MinecraftNew.getInstance());
+    }
+
+    @EventHandler
+    public void onVillagerDamage(EntityDamageEvent event) {
+        if (!(event.getEntity() instanceof Villager)) return;
+        SkillTreeManager mgr = SkillTreeManager.getInstance();
+        if (mgr == null) return;
+        int highest = 0;
+        for (Player p : Bukkit.getOnlinePlayers()) {
+            int lvl = mgr.getTalentLevel(p.getUniqueId(), Skill.BARTERING, Talent.UNIFORM);
+            if (lvl > highest) highest = lvl;
+        }
+        if (highest > 0) {
+            double reduction = highest * 0.10;
+            event.setDamage(event.getDamage() * (1 - reduction));
+        }
+    }
+
+    @EventHandler
+    public void onVillagerTransform(EntityTransformEvent event) {
+        if (event.getEntityType() != EntityType.VILLAGER) return;
+        if (event.getTransformedEntityType() != EntityType.ZOMBIE_VILLAGER && event.getTransformedEntityType() != EntityType.WITCH)
+            return;
+        SkillTreeManager mgr = SkillTreeManager.getInstance();
+        if (mgr == null) return;
+        int highest = 0;
+        for (Player p : Bukkit.getOnlinePlayers()) {
+            int lvl = mgr.getTalentLevel(p.getUniqueId(), Skill.BARTERING, Talent.ITS_ALIVE);
+            if (lvl > highest) highest = lvl;
+        }
+        if (highest > 0 && Math.random() < highest * 0.20) {
+            event.setCancelled(true);
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerWorkCycleManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerWorkCycleManager.java
@@ -125,10 +125,15 @@ public class VillagerWorkCycleManager implements Listener, CommandExecutor {
         if (manager == null) return 0;
         int highest = 0;
         for (Player player : Bukkit.getOnlinePlayers()) {
-            int level = manager.getTalentLevel(player.getUniqueId(), Skill.BARTERING, Talent.WORK_CYCLE_EFFICIENCY);
-            if (level > highest) highest = level;
+            int total = 0;
+            total += manager.getTalentLevel(player.getUniqueId(), Skill.BARTERING, Talent.SWEATSHOP_SUPERVISOR);
+            total += manager.getTalentLevel(player.getUniqueId(), Skill.BARTERING, Talent.DEADLINE_DICTATOR);
+            total += manager.getTalentLevel(player.getUniqueId(), Skill.BARTERING, Talent.TASKMASTER_TYRANT);
+            total += manager.getTalentLevel(player.getUniqueId(), Skill.BARTERING, Talent.OVERTIME_OVERLORD);
+            total += manager.getTalentLevel(player.getUniqueId(), Skill.BARTERING, Talent.SLAVE_DRIVER);
+            if (total > highest) highest = total;
         }
-        return highest * 5 * 20;
+        return highest * 10 * 20;
     }
 
     /**

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/professions/bartender/BartenderVillagerManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/professions/bartender/BartenderVillagerManager.java
@@ -105,7 +105,7 @@ public class BartenderVillagerManager implements Listener {
                 int base = ti.getEmeraldValue();
                 int price = VillagerTradeManager
                         .getInstance((JavaPlugin)MinecraftNew.getInstance())
-                        .calculateDiscountedPrice(player, base);
+                        .calculateDiscountedPrice(player, base, ti.getItem());
 
                 m.setLore(List.of(
                         ChatColor.RED   + "Original Price: "   + base   + " emerald(s)",
@@ -187,7 +187,7 @@ public class BartenderVillagerManager implements Listener {
                 TradeItem ti = bartenderTrades.get(purchaseIndex);
                 // delegate to your VillagerTradeManager helper:
                 VillagerTradeManager.getInstance((JavaPlugin)MinecraftNew.getInstance())
-                        .processPurchase(p, v, ti);
+                        .processPurchase(p, v, ti, 1);
                 p.closeInventory();
             }
         }

--- a/src/main/java/goat/minecraft/minecraftnew/utils/stats/StatsCalculator.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/stats/StatsCalculator.java
@@ -230,8 +230,16 @@ public class StatsCalculator {
     public double getDiscount(Player player) {
         double discount = 0.0;
         if (SkillTreeManager.getInstance() != null) {
-            int level = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.BARTERING, Talent.BARTER_DISCOUNT);
-            discount += level * 4.0;
+            SkillTreeManager mgr = SkillTreeManager.getInstance();
+            int level = 0;
+            level += mgr.getTalentLevel(player.getUniqueId(), Skill.BARTERING, Talent.HAGGLER_I) * 1; // each 0.5%
+            level += mgr.getTalentLevel(player.getUniqueId(), Skill.BARTERING, Talent.HAGGLER_II) * 2; // 1%
+            level += mgr.getTalentLevel(player.getUniqueId(), Skill.BARTERING, Talent.HAGGLER_III) * 3; // 1.5%
+            level += mgr.getTalentLevel(player.getUniqueId(), Skill.BARTERING, Talent.HAGGLER_IV) * 4; // 2%
+            level += mgr.getTalentLevel(player.getUniqueId(), Skill.BARTERING, Talent.HAGGLER_V) * 5; // 2.5%
+            discount += level * 0.5;
+            int billionaire = mgr.getTalentLevel(player.getUniqueId(), Skill.BARTERING, Talent.BILLIONAIRE_DISCOUNT);
+            discount += billionaire * 5.0;
         }
         PetManager.Pet pet = PetManager.getInstance(plugin).getActivePet(player);
         if (pet != null && pet.getTrait() == PetTrait.FINANCIAL) {


### PR DESCRIPTION
## Summary
- overhaul bartering talent enum
- register new bartering talents
- show dynamic descriptions for the new talents
- compute barter discounts using new Hagglers and Billionaire's Discount
- overhaul purchase/sell logic with new talents
- adjust villager work cycle reduction
- lower villager tier thresholds with Corporate Benefits
- add villager talent listener for protection and transformation fails
- expose bank method to add emeralds

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6886daa3dfd483328844753f4b453ad0