### PR TITLE
Modify Redemption perk for super saplings

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/ignoreme
+++ b/src/main/java/goat/minecraft/minecraftnew/ignoreme
@@ -236,7 +236,7 @@ Spirit Chance V: +0.0010 Spirit Chance, Max level 4
 Timber V: +4% Double Logs Chance, Max level 5
 Leverage V: +2% Haste Chance, Max level 4
 Ancient Confusion: -10 Spirit Level, Max level 5
-Redemption: +50% Chance to Replant a sapling nearby, Max level 2
+Redemption: Doubles Super Sapling drop chance (triples at lvl 2), Max level 2
 
 
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/enchanting/UltimateEnchantmentListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/enchanting/UltimateEnchantmentListener.java
@@ -454,7 +454,7 @@ public class UltimateEnchantmentListener implements Listener {
         }
 
         SaplingManager.getInstance(MinecraftNew.getInstance())
-                .maybeDropSuperSapling(startBlock.getType(), startBlock.getLocation());
+                .maybeDropSuperSapling(startBlock.getType(), startBlock.getLocation(), player);
 
         // ---- Finally, break them all gradually! ----
         // 1) Break logs with durability usage, because they’re not ores.

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -536,8 +536,7 @@ public class SkillTreeManager implements Listener {
                 int lost = level * 10;
                 return ChatColor.DARK_GRAY + "-" + lost + " Spirit Level";
             case REDEMPTION:
-                double replant = level * 50;
-                return ChatColor.GREEN + "+" + replant + "% Sapling Replant Chance";
+                return ChatColor.GREEN + "x" + (level + 1) + " Super Sapling Chance";
             case PET_TRAINER:
                 double xpChance = level * 4;
                 return ChatColor.YELLOW + "+" + xpChance + "% " + ChatColor.GRAY + "Double Pet XP chance";

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -1188,8 +1188,8 @@ public enum Talent {
     ),
     REDEMPTION(
             "Redemption",
-            ChatColor.GRAY + "Chance to automatically replant saplings",
-            ChatColor.GREEN + "+50% Sapling Replant Chance",
+            ChatColor.GRAY + "Greater chance for Super Saplings",
+            ChatColor.GREEN + "Improved Treecapitator rewards",
             2,
             80,
             Material.OAK_SAPLING

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/SaplingManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/SaplingManager.java
@@ -2,6 +2,9 @@ package goat.minecraft.minecraftnew.subsystems.forestry;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -237,9 +240,17 @@ public class SaplingManager implements Listener {
         };
     }
 
-    public void maybeDropSuperSapling(Material log, Location loc) {
+    public void maybeDropSuperSapling(Material log, Location loc, Player player) {
         if (log == Material.CRIMSON_STEM || log == Material.WARPED_STEM) return;
-        if (Math.random() < 0.01) {
+
+        double chance = 0.01;
+        if (player != null) {
+            SkillTreeManager mgr = SkillTreeManager.getInstance();
+            int level = mgr.getTalentLevel(player.getUniqueId(), Skill.FORESTRY, Talent.REDEMPTION);
+            chance *= (1 + level); // level 1 -> 2x, level 2 -> 3x
+        }
+
+        if (Math.random() < chance) {
             ItemStack drop = getSuperSaplingForLog(log);
             if (drop != null) {
                 loc.getWorld().dropItemNaturally(loc, drop);


### PR DESCRIPTION
## Summary
- update Redemption talent text and description
- change dynamic description for Redemption
- adjust sapling drop chance based on Redemption level
- pass player into super sapling drop check
- update talent listing documentation

## Testing
- `mvn -q test` *(fails: could not download maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6886fd0a8e10833292d053731ce4699a