### PR TITLE
Add 100 Acre Woods perk support

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/enchanting/UltimateEnchantmentListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/enchanting/UltimateEnchantmentListener.java
@@ -387,6 +387,7 @@ public class UltimateEnchantmentListener implements Listener {
             ItemStack axe = player.getInventory().getItemInMainHand();
             int orchard = EffigyUpgradeSystem.getUpgradeLevel(axe, EffigyUpgradeSystem.UpgradeType.ORCHARD);
             forestry.processPerfectAppleChance(player, currentBlock, xpManager.getPlayerLevel(player, "Forestry"), orchard);
+            forestry.processHoneyBottleChance(player, currentBlock);
             forestry.processDoubleDropChance(player, currentBlock);
 
             if (visitedLogs.size() % 4 == 0) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/Forestry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/Forestry.java
@@ -495,6 +495,9 @@ public class Forestry implements Listener {
             int orchard = EffigyUpgradeSystem.getUpgradeLevel(axe, EffigyUpgradeSystem.UpgradeType.ORCHARD);
             processPerfectAppleChance(player, block, forestryLevel, orchard);
 
+            // Process honey bottle chance from 100 Acre Woods talent.
+            processHoneyBottleChance(player, block);
+
             int goldenApple = EffigyUpgradeSystem.getUpgradeLevel(axe, EffigyUpgradeSystem.UpgradeType.GOLDEN_APPLE);
             processNotchAppleChance(player, block, goldenApple);
 
@@ -576,6 +579,25 @@ public class Forestry implements Listener {
             Location dropLocation = block.getLocation().add(0.5, 0.5, 0.5);
             dropLocation.getWorld().dropItemNaturally(dropLocation, new ItemStack(Material.ENCHANTED_GOLDEN_APPLE));
             dropLocation.getWorld().playSound(dropLocation, Sound.ENTITY_ITEM_PICKUP, 0.8f, 1.2f);
+        }
+    }
+
+    public void processHoneyBottleChance(Player player, Block block) {
+        SkillTreeManager mgr = SkillTreeManager.getInstance();
+        int level = mgr.getTalentLevel(player.getUniqueId(), Skill.FORESTRY, Talent.ONE_HUNDRED_ACRE_WOODS);
+        if (level <= 0) return;
+
+        double chance = level * 1.0; // 1% per level
+        if (random.nextDouble() * 100 < chance) {
+            final Location dropLocation = block.getLocation().add(0.5, 0.5, 0.5);
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    dropLocation.getWorld().dropItemNaturally(dropLocation, new ItemStack(Material.HONEY_BOTTLE));
+                    dropLocation.getWorld().playSound(dropLocation, Sound.ITEM_BOTTLE_FILL, 0.8f, 1.0f);
+                    dropLocation.getWorld().spawnParticle(Particle.FALLING_HONEY, dropLocation, 5, 0.3, 0.3, 0.3, 0.01);
+                }
+            }.runTaskLater(plugin, 1L);
         }
     }
 


### PR DESCRIPTION
## Summary
- implement honey bottle drop logic for the `100 Acre Woods` perk
- invoke this drop from Forestry and Treecapitator logic

## Testing
- `mvn -q -DskipTests install` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6886e9e4c1548332b93056a11d839696