### PR TITLE
Add player health and study talents

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/health/HealthManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/health/HealthManager.java
@@ -43,8 +43,16 @@ public class HealthManager {
 
         int talentLevel = 0;
         if (SkillTreeManager.getInstance() != null) {
-            talentLevel = SkillTreeManager.getInstance()
-                    .getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.VITALITY);
+            talentLevel += SkillTreeManager.getInstance()
+                    .getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_I);
+            talentLevel += SkillTreeManager.getInstance()
+                    .getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_II);
+            talentLevel += SkillTreeManager.getInstance()
+                    .getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_III);
+            talentLevel += SkillTreeManager.getInstance()
+                    .getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_IV);
+            talentLevel += SkillTreeManager.getInstance()
+                    .getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_V);
         }
         health += talentLevel;
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -541,9 +541,35 @@ public class SkillTreeManager implements Listener {
             case PET_TRAINER:
                 double xpChance = level * 4;
                 return ChatColor.YELLOW + "+" + xpChance + "% " + ChatColor.GRAY + "Double Pet XP chance";
-            case VITALITY:
+            case HEALTH_I:
+            case HEALTH_II:
+            case HEALTH_III:
+            case HEALTH_IV:
+            case HEALTH_V:
                 int extraHealth = level;
-                return ChatColor.GREEN + "+" + extraHealth + " Max Health";
+                return ChatColor.GREEN + "+" + extraHealth + " Bonus Health";
+            case STUDY_BREWING:
+                return ChatColor.YELLOW + "+" + level + " Brewing Talent Point";
+            case STUDY_SMITHING:
+                return ChatColor.YELLOW + "+" + level + " Smithing Talent Point";
+            case STUDY_CULINARY:
+                return ChatColor.YELLOW + "+" + level + " Culinary Talent Point";
+            case STUDY_BARTERING:
+                return ChatColor.YELLOW + "+" + level + " Bartering Talent Point";
+            case STUDY_FORESTRY:
+                return ChatColor.YELLOW + "+" + level + " Forestry Talent Point";
+            case STUDY_TAMING:
+                return ChatColor.YELLOW + "+" + level + " Taming Talent Point";
+            case STUDY_COMBAT:
+                return ChatColor.YELLOW + "+" + level + " Combat Talent Point";
+            case STUDY_TERRAFORMING:
+                return ChatColor.YELLOW + "+" + level + " Terraforming Talent Point";
+            case STUDY_MINING:
+                return ChatColor.YELLOW + "+" + level + " Mining Talent Point";
+            case STUDY_FARMING:
+                return ChatColor.YELLOW + "+" + level + " Farming Talent Point";
+            case STUDY_FISHING:
+                return ChatColor.YELLOW + "+" + level + " Fishing Talent Point";
             case CONSERVATIONIST:
                 double duraChance = level;
                 return ChatColor.YELLOW + "+" + duraChance + "% " + ChatColor.GRAY + "durability save chance";
@@ -755,8 +781,35 @@ public class SkillTreeManager implements Listener {
         }
         setTalentLevel(player.getUniqueId(), skill, talent, currentLevel + 1);
         player.sendMessage(ChatColor.GREEN + "Upgraded " + talent.getName() + " to " + (currentLevel + 1));
-        if (skill == Skill.PLAYER && talent == Talent.VITALITY) {
-            HealthManager.getInstance(plugin).applyAndFill(player);
+        if (skill == Skill.PLAYER) {
+            if (talent == Talent.HEALTH_I || talent == Talent.HEALTH_II ||
+                    talent == Talent.HEALTH_III || talent == Talent.HEALTH_IV ||
+                    talent == Talent.HEALTH_V) {
+                HealthManager.getInstance(plugin).applyAndFill(player);
+            }
+            if (talent == Talent.STUDY_BREWING) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.BREWING, 1);
+            } else if (talent == Talent.STUDY_SMITHING) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.SMITHING, 1);
+            } else if (talent == Talent.STUDY_CULINARY) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.CULINARY, 1);
+            } else if (talent == Talent.STUDY_BARTERING) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.BARTERING, 1);
+            } else if (talent == Talent.STUDY_FORESTRY) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.FORESTRY, 1);
+            } else if (talent == Talent.STUDY_TAMING) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.TAMING, 1);
+            } else if (talent == Talent.STUDY_COMBAT) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.COMBAT, 1);
+            } else if (talent == Talent.STUDY_TERRAFORMING) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.TERRAFORMING, 1);
+            } else if (talent == Talent.STUDY_MINING) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.MINING, 1);
+            } else if (talent == Talent.STUDY_FARMING) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.FARMING, 1);
+            } else if (talent == Talent.STUDY_FISHING) {
+                addExtraTalentPoints(player.getUniqueId(), Skill.FISHING, 1);
+            }
         }
         if (skill == Skill.FORESTRY &&
                 (talent == Talent.REGROWTH_I || talent == Talent.REGROWTH_II || talent == Talent.REGROWTH_III)) {

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -1202,14 +1202,134 @@ public enum Talent {
             1,
             Material.BONE
     ),
-  VITALITY(
-            "Vitality",
-            ChatColor.GRAY + "Fortify your body to survive longer",
-            ChatColor.GREEN + "+1 Max Health per level",
-            20,
+    HEALTH_I(
+            "Health I",
+            ChatColor.GRAY + "Fortify your body for survival",
+            ChatColor.GREEN + "+1 Bonus Health",
+            4,
             1,
             Material.APPLE
-     ),
+    ),
+    STUDY_BREWING(
+            "Study Brewing",
+            ChatColor.GRAY + "Learn the art of brewing",
+            ChatColor.YELLOW + "+1 Brewing Talent Point",
+            100,
+            1,
+            Material.BOOK
+    ),
+    STUDY_SMITHING(
+            "Study Smithing",
+            ChatColor.GRAY + "Learn the art of smithing",
+            ChatColor.YELLOW + "+1 Smithing Talent Point",
+            100,
+            1,
+            Material.BOOK
+    ),
+    STUDY_CULINARY(
+            "Study Culinary",
+            ChatColor.GRAY + "Learn culinary secrets",
+            ChatColor.YELLOW + "+1 Culinary Talent Point",
+            100,
+            1,
+            Material.BOOK
+    ),
+    STUDY_BARTERING(
+            "Study Bartering",
+            ChatColor.GRAY + "Master the art of bartering",
+            ChatColor.YELLOW + "+1 Bartering Talent Point",
+            100,
+            1,
+            Material.BOOK
+    ),
+    STUDY_FORESTRY(
+            "Study Forestry",
+            ChatColor.GRAY + "Learn to manage forests",
+            ChatColor.YELLOW + "+1 Forestry Talent Point",
+            100,
+            1,
+            Material.BOOK
+    ),
+    STUDY_TAMING(
+            "Study Taming",
+            ChatColor.GRAY + "Improve your taming skills",
+            ChatColor.YELLOW + "+1 Taming Talent Point",
+            100,
+            1,
+            Material.BOOK
+    ),
+    STUDY_COMBAT(
+            "Study Combat",
+            ChatColor.GRAY + "Train in combat techniques",
+            ChatColor.YELLOW + "+1 Combat Talent Point",
+            100,
+            1,
+            Material.BOOK
+    ),
+    STUDY_TERRAFORMING(
+            "Study Terraforming",
+            ChatColor.GRAY + "Learn efficient terraforming",
+            ChatColor.YELLOW + "+1 Terraforming Talent Point",
+            100,
+            1,
+            Material.BOOK
+    ),
+    STUDY_MINING(
+            "Study Mining",
+            ChatColor.GRAY + "Improve your mining technique",
+            ChatColor.YELLOW + "+1 Mining Talent Point",
+            100,
+            1,
+            Material.BOOK
+    ),
+    STUDY_FARMING(
+            "Study Farming",
+            ChatColor.GRAY + "Learn optimal farming methods",
+            ChatColor.YELLOW + "+1 Farming Talent Point",
+            100,
+            1,
+            Material.BOOK
+    ),
+    STUDY_FISHING(
+            "Study Fishing",
+            ChatColor.GRAY + "Master angling skills",
+            ChatColor.YELLOW + "+1 Fishing Talent Point",
+            100,
+            1,
+            Material.BOOK
+    ),
+    HEALTH_II(
+            "Health II",
+            ChatColor.GRAY + "Increase your vitality",
+            ChatColor.GREEN + "+1 Bonus Health",
+            6,
+            20,
+            Material.APPLE
+    ),
+    HEALTH_III(
+            "Health III",
+            ChatColor.GRAY + "Further increase vitality",
+            ChatColor.GREEN + "+1 Bonus Health",
+            8,
+            40,
+            Material.APPLE
+    ),
+    HEALTH_IV(
+            "Health IV",
+            ChatColor.GRAY + "Empower your life force",
+            ChatColor.GREEN + "+1 Bonus Health",
+            10,
+            60,
+            Material.APPLE
+    ),
+    HEALTH_V(
+            "Health V",
+            ChatColor.GRAY + "Attain peak endurance",
+            ChatColor.GREEN + "+1 Bonus Health",
+            12,
+            80,
+            Material.APPLE
+    ),
     CONSERVATIONIST(
             "Conservationist",
             ChatColor.GRAY + "Reduce wear on your tools",

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -248,9 +248,25 @@ public final class TalentRegistry {
         );
         SKILL_TALENTS.put(
                 Skill.PLAYER,
-                Collections.singletonList(Talent.VITALITY
+                Arrays.asList(
+                        Talent.HEALTH_I,
+                        Talent.STUDY_BREWING,
+                        Talent.STUDY_SMITHING,
+                        Talent.STUDY_CULINARY,
+                        Talent.STUDY_BARTERING,
+                        Talent.STUDY_FORESTRY,
+                        Talent.STUDY_TAMING,
+                        Talent.STUDY_COMBAT,
+                        Talent.STUDY_TERRAFORMING,
+                        Talent.STUDY_MINING,
+                        Talent.STUDY_FARMING,
+                        Talent.STUDY_FISHING,
+                        Talent.HEALTH_II,
+                        Talent.HEALTH_III,
+                        Talent.HEALTH_IV,
+                        Talent.HEALTH_V
                 )
-          );
+        );
               SKILL_TALENTS.put(
                 Skill.TERRAFORMING,
                 Arrays.asList(


### PR DESCRIPTION
## Summary
- extend player skill tree with new health upgrades and study talents
- allocate health bonuses from new talent tiers
- allow investing player skill points to buy other skill points

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6887154ae4448332ba572ebedbb89799