### PR TITLE
Limit Feather Falling to boots and nerf fall protections

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -510,6 +510,8 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new Spectral(this), this);
         getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.pets.perks.Revenant(this), this);
         getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.other.qol.FastAscend(), this);
+        // Nerf Feather Falling and Protection against fall damage
+        getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.other.resistance.FallDamageNerfListener(), this);
 
         this.getCommand("givecustomitem").setExecutor(new GiveCustomItem());
         this.getCommand("i").setExecutor(new ItemCommand());

--- a/src/main/java/goat/minecraft/minecraftnew/other/resistance/FallDamageNerfListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/resistance/FallDamageNerfListener.java
@@ -1,0 +1,47 @@
+package goat.minecraft.minecraftnew.other.resistance;
+
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Listener that reduces the effectiveness of Protection and Feather Falling
+ * enchantments against fall damage. Any player wearing gear with these
+ * enchantments will take roughly 50% more fall damage.
+ */
+public class FallDamageNerfListener implements Listener {
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onPlayerFall(EntityDamageEvent event) {
+        if (event.getCause() != EntityDamageEvent.DamageCause.FALL) {
+            return;
+        }
+        if (!(event.getEntity() instanceof Player player)) {
+            return;
+        }
+
+        boolean hasFeather = false;
+        boolean hasProtection = false;
+
+        ItemStack boots = player.getInventory().getBoots();
+        if (boots != null && boots.containsEnchantment(Enchantment.FEATHER_FALLING)) {
+            hasFeather = true;
+        }
+
+        for (ItemStack armorPiece : player.getInventory().getArmorContents()) {
+            if (armorPiece != null && armorPiece.containsEnchantment(Enchantment.PROTECTION_ENVIRONMENTAL)) {
+                hasProtection = true;
+                break;
+            }
+        }
+
+        if (hasFeather || hasProtection) {
+            double damage = event.getDamage();
+            event.setDamage(damage * 1.5);
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
@@ -378,6 +378,16 @@ public class AnvilRepair implements Listener {
             Material.NETHERITE_HELMET, Material.NETHERITE_CHESTPLATE,
             Material.NETHERITE_LEGGINGS, Material.NETHERITE_BOOTS
     );
+
+    // Boots only subset used for boot-specific enchantments like Feather Falling
+    public static final Set<Material> BOOTS_ONLY = EnumSet.of(
+            Material.LEATHER_BOOTS,
+            Material.IRON_BOOTS,
+            Material.CHAINMAIL_BOOTS,
+            Material.GOLDEN_BOOTS,
+            Material.DIAMOND_BOOTS,
+            Material.NETHERITE_BOOTS
+    );
     /**
      * Finds the nearest anvil block around the player within a given radius.
      *
@@ -898,7 +908,7 @@ public class AnvilRepair implements Listener {
 
             player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
             return;
-        }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Humid Bark") && ARMOR.contains(repairee.getType())){
+        }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Humid Bark") && BOOTS_ONLY.contains(repairee.getType())){
             incrementEnchantment(player, repairee, billItem,Enchantment.FEATHER_FALLING);
 
             player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
@@ -1306,7 +1316,7 @@ public class AnvilRepair implements Listener {
 
             player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
             return;
-        }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Feather Falling Expertise")&& ARMOR.contains(repairee.getType())){
+        }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Feather Falling Expertise")&& BOOTS_ONLY.contains(repairee.getType())){
             incrementEnchantmentUnsafely(player, repairee, billItem, Enchantment.FEATHER_FALLING);
 
             player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);


### PR DESCRIPTION
## Summary
- reduce the effect of Protection and Feather Falling on fall damage
- restrict Feather Falling enchantment to boots in the anvil
- register new fall damage nerf listener

## Testing
- `mvn -q -DskipTests=false test` *(fails: maven dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_688a4d014a5c8332984ad8a56645a1c3