### PR TITLE
Add environment sidebar bars toggle

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -64,6 +64,7 @@ import goat.minecraft.minecraftnew.utils.commands.AuraCommand;
 import goat.minecraft.minecraftnew.utils.commands.ToggleCustomEnchantmentsCommand;
 import goat.minecraft.minecraftnew.utils.commands.StatsCommand;
 import goat.minecraft.minecraftnew.utils.commands.TogglePotionEffectsCommand;
+import goat.minecraft.minecraftnew.utils.commands.ToggleBarsCommand;
 import goat.minecraft.minecraftnew.utils.developercommands.*;
 import goat.minecraft.minecraftnew.utils.developercommands.SetCustomDurabilityCommand;
 import goat.minecraft.minecraftnew.utils.stats.StatsCalculator;
@@ -107,6 +108,7 @@ import goat.minecraft.minecraftnew.other.structureblocks.GetStructureBlockComman
 import goat.minecraft.minecraftnew.other.structureblocks.SetStructureBlockPowerCommand;
 import goat.minecraft.minecraftnew.other.warpgate.WarpGateManager;
 import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentPreferences;
+import goat.minecraft.minecraftnew.other.additionalfunctionality.EnvironmentSidebarPreferences;
 
 import goat.minecraft.minecraftnew.subsystems.music.PigStepArena;
 import goat.minecraft.minecraftnew.other.realms.Tropic;
@@ -393,6 +395,8 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new CustomEnchantmentPreferences(), this);
         PotionEffectPreferences.init(this);
         getServer().getPluginManager().registerEvents(new PotionEffectPreferences(), this);
+        EnvironmentSidebarPreferences.init(this);
+        getServer().getPluginManager().registerEvents(new EnvironmentSidebarPreferences(), this);
 
         forestryPetManager = new ForestryPetManager(this);
 
@@ -721,6 +725,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getCommand("openvillagertrademenu").setExecutor(new OpenVillagerTradeMenuCommand(this));
         getCommand("togglecustomenchantments").setExecutor(new ToggleCustomEnchantmentsCommand(this));
         getCommand("togglepotioneffects").setExecutor(new TogglePotionEffectsCommand(this));
+        getCommand("togglebars").setExecutor(new ToggleBarsCommand());
         getCommand("stripreforge").setExecutor(new StripReforgeCommand());
         getCommand("applyreforge").setExecutor(new ApplyReforgeCommand());
         new SetAmountCommand(this);
@@ -848,6 +853,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         }
         CustomEnchantmentPreferences.saveAll();
         PotionEffectPreferences.saveAll();
+        EnvironmentSidebarPreferences.saveAll();
         BeaconPassivesGUI.saveAllPassives();
         if (CatalystManager.getInstance() != null) {
             CatalystManager.getInstance().shutdown();

--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/ContinuityBoardManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/ContinuityBoardManager.java
@@ -3,6 +3,7 @@ package goat.minecraft.minecraftnew.other.additionalfunctionality;
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.forestry.Forestry;
 import goat.minecraft.minecraftnew.subsystems.mining.PlayerOxygenManager;
+import goat.minecraft.minecraftnew.other.additionalfunctionality.EnvironmentSidebarPreferences;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -67,14 +68,52 @@ public class ContinuityBoardManager implements Listener {
             scoreboard.resetScores(entry);
         }
 
-        // Set scores with ordering (higher score means higher up in the sidebar).
-        objective.getScore(notorietyStr).setScore(4);
-        objective.getScore(saturationStr).setScore(3);
-        objective.getScore(oxygenStr).setScore(2);
-        objective.getScore(temperatureStr).setScore(1);
+        boolean bars = EnvironmentSidebarPreferences.isEnabled(player);
+
+        int line = bars ? 8 : 4;
+        objective.getScore(notorietyStr).setScore(line--);
+        if (bars) {
+            String bar = createBar(notoriety, 700, ChatColor.DARK_RED);
+            objective.getScore(bar).setScore(line--);
+        }
+        objective.getScore(saturationStr).setScore(line--);
+        if (bars) {
+            String bar = createBar(saturation, 20, ChatColor.YELLOW);
+            objective.getScore(bar).setScore(line--);
+        }
+        objective.getScore(oxygenStr).setScore(line--);
+        if (bars) {
+            int maxOxygen = PlayerOxygenManager.getInstance().calculateInitialOxygen(player);
+            String bar = createBar(currentOxygen, maxOxygen, ChatColor.AQUA);
+            objective.getScore(bar).setScore(line--);
+        }
+        objective.getScore(temperatureStr).setScore(line--);
+        if (bars) {
+            String bar = createBar(temperature, 400, ChatColor.RED);
+            objective.getScore(bar).setScore(line--);
+        }
 
         // Re-apply the scoreboard to the player.
         player.setScoreboard(scoreboard);
+    }
+
+    /**
+     * Builds a small progress bar string for the scoreboard.
+     */
+    private String createBar(int current, int max, ChatColor color) {
+        int segments = 10;
+        if (max <= 0) return "";
+        double ratio = Math.min(1.0, (double) current / max);
+        int filled = (int) Math.round(ratio * segments);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < segments; i++) {
+            if (i < filled) {
+                sb.append(color).append('|');
+            } else {
+                sb.append(ChatColor.DARK_GRAY).append('|');
+            }
+        }
+        return sb.toString();
     }
 
     @EventHandler

