### PR TITLE
Add player merit talents

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -845,6 +845,17 @@ public class SkillTreeManager implements Listener {
                 return ChatColor.YELLOW + "+" + (level * 5) + "% Discount";
             case QUIRKY:
                 return ChatColor.YELLOW + "+" + (level * 20) + "% Trait Effect";
+            case SHULKL_BOX:
+                return ChatColor.YELLOW + "Right Click in Backpack: " + ChatColor.GRAY + "Opens box";
+            case QUICKSWAP:
+                return ChatColor.YELLOW + "Refills block stack when placing";
+            case RESTOCK:
+                return ChatColor.YELLOW + "Grants one arrow when empty";
+            case KEEP_INVENTORY:
+                int keepChance = level * 10;
+                return ChatColor.YELLOW + "+" + keepChance + "% chance to keep inventory";
+            case TUXEDO:
+                return ChatColor.YELLOW + "Displays two extra auction items";
             case NATURAL_SELECTION:
                 return ChatColor.YELLOW + "Removes lowest rarity";
             default:

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -1558,6 +1558,46 @@ public enum Talent {
             80,
             Material.APPLE
     ),
+    SHULKL_BOX(
+            "Shulkl Box",
+            ChatColor.GRAY + "Open shulker boxes inside backpacks",
+            ChatColor.YELLOW + "Right Click in Backpack: " + ChatColor.GRAY + "Opens box",
+            1,
+            40,
+            Material.SHULKER_SHELL
+    ),
+    QUICKSWAP(
+            "QuickSwap",
+            ChatColor.GRAY + "Replenish blocks when placing",
+            ChatColor.YELLOW + "Uses matching stack from inventory",
+            1,
+            1,
+            Material.TRIPWIRE_HOOK
+    ),
+    RESTOCK(
+            "Restock",
+            ChatColor.GRAY + "Grants an arrow when empty",
+            ChatColor.YELLOW + "On bow use with no arrows",
+            1,
+            1,
+            Material.ARROW
+    ),
+    KEEP_INVENTORY(
+            "Keepinventory",
+            ChatColor.GRAY + "Chance to keep items on death",
+            ChatColor.YELLOW + "+(10*level)% Chance to keep inventory",
+            10,
+            1,
+            Material.CHEST
+    ),
+    TUXEDO(
+            "Tuxedo",
+            ChatColor.GRAY + "Displays two extra auction items",
+            ChatColor.YELLOW + "Bonus items with rare rewards",
+            1,
+            60,
+            Material.BLACK_WOOL
+    ),
     BOUNTIFUL_HARVEST(
             "Bountiful Harvest",
             ChatColor.GRAY + "Increases chances for extra crops",

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -259,7 +259,12 @@ public final class TalentRegistry {
                         Talent.HEALTH_II,
                         Talent.HEALTH_III,
                         Talent.HEALTH_IV,
-                        Talent.HEALTH_V
+                        Talent.HEALTH_V,
+                        Talent.SHULKL_BOX,
+                        Talent.QUICKSWAP,
+                        Talent.RESTOCK,
+                        Talent.KEEP_INVENTORY,
+                        Talent.TUXEDO
                 )
         );
         SKILL_TALENTS.put(


### PR DESCRIPTION
## Summary
- add player merit perks as new talents: Shulkl Box, QuickSwap, Restock, Keepinventory and Tuxedo
- register these new talents for the Player skill
- display dynamic effects for the new talents

## Testing
- `mvn -q test` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_688a4b6682a88332a052af86cc9585e2