### PR TITLE
Fix flight bug and add per-player flight time

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/StatsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/StatsCommand.java
@@ -76,7 +76,7 @@ public class StatsCommand implements CommandExecutor, Listener {
         addStatItem(inv, slots[index++], Material.IRON_SWORD, "Damage +%", String.format("%.1f%%", calculator.getDamageIncrease(player)));
         addStatItem(inv, slots[index++], Material.BOW, "Arrow Damage +%", String.format("%.1f%%", calculator.getArrowDamageIncrease(player)));
         addStatItem(inv, slots[index++], Material.SHIELD, "Resistance", String.format("%.1f%%", calculator.getResistance(player)));
-        addStatItem(inv, slots[index++], Material.ELYTRA, "Flight Distance", String.format("%.2f km", calculator.getFlightDistance(player)));
+        addStatItem(inv, slots[index++], Material.ELYTRA, "Flight Time", String.format("%ds", calculator.getFlightTime(player)));
         addStatItem(inv, slots[index++], Material.SOUL_TORCH, "Grave Chance", String.format("%.3f%%", calculator.getGraveChance(player)));
         addStatItem(inv, slots[index++], Material.NAUTILUS_SHELL, "Sea Creature Chance", String.format("%.2f%%", calculator.getSeaCreatureChance(player)));
         addStatItem(inv, slots[index++], Material.CHEST, "Treasure Chance", String.format("%.2f%%", calculator.getTreasureChance(player)));

--- a/src/main/java/goat/minecraft/minecraftnew/utils/stats/StatsCalculator.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/stats/StatsCalculator.java
@@ -128,18 +128,18 @@ public class StatsCalculator {
         return PlayerResistanceManager.getInstance(plugin).computeTotalResistance(player);
     }
 
-    /** Maximum flight distance in km from pet perks and merits. */
-    public double getFlightDistance(Player player) {
+    /** Maximum flight time in seconds from pet perks and merits. */
+    public int getFlightTime(Player player) {
         PetManager.Pet pet = PetManager.getInstance(plugin).getActivePet(player);
-        double distance = 0.0;
+        int seconds = 0;
         if (pet != null && pet.hasPerk(PetManager.PetPerk.FLIGHT)) {
-            distance = pet.getLevel() / 100.0; // scales to 1km at level 100
+            seconds = (int) (pet.getLevel() / 100.0 * 60);
             PlayerMeritManager merits = PlayerMeritManager.getInstance(plugin);
             if (merits.hasPerk(player.getUniqueId(), "Icarus")) {
-                distance *= 2;
+                seconds *= 2;
             }
         }
-        return distance;
+        return seconds;
     }
 
     /** Grave spawning chance from talents and pet traits. */


### PR DESCRIPTION
## Summary
- track flight capability in seconds per player instead of distance
- only allow flight when a catalyst is nearby or the pet has the Flight perk
- reduce remaining flight time each second while flying
- show flight time in the stats command

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688a48d06df0833291d73b207cfcca44