### PR TITLE
Add Mining skill talents

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -630,6 +630,52 @@ public class SkillTreeManager implements Listener {
             case DEEP_LUNGS:
                 int oxygenBonus = level * 20;
                 return ChatColor.YELLOW + "+" + oxygenBonus + " " + ChatColor.AQUA + "Oxygen Capacity";
+            case OXYGEN_I:
+                return ChatColor.YELLOW + "+" + (level * 10) + " " + ChatColor.AQUA + "Oxygen";
+            case OXYGEN_EFFICIENCY_I:
+                return ChatColor.YELLOW + "-" + level + "% Oxygen Depletion Rate";
+            case REST:
+                return ChatColor.YELLOW + "+" + (level * 5) + "% Max Oxygen on sleep";
+            case BUBBLES_I:
+                return ChatColor.YELLOW + "+" + level + "% Bubble spawn chance";
+            case OXYGEN_II:
+                return ChatColor.YELLOW + "+" + (level * 20) + " " + ChatColor.AQUA + "Oxygen";
+            case OXYGEN_EFFICIENCY_II:
+                return ChatColor.YELLOW + "-" + level + "% Oxygen Depletion Rate";
+            case ANCIENT_DEBRIS:
+                return ChatColor.YELLOW + "+" + (level * 0.10) + "% Masterwork Ingot Chance";
+            case BUBBLES_II:
+                return ChatColor.YELLOW + "+" + level + "% Bubble spawn chance";
+            case OXYGEN_III:
+                return ChatColor.YELLOW + "+" + (level * 30) + " " + ChatColor.AQUA + "Oxygen";
+            case BIG_BUBBLES_I:
+                return ChatColor.YELLOW + "+" + (level * 10) + " Oxygen from bubbles";
+            case OXYGEN_EFFICIENCY_III:
+                return ChatColor.YELLOW + "-" + level + "% Oxygen Depletion Rate";
+            case GOLD_FEVER:
+                return ChatColor.YELLOW + "Removes Mining Fatigue from Moderate Hypoxia";
+            case MAGNET:
+                return ChatColor.YELLOW + "Items within " + level + " blocks collected every " + (10 - level) + "s";
+            case OXYGEN_IV:
+                return ChatColor.YELLOW + "+" + (level * 40) + " " + ChatColor.AQUA + "Oxygen";
+            case BIG_BUBBLES_II:
+                return ChatColor.YELLOW + "+" + (level * 10) + " Oxygen from bubbles";
+            case OXYGEN_EFFICIENCY_IV:
+                return ChatColor.YELLOW + "-" + level + "% Oxygen Depletion Rate";
+            case OXYGEN_RESERVE:
+                return ChatColor.YELLOW + "-" + (level * 5) + "% Depletion Rate below 50% Oxygen";
+            case COAL_YIELD:
+                return ChatColor.YELLOW + "+" + level + " Coal per Ore";
+            case OXYGEN_V:
+                return ChatColor.YELLOW + "+" + (level * 50) + " " + ChatColor.AQUA + "Oxygen";
+            case BIG_BUBBLES_III:
+                return ChatColor.YELLOW + "+" + (level * 10) + " Oxygen from bubbles";
+            case OXYGEN_EFFICIENCY_V:
+                return ChatColor.YELLOW + "-" + level + "% Oxygen Depletion Rate";
+            case WAKE_UP_THE_STATUES:
+                return ChatColor.YELLOW + "Reduce Severe Hypoxia fatigue by 1";
+            case HEART_OF_THE_MOUNTAIN:
+                return ChatColor.YELLOW + "+" + (level * 100) + " Max Durability to Pickaxes";
             case EXTRA_CROP_CHANCE_I:
                 return ChatColor.YELLOW + "+" + (level * 8) + "% " + ChatColor.GRAY + "Extra Crop Chance";
             case FOR_THE_STREETS:

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -1358,6 +1358,199 @@ public enum Talent {
     ),
 
     // =============================================================
+    // Mining Talents
+    // =============================================================
+
+    OXYGEN_I(
+            "Oxygen I",
+            ChatColor.GRAY + "Increase your oxygen reserves",
+            ChatColor.YELLOW + "+10 Oxygen",
+            4,
+            1,
+            Material.GLASS_BOTTLE
+    ),
+    OXYGEN_EFFICIENCY_I(
+            "Oxygen Efficiency I",
+            ChatColor.GRAY + "Reduce oxygen consumption",
+            ChatColor.YELLOW + "-1% Oxygen Depletion Rate",
+            5,
+            1,
+            Material.PAPER
+    ),
+    REST(
+            "Rest",
+            ChatColor.GRAY + "Sleeping restores oxygen",
+            ChatColor.YELLOW + "+5% Max Oxygen on sleep",
+            5,
+            1,
+            Material.RED_BED
+    ),
+    BUBBLES_I(
+            "Bubbles I",
+            ChatColor.GRAY + "Chance to spawn oxygen bubbles",
+            ChatColor.YELLOW + "+1% Bubble spawn chance",
+            5,
+            1,
+            Material.SLIME_BALL
+    ),
+
+    OXYGEN_II(
+            "Oxygen II",
+            ChatColor.GRAY + "Further increase your oxygen reserves",
+            ChatColor.YELLOW + "+20 Oxygen",
+            6,
+            20,
+            Material.GLASS_BOTTLE
+    ),
+    OXYGEN_EFFICIENCY_II(
+            "Oxygen Efficiency II",
+            ChatColor.GRAY + "Reduce oxygen consumption",
+            ChatColor.YELLOW + "-1% Oxygen Depletion Rate",
+            5,
+            20,
+            Material.PAPER
+    ),
+    ANCIENT_DEBRIS(
+            "Ancient Debris",
+            ChatColor.GRAY + "Chance for masterwork ingots",
+            ChatColor.YELLOW + "+0.10% Masterwork Ingot Chance",
+            4,
+            20,
+            Material.ANCIENT_DEBRIS
+    ),
+    BUBBLES_II(
+            "Bubbles II",
+            ChatColor.GRAY + "Chance to spawn oxygen bubbles",
+            ChatColor.YELLOW + "+1% Bubble spawn chance",
+            5,
+            20,
+            Material.SLIME_BALL
+    ),
+
+    OXYGEN_III(
+            "Oxygen III",
+            ChatColor.GRAY + "Greatly increase your oxygen reserves",
+            ChatColor.YELLOW + "+30 Oxygen",
+            8,
+            40,
+            Material.GLASS_BOTTLE
+    ),
+    BIG_BUBBLES_I(
+            "Big Bubbles I",
+            ChatColor.GRAY + "Bubbles restore more oxygen",
+            ChatColor.YELLOW + "+10 Oxygen from bubbles",
+            5,
+            40,
+            Material.SLIME_BLOCK
+    ),
+    OXYGEN_EFFICIENCY_III(
+            "Oxygen Efficiency III",
+            ChatColor.GRAY + "Reduce oxygen consumption",
+            ChatColor.YELLOW + "-1% Oxygen Depletion Rate",
+            5,
+            40,
+            Material.PAPER
+    ),
+    GOLD_FEVER(
+            "Gold Fever",
+            ChatColor.GRAY + "Ignore fatigue at moderate hypoxia",
+            ChatColor.YELLOW + "Removes Mining Fatigue from Moderate Hypoxia",
+            2,
+            40,
+            Material.GOLD_INGOT
+    ),
+    MAGNET(
+            "Magnet",
+            ChatColor.GRAY + "Attract dropped items",
+            ChatColor.YELLOW + "Items within (1*level) blocks collected every (10-level)s",
+            4,
+            40,
+            Material.IRON_INGOT
+    ),
+
+    OXYGEN_IV(
+            "Oxygen IV",
+            ChatColor.GRAY + "Massively increase your oxygen reserves",
+            ChatColor.YELLOW + "+40 Oxygen",
+            10,
+            60,
+            Material.GLASS_BOTTLE
+    ),
+    BIG_BUBBLES_II(
+            "Big Bubbles II",
+            ChatColor.GRAY + "Bubbles restore even more oxygen",
+            ChatColor.YELLOW + "+10 Oxygen from bubbles",
+            5,
+            60,
+            Material.SLIME_BLOCK
+    ),
+    OXYGEN_EFFICIENCY_IV(
+            "Oxygen Efficiency IV",
+            ChatColor.GRAY + "Reduce oxygen consumption",
+            ChatColor.YELLOW + "-1% Oxygen Depletion Rate",
+            5,
+            60,
+            Material.PAPER
+    ),
+    OXYGEN_RESERVE(
+            "Oxygen Reserve",
+            ChatColor.GRAY + "Conserve oxygen when low",
+            ChatColor.YELLOW + "-5% Depletion Rate below 50% Oxygen",
+            4,
+            60,
+            Material.BEACON
+    ),
+    COAL_YIELD(
+            "Coal Yield",
+            ChatColor.GRAY + "Mine extra coal",
+            ChatColor.YELLOW + "+1 Coal per Ore",
+            4,
+            60,
+            Material.COAL
+    ),
+
+    OXYGEN_V(
+            "Oxygen V",
+            ChatColor.GRAY + "Maximize your oxygen reserves",
+            ChatColor.YELLOW + "+50 Oxygen",
+            12,
+            80,
+            Material.GLASS_BOTTLE
+    ),
+    BIG_BUBBLES_III(
+            "Big Bubbles III",
+            ChatColor.GRAY + "Bubbles restore the most oxygen",
+            ChatColor.YELLOW + "+10 Oxygen from bubbles",
+            5,
+            80,
+            Material.SLIME_BLOCK
+    ),
+    OXYGEN_EFFICIENCY_V(
+            "Oxygen Efficiency V",
+            ChatColor.GRAY + "Reduce oxygen consumption",
+            ChatColor.YELLOW + "-1% Oxygen Depletion Rate",
+            5,
+            80,
+            Material.PAPER
+    ),
+    WAKE_UP_THE_STATUES(
+            "Wake Up The Statues",
+            ChatColor.GRAY + "Lessen severe fatigue",
+            ChatColor.YELLOW + "Reduce Severe Hypoxia fatigue by 1",
+            2,
+            80,
+            Material.STONE_PICKAXE
+    ),
+    HEART_OF_THE_MOUNTAIN(
+            "Heart Of The Mountain",
+            ChatColor.GRAY + "Strengthen your pickaxe",
+            ChatColor.YELLOW + "+100 Max Durability to Pickaxes",
+            4,
+            80,
+            Material.DIAMOND_PICKAXE
+    ),
+
+    // =============================================================
     // Terraforming Talents
     // =============================================================
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -332,9 +332,37 @@ public final class TalentRegistry {
                         Talent.ANGLERS_INSTINCT
                )
         );
