### PR TITLE
Implement Ancient Confusion spirit debuff

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/ignoreme
+++ b/src/main/java/goat/minecraft/minecraftnew/ignoreme
@@ -235,7 +235,7 @@ Legendary:
 Spirit Chance V: +0.0010 Spirit Chance, Max level 4
 Timber V: +4% Double Logs Chance, Max level 5
 Leverage V: +2% Haste Chance, Max level 4
-Ancient Confusion: -10 Spirit Level, Max level 5
+Ancient Confusion: -10 Forest Spirit Levels, Max level 5
 Redemption: +50% Chance to Replant a sapling nearby, Max level 2
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/ForestSpiritManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/ForestSpiritManager.java
@@ -11,6 +11,9 @@ import goat.minecraft.minecraftnew.subsystems.combat.SpawnMonsters;
 import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
@@ -136,6 +139,15 @@ public class ForestSpiritManager implements Listener {
     public void spawnSpirit(String spiritName, Location loc, Block block, Player player) {
         int tier = getSpiritTier(player);
         int level = getSpiritLevelForTier(tier);
+
+        // Apply Ancient Confusion talent reduction
+        SkillTreeManager mgr = SkillTreeManager.getInstance();
+        if (mgr != null) {
+            int confusion = mgr.getTalentLevel(player.getUniqueId(), Skill.FORESTRY, Talent.ANCIENT_CONFUSION);
+            if (confusion > 0) {
+                level = Math.max(1, level - (confusion * 10));
+            }
+        }
 
         SpawnMonsters spawnMonsters = SpawnMonsters.getInstance(xpManager);
         World world = loc.getWorld();


### PR DESCRIPTION
## Summary
- apply Ancient Confusion talent when spawning forest spirits
- document the updated talent description

## Testing
- `mvn -q test` *(fails: Plugin resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_6886fc973d7c8332ab6cf85373e3c659