### PR TITLE
Add Player bonus health talents

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/health/HealthManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/health/HealthManager.java
@@ -41,12 +41,20 @@ public class HealthManager {
     public double computeMaxHealth(Player player) {
         double health = 20.0;
 
-        int talentLevel = 0;
+        int bonus = 0;
         if (SkillTreeManager.getInstance() != null) {
-            talentLevel = SkillTreeManager.getInstance()
-                    .getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.VITALITY);
+            bonus += SkillTreeManager.getInstance()
+                    .getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_I);
+            bonus += SkillTreeManager.getInstance()
+                    .getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_II);
+            bonus += SkillTreeManager.getInstance()
+                    .getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_III);
+            bonus += SkillTreeManager.getInstance()
+                    .getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_IV);
+            bonus += SkillTreeManager.getInstance()
+                    .getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_V);
         }
-        health += talentLevel;
+        health += bonus;
 
         if (BeaconPassivesGUI.hasBeaconPassives(player) &&
                 BeaconPassivesGUI.hasPassiveEnabled(player, "mending")) {

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -541,9 +541,35 @@ public class SkillTreeManager implements Listener {
             case PET_TRAINER:
                 double xpChance = level * 4;
                 return ChatColor.YELLOW + "+" + xpChance + "% " + ChatColor.GRAY + "Double Pet XP chance";
-            case VITALITY:
+            case HEALTH_I:
+            case HEALTH_II:
+            case HEALTH_III:
+            case HEALTH_IV:
+            case HEALTH_V:
                 int extraHealth = level;
-                return ChatColor.GREEN + "+" + extraHealth + " Max Health";
+                return ChatColor.GREEN + "+" + extraHealth + " Bonus Health";
+            case STUDY_BREWING:
+                return ChatColor.YELLOW + "+" + level + " Brewing Talent";
+            case STUDY_SMITHING:
+                return ChatColor.YELLOW + "+" + level + " Smithing Talent";
+            case STUDY_CULINARY:
+                return ChatColor.YELLOW + "+" + level + " Culinary Talent";
+            case STUDY_BARTERING:
+                return ChatColor.YELLOW + "+" + level + " Bartering Talent";
+            case STUDY_FORESTRY:
+                return ChatColor.YELLOW + "+" + level + " Forestry Talent";
+            case STUDY_TAMING:
+                return ChatColor.YELLOW + "+" + level + " Taming Talent";
+            case STUDY_COMBAT:
+                return ChatColor.YELLOW + "+" + level + " Combat Talent";
+            case STUDY_TERRAFORMING:
+                return ChatColor.YELLOW + "+" + level + " Terraforming Talent";
+            case STUDY_MINING:
+                return ChatColor.YELLOW + "+" + level + " Mining Talent";
+            case STUDY_FARMING:
+                return ChatColor.YELLOW + "+" + level + " Farming Talent";
+            case STUDY_FISHING:
+                return ChatColor.YELLOW + "+" + level + " Fishing Talent";
             case CONSERVATIONIST:
                 double duraChance = level;
                 return ChatColor.YELLOW + "+" + duraChance + "% " + ChatColor.GRAY + "durability save chance";
@@ -755,8 +781,34 @@ public class SkillTreeManager implements Listener {
         }
         setTalentLevel(player.getUniqueId(), skill, talent, currentLevel + 1);
         player.sendMessage(ChatColor.GREEN + "Upgraded " + talent.getName() + " to " + (currentLevel + 1));
-        if (skill == Skill.PLAYER && talent == Talent.VITALITY) {
-            HealthManager.getInstance(plugin).applyAndFill(player);
+        if (skill == Skill.PLAYER) {
+            if (talent == Talent.HEALTH_I || talent == Talent.HEALTH_II ||
+                    talent == Talent.HEALTH_III || talent == Talent.HEALTH_IV ||
+                    talent == Talent.HEALTH_V) {
+                HealthManager.getInstance(plugin).applyAndFill(player);
+            } else if (talent == Talent.STUDY_BREWING) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.BREWING, 1);
+            } else if (talent == Talent.STUDY_SMITHING) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.SMITHING, 1);
+            } else if (talent == Talent.STUDY_CULINARY) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.CULINARY, 1);
+            } else if (talent == Talent.STUDY_BARTERING) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.BARTERING, 1);
+            } else if (talent == Talent.STUDY_FORESTRY) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.FORESTRY, 1);
+            } else if (talent == Talent.STUDY_TAMING) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.TAMING, 1);
+            } else if (talent == Talent.STUDY_COMBAT) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.COMBAT, 1);
+            } else if (talent == Talent.STUDY_TERRAFORMING) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.TERRAFORMING, 1);
+            } else if (talent == Talent.STUDY_MINING) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.MINING, 1);
+            } else if (talent == Talent.STUDY_FARMING) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.FARMING, 1);
+            } else if (talent == Talent.STUDY_FISHING) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.FISHING, 1);
+            }
         }
         if (skill == Skill.FORESTRY &&
                 (talent == Talent.REGROWTH_I || talent == Talent.REGROWTH_II || talent == Talent.REGROWTH_III)) {

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -1202,14 +1202,134 @@ public enum Talent {
             1,
             Material.BONE
     ),
-  VITALITY(
-            "Vitality",
-            ChatColor.GRAY + "Fortify your body to survive longer",
-            ChatColor.GREEN + "+1 Max Health per level",
-            20,
+    HEALTH_I(
+            "Health I",
+            ChatColor.GRAY + "Bolster your vitality slightly",
+            ChatColor.GREEN + "+1 Bonus Health",
+            4,
             1,
             Material.APPLE
-     ),
+    ),
+    STUDY_BREWING(
+            "Study Brewing",
+            ChatColor.GRAY + "Dedicate time to potion research",
+            ChatColor.YELLOW + "+1 Brewing Talent",
+            100,
+            1,
+            Material.BREWING_STAND
+    ),
+    STUDY_SMITHING(
+            "Study Smithing",
+            ChatColor.GRAY + "Practice superior metalwork",
+            ChatColor.YELLOW + "+1 Smithing Talent",
+            100,
+            1,
+            Material.ANVIL
+    ),
+    STUDY_CULINARY(
+            "Study Culinary",
+            ChatColor.GRAY + "Experiment with new recipes",
+            ChatColor.YELLOW + "+1 Culinary Talent",
+            100,
+            1,
+            Material.COOKED_BEEF
+    ),
+    STUDY_BARTERING(
+            "Study Bartering",
+            ChatColor.GRAY + "Learn the art of the deal",
+            ChatColor.YELLOW + "+1 Bartering Talent",
+            100,
+            1,
+            Material.EMERALD
+    ),
+    STUDY_FORESTRY(
+            "Study Forestry",
+            ChatColor.GRAY + "Understand the ways of the woods",
+            ChatColor.YELLOW + "+1 Forestry Talent",
+            100,
+            1,
+            Material.OAK_SAPLING
+    ),
+    STUDY_TAMING(
+            "Study Taming",
+            ChatColor.GRAY + "Improve animal handling",
+            ChatColor.YELLOW + "+1 Taming Talent",
+            100,
+            1,
+            Material.BONE
+    ),
+    STUDY_COMBAT(
+            "Study Combat",
+            ChatColor.GRAY + "Train in advanced combat",
+            ChatColor.YELLOW + "+1 Combat Talent",
+            100,
+            1,
+            Material.IRON_SWORD
+    ),
+    STUDY_TERRAFORMING(
+            "Study Terraforming",
+            ChatColor.GRAY + "Survey the lands with purpose",
+            ChatColor.YELLOW + "+1 Terraforming Talent",
+            100,
+            1,
+            Material.DIRT
+    ),
+    STUDY_MINING(
+            "Study Mining",
+            ChatColor.GRAY + "Hone excavation techniques",
+            ChatColor.YELLOW + "+1 Mining Talent",
+            100,
+            1,
+            Material.IRON_PICKAXE
+    ),
+    STUDY_FARMING(
+            "Study Farming",
+            ChatColor.GRAY + "Master the secrets of crops",
+            ChatColor.YELLOW + "+1 Farming Talent",
+            100,
+            1,
+            Material.WHEAT
+    ),
+    STUDY_FISHING(
+            "Study Fishing",
+            ChatColor.GRAY + "Learn to reel in the big ones",
+            ChatColor.YELLOW + "+1 Fishing Talent",
+            100,
+            1,
+            Material.FISHING_ROD
+    ),
+    HEALTH_II(
+            "Health II",
+            ChatColor.GRAY + "Further enhance your vitality",
+            ChatColor.GREEN + "+1 Bonus Health",
+            6,
+            20,
+            Material.APPLE
+    ),
+    HEALTH_III(
+            "Health III",
+            ChatColor.GRAY + "Push your limits for more health",
+            ChatColor.GREEN + "+1 Bonus Health",
+            8,
+            40,
+            Material.APPLE
+    ),
+    HEALTH_IV(
+            "Health IV",
+            ChatColor.GRAY + "Achieve remarkable endurance",
+            ChatColor.GREEN + "+1 Bonus Health",
+            10,
+            60,
+            Material.APPLE
+    ),
+    HEALTH_V(
+            "Health V",
+            ChatColor.GRAY + "Reach peak physical condition",
+            ChatColor.GREEN + "+1 Bonus Health",
+            12,
+            80,
+            Material.APPLE
+    ),
     CONSERVATIONIST(
             "Conservationist",
             ChatColor.GRAY + "Reduce wear on your tools",

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -248,9 +248,25 @@ public final class TalentRegistry {
         );
         SKILL_TALENTS.put(
                 Skill.PLAYER,
-                Collections.singletonList(Talent.VITALITY
+                Arrays.asList(
+                        Talent.HEALTH_I,
+                        Talent.STUDY_BREWING,
+                        Talent.STUDY_SMITHING,
+                        Talent.STUDY_CULINARY,
+                        Talent.STUDY_BARTERING,
+                        Talent.STUDY_FORESTRY,
+                        Talent.STUDY_TAMING,
+                        Talent.STUDY_COMBAT,
+                        Talent.STUDY_TERRAFORMING,
+                        Talent.STUDY_MINING,
+                        Talent.STUDY_FARMING,
+                        Talent.STUDY_FISHING,
+                        Talent.HEALTH_II,
+                        Talent.HEALTH_III,
+                        Talent.HEALTH_IV,
+                        Talent.HEALTH_V
                 )
-          );
+        );
               SKILL_TALENTS.put(
                 Skill.TERRAFORMING,
                 Arrays.asList(


### PR DESCRIPTION
## Summary
- expand the `Talent` enum with Health I-V and Study talents
- wire Player health bonus into `HealthManager`
- grant extra skill points and bonus health when purchasing talents
- register the new talents under the Player skill

## Testing
- `mvn -q -e -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6887111d93f083328206e34f5afe7ac4