### PR TITLE
Add Spectral Armor damage reduction

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatSubsystemManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatSubsystemManager.java
@@ -11,6 +11,7 @@ import goat.minecraft.minecraftnew.subsystems.combat.damage.strategies.CorpseLev
 import goat.minecraft.minecraftnew.subsystems.combat.damage.strategies.SwordTalentDamageStrategy;
 import goat.minecraft.minecraftnew.subsystems.combat.damage.strategies.SpiderDamageStrategy;
 import goat.minecraft.minecraftnew.subsystems.combat.damage.strategies.HellbentDamageStrategy;
+import goat.minecraft.minecraftnew.subsystems.combat.damage.strategies.SpectralArmorDamageStrategy;
 import goat.minecraft.minecraftnew.subsystems.combat.commands.CombatReloadCommand;
 import goat.minecraft.minecraftnew.subsystems.combat.hostility.HostilityGUIController;
 import goat.minecraft.minecraftnew.subsystems.combat.hostility.HostilityService;
@@ -258,6 +259,7 @@ public class CombatSubsystemManager implements CommandExecutor {
         // Register catalyst damage strategies (always enabled)
         damageCalculationService.registerStrategy(new PowerCatalystDamageStrategy());
         damageCalculationService.registerStrategy(new InsanityCatalystDamageStrategy());
+        damageCalculationService.registerStrategy(new SpectralArmorDamageStrategy());
         
         logger.fine("Damage calculation strategies registered");
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/damage/strategies/SpectralArmorDamageStrategy.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/damage/strategies/SpectralArmorDamageStrategy.java
@@ -1,0 +1,92 @@
+package goat.minecraft.minecraftnew.subsystems.combat.damage.strategies;
+
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
+import goat.minecraft.minecraftnew.subsystems.combat.damage.DamageCalculationContext;
+import goat.minecraft.minecraftnew.subsystems.combat.damage.DamageCalculationResult;
+import goat.minecraft.minecraftnew.subsystems.combat.damage.DamageCalculationStrategy;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Skeleton;
+
+import java.util.logging.Logger;
+
+/**
+ * Reduces damage from forest spirits when the target has the Spectral Armor talent.
+ * Forest spirits are detected by parsing their custom names rather than relying on metadata.
+ */
+public class SpectralArmorDamageStrategy implements DamageCalculationStrategy {
+
+    private static final Logger logger = Logger.getLogger(SpectralArmorDamageStrategy.class.getName());
+
+    @Override
+    public DamageCalculationResult calculateDamage(DamageCalculationContext context) {
+        if (!isApplicable(context)) {
+            return DamageCalculationResult.noChange(context.getBaseDamage());
+        }
+
+        Player player = (Player) context.getTarget();
+        double originalDamage = context.getBaseDamage();
+
+        try {
+            SkillTreeManager manager = SkillTreeManager.getInstance();
+            if (manager == null) {
+                return DamageCalculationResult.noChange(originalDamage);
+            }
+            int level = manager.getTalentLevel(player.getUniqueId(), Skill.FORESTRY, Talent.SPECTRAL_ARMOR);
+            if (level <= 0) {
+                return DamageCalculationResult.noChange(originalDamage);
+            }
+
+            double reduction = Math.min(level * 0.10, 0.95); // cap at 95% for safety
+            double multiplier = 1.0 - reduction;
+            double finalDamage = originalDamage * multiplier;
+
+            DamageCalculationResult.DamageModifier modifier =
+                DamageCalculationResult.DamageModifier.multiplicative(
+                    "Spectral Armor",
+                    multiplier,
+                    String.format("-%d%% Spirit Damage", (int) (reduction * 100))
+                );
+
+            return DamageCalculationResult.withModifier(originalDamage, finalDamage, modifier);
+
+        } catch (Exception e) {
+            logger.warning(String.format("Failed to apply Spectral Armor reduction for %s: %s",
+                    player.getName(), e.getMessage()));
+            return DamageCalculationResult.noChange(originalDamage);
+        }
+    }
+
+    private boolean isForestSpirit(Entity entity) {
+        if (!(entity instanceof Skeleton)) {
+            return false;
+        }
+        String name = entity.getCustomName();
+        if (name == null) {
+            return false;
+        }
+        name = ChatColor.stripColor(name);
+        if (name.contains("] ")) {
+            name = name.substring(name.indexOf("] ") + 2);
+        }
+        return name.toLowerCase().endsWith("spirit");
+    }
+
+    @Override
+    public boolean isApplicable(DamageCalculationContext context) {
+        return context.getTarget() instanceof Player && isForestSpirit(context.getAttacker());
+    }
+
+    @Override
+    public int getPriority() {
+        return 61; // run after Insanity Catalyst but before generic modifiers
+    }
+
+    @Override
+    public String getName() {
+        return "Spectral Armor Damage Reduction";
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SpectralArmorDamageStrategy` to reduce damage from forest spirits if player unlocked the Spectral Armor talent
- register strategy in `CombatSubsystemManager` so it activates during combat calculations

## Testing
- `mvn -q -DskipTests compile` *(fails: Plugin resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_6886fc5ad13083329327825c1f6a5513