### PR TITLE
Implement Regrowth talent functionality

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -18,6 +18,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import goat.minecraft.minecraftnew.other.health.HealthManager;
+import goat.minecraft.minecraftnew.subsystems.forestry.SaplingManager;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -678,6 +679,10 @@ public class SkillTreeManager implements Listener {
         player.sendMessage(ChatColor.GREEN + "Upgraded " + talent.getName() + " to " + (currentLevel + 1));
         if (skill == Skill.PLAYER && talent == Talent.VITALITY) {
             HealthManager.getInstance(plugin).applyAndFill(player);
+        }
+        if (skill == Skill.FORESTRY &&
+                (talent == Talent.REGROWTH_I || talent == Talent.REGROWTH_II || talent == Talent.REGROWTH_III)) {
+            SaplingManager.getInstance(plugin).reduceCooldownDays(1);
         }
         openSkillTree(player, skill, page);
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/SaplingManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/SaplingManager.java
@@ -2,6 +2,9 @@ package goat.minecraft.minecraftnew.subsystems.forestry;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -33,6 +36,7 @@ public class SaplingManager implements Listener {
     private BukkitRunnable timerTask;
 
     private static final int DEFAULT_COOLDOWN = 30 * 24 * 60 * 60; // 30 days
+    private static final int SECONDS_IN_DAY = 24 * 60 * 60;
 
     private SaplingManager(JavaPlugin plugin) {
         this.plugin = plugin;
@@ -122,7 +126,9 @@ public class SaplingManager implements Listener {
             loc.getWorld().generateTree(loc, type);
         }
         saplingLocations.clear();
-        cooldownSeconds = DEFAULT_COOLDOWN;
+        int bonusDays = getRegrowthBonusFromOnlinePlayers();
+        cooldownSeconds = DEFAULT_COOLDOWN - bonusDays * SECONDS_IN_DAY;
+        if (cooldownSeconds < 0) cooldownSeconds = 0;
         saveData();
     }
 
@@ -245,6 +251,29 @@ public class SaplingManager implements Listener {
                 loc.getWorld().dropItemNaturally(loc, drop);
             }
         }
+    }
+
+    /**
+     * Reduce the current cooldown by the specified number of days.
+     */
+    public void reduceCooldownDays(int days) {
+        if (days <= 0) return;
+        setCooldownSecondsRemaining(Math.max(0, cooldownSeconds - days * SECONDS_IN_DAY));
+    }
+
+    /**
+     * Calculate active Regrowth bonuses from online players.
+     */
+    private int getRegrowthBonusFromOnlinePlayers() {
+        int bonus = 0;
+        SkillTreeManager stm = SkillTreeManager.getInstance();
+        if (stm == null) return 0;
+        for (Player p : Bukkit.getOnlinePlayers()) {
+            bonus += stm.getTalentLevel(p.getUniqueId(), Skill.FORESTRY, Talent.REGROWTH_I);
+            bonus += stm.getTalentLevel(p.getUniqueId(), Skill.FORESTRY, Talent.REGROWTH_II);
+            bonus += stm.getTalentLevel(p.getUniqueId(), Skill.FORESTRY, Talent.REGROWTH_III);
+        }
+        return bonus;
     }
 
     public void shutdown() {


### PR DESCRIPTION
## Summary
- use new `SECONDS_IN_DAY` constant for clarity
- reduce orchard cooldown when Regrowth talents are acquired
- compute bonus from online players when saplings grow
- update skill tree to apply Regrowth bonus on talent purchase

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6886fc2eb7648332b80660db6a112efc