-              SKILL_TALENTS.put(
+        SKILL_TALENTS.put(
                 Skill.MINING,
                 Arrays.asList(
+                        Talent.OXYGEN_I,
+                        Talent.OXYGEN_EFFICIENCY_I,
+                        Talent.REST,
+                        Talent.BUBBLES_I,
+
+                        Talent.OXYGEN_II,
+                        Talent.OXYGEN_EFFICIENCY_II,
+                        Talent.ANCIENT_DEBRIS,
+                        Talent.BUBBLES_II,
+
+                        Talent.OXYGEN_III,
+                        Talent.BIG_BUBBLES_I,
+                        Talent.OXYGEN_EFFICIENCY_III,
+                        Talent.GOLD_FEVER,
+                        Talent.MAGNET,
+
+                        Talent.OXYGEN_IV,
+                        Talent.BIG_BUBBLES_II,
+                        Talent.OXYGEN_EFFICIENCY_IV,
+                        Talent.OXYGEN_RESERVE,
+                        Talent.COAL_YIELD,
+
+                        Talent.OXYGEN_V,
+                        Talent.BIG_BUBBLES_III,
+                        Talent.OXYGEN_EFFICIENCY_V,
+                        Talent.WAKE_UP_THE_STATUES,
+                        Talent.HEART_OF_THE_MOUNTAIN,
+
                         Talent.RICH_VEINS,
                         Talent.DEEP_LUNGS
                 )


### PR DESCRIPTION
## Summary
- implement Mining skill tree talents and register them
- add dynamic descriptions for new talents

## Testing
- `mvn -q test` *(fails: Plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68871d02ffe88332b7becd3fbff9ac5e