--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/EnvironmentSidebarPreferences.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/EnvironmentSidebarPreferences.java
@@ -1,0 +1,95 @@
+package goat.minecraft.minecraftnew.other.additionalfunctionality;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Stores per-player preference for displaying environment sidebar values
+ * as numeric values only or with progress bars. Preferences are persisted
+ * to a YAML file.
+ */
+public class EnvironmentSidebarPreferences implements Listener {
+    private static final Map<UUID, Boolean> prefs = new HashMap<>();
+    private static File prefFile;
+    private static FileConfiguration prefConfig;
+
+    /** Initialise the preference manager and load saved data. */
+    public static void init(JavaPlugin plugin) {
+        prefFile = new File(plugin.getDataFolder(), "togglebars.yml");
+        if (!prefFile.exists()) {
+            try {
+                plugin.getDataFolder().mkdirs();
+                prefFile.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        prefConfig = YamlConfiguration.loadConfiguration(prefFile);
+        for (String key : prefConfig.getKeys(false)) {
+            try {
+                UUID id = UUID.fromString(key);
+                boolean enabled = prefConfig.getBoolean(key, false);
+                prefs.put(id, enabled);
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+    }
+
+    /**
+     * Check if environment bars are enabled for the given player.
+     */
+    public static boolean isEnabled(Player player) {
+        return prefs.getOrDefault(player.getUniqueId(), false);
+    }
+
+    /**
+     * Toggle bars for the player and save immediately.
+     *
+     * @return the new state after toggling
+     */
+    public static boolean toggle(Player player) {
+        boolean newVal = !prefs.getOrDefault(player.getUniqueId(), false);
+        prefs.put(player.getUniqueId(), newVal);
+        savePlayer(player.getUniqueId());
+        return newVal;
+    }
+
+    private static void savePlayer(UUID id) {
+        prefConfig.set(id.toString(), prefs.getOrDefault(id, false));
+        try {
+            prefConfig.save(prefFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /** Save all preferences to disk. */
+    public static void saveAll() {
+        for (UUID id : prefs.keySet()) {
+            savePlayer(id);
+        }
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        prefs.computeIfAbsent(event.getPlayer().getUniqueId(),
+                k -> prefConfig.getBoolean(event.getPlayer().getUniqueId().toString(), false));
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        savePlayer(event.getPlayer().getUniqueId());
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/ToggleBarsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/ToggleBarsCommand.java
@@ -1,0 +1,25 @@
+package goat.minecraft.minecraftnew.utils.commands;
+
+import goat.minecraft.minecraftnew.other.additionalfunctionality.EnvironmentSidebarPreferences;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Toggles display of progress bars on the Environment scoreboard for the player.
+ */
+public class ToggleBarsCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players can use this command.");
+            return true;
+        }
+        boolean enabled = EnvironmentSidebarPreferences.toggle(player);
+        player.sendMessage(ChatColor.YELLOW + "Environment bars " + (enabled ? "enabled" : "disabled") + ".");
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -183,6 +183,10 @@ commands:
     description: Toggle your custom potion effects on or off
     usage: /togglepotioneffects
     default: true
+  togglebars:
+    description: Toggle bar display on your Environment sidebar
+    usage: /togglebars
+    default: true
   setskilllevel:
     description: Sets a player's skill level
     usage: /setskilllevel <player> <skill> <level>


### PR DESCRIPTION
## Summary
- add per-player sidebar preference `EnvironmentSidebarPreferences`
- add `/togglebars` command to control displaying bars
- extend scoreboard manager to draw progress bars when enabled
- register preference system and command in plugin
- update plugin.yml

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688861b31a8c83329170b04ff518714c