### PR TITLE
Move motion sensor to skill tree

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/qol/Doors.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/qol/Doors.java
@@ -1,7 +1,8 @@
 package goat.minecraft.minecraftnew.other.qol;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
-import goat.minecraft.minecraftnew.utils.devtools.PlayerMeritManager;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
@@ -36,9 +37,12 @@ public class Doors implements Listener {
         if (doorData.isOpen()) {
             return;
         }
-        PlayerMeritManager playerMeritManager = PlayerMeritManager.getInstance(MinecraftNew.getInstance());
         Player player = event.getPlayer();
-        if(playerMeritManager.hasPerk(player.getUniqueId(), "Motion Sensor")) {
+        SkillTreeManager manager = SkillTreeManager.getInstance();
+        Material type = bottomDoorBlock.getType();
+        boolean hasWood = manager.hasTalent(player, Talent.MOTION_SENSOR);
+        boolean hasIron = manager.hasTalent(player, Talent.MOTION_SENSOR_IRON);
+        if((type != Material.IRON_DOOR && hasWood) || (type == Material.IRON_DOOR && hasIron)) {
             openOrCloseDoor(bottomDoorBlock, true);
             playDoorSound(bottomDoorBlock, true);
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -620,6 +620,10 @@ public class SkillTreeManager implements Listener {
                 return ChatColor.YELLOW + "+" + level + " Farming Talent Point";
             case STUDY_FISHING:
                 return ChatColor.YELLOW + "+" + level + " Fishing Talent Point";
+            case MOTION_SENSOR:
+                return ChatColor.YELLOW + "Enables wooden door motion sensor";
+            case MOTION_SENSOR_IRON:
+                return ChatColor.YELLOW + "Enables iron door motion sensor";
             case GRAVE_DIGGER_I:
                 return ChatColor.YELLOW + "+" + String.format("%.3f", level * 0.001) + ChatColor.GRAY + " grave chance";
             case POST_MORTEM_COMPLICATIONS_I:

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -1558,6 +1558,22 @@ public enum Talent {
             80,
             Material.APPLE
     ),
+    MOTION_SENSOR(
+            "Motion Sensor",
+            ChatColor.GRAY + "Automatically open wooden doors",
+            ChatColor.YELLOW + "Enables wooden door motion sensor",
+            1,
+            20,
+            Material.OAK_DOOR
+    ),
+    MOTION_SENSOR_IRON(
+            "Iron Motion Sensor",
+            ChatColor.GRAY + "Extend motion sensor to iron doors",
+            ChatColor.YELLOW + "Enables iron door motion sensor",
+            1,
+            40,
+            Material.IRON_DOOR
+    ),
     BOUNTIFUL_HARVEST(
             "Bountiful Harvest",
             ChatColor.GRAY + "Increases chances for extra crops",

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -259,7 +259,9 @@ public final class TalentRegistry {
                         Talent.HEALTH_II,
                         Talent.HEALTH_III,
                         Talent.HEALTH_IV,
-                        Talent.HEALTH_V
+                        Talent.HEALTH_V,
+                        Talent.MOTION_SENSOR,
+                        Talent.MOTION_SENSOR_IRON
                 )
         );
         SKILL_TALENTS.put(

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/MeritCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/MeritCommand.java
@@ -72,11 +72,6 @@ public class MeritCommand implements CommandExecutor, Listener {
                             ChatColor.GRAY + "Allows opening Shulker Boxes only inside backpacks.",
                             ChatColor.BLUE + "Right Click Shulker Box in Backpack: " + ChatColor.GRAY + "Opens it."
                     )),
-            new Perk(ChatColor.DARK_GRAY + "Motion Sensor", 1, Material.OAK_DOOR,
-                    Arrays.asList(
-                            ChatColor.GRAY + "Enables Autoclose doors.",
-                            ChatColor.BLUE + "On Left Click Door: " + ChatColor.GRAY + "Opens doors for 2 seconds."
-                    )),
             new Perk(ChatColor.DARK_GRAY + "QuickSwap", 3, Material.TRIPWIRE_HOOK,
                     Arrays.asList(
                             ChatColor.GRAY + "Replenishes your supply of blocks.",


### PR DESCRIPTION
## Summary
- drop the old Motion Sensor merit perk
- add Motion Sensor and Iron Motion Sensor talents to the Player skill
- expose new talents in the skill registry
- show descriptions for the new talents
- open doors using the talent instead of a merit perk

## Testing
- `mvn -q test` *(fails: Could not resolve plugin due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688a4ab6f69483329181472aa9dd2a90