### PR TITLE
Rename /pet command to /pets

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -519,7 +519,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         // Register events
         getServer().getPluginManager().registerEvents(petManager, this);
         // Register commands
-        getCommand("pet").setExecutor((sender, command, label, args) -> {
+        getCommand("pets").setExecutor((sender, command, label, args) -> {
             if (!(sender instanceof org.bukkit.entity.Player)) {
                 sender.sendMessage("Only players can use this command.");
                 return true;

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetCommand.java
@@ -23,7 +23,7 @@ public class PetCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
 
-        if (label.equalsIgnoreCase("pet")) {
+        if (label.equalsIgnoreCase("pets")) {
             if (!(sender instanceof Player)) {
                 sender.sendMessage("Only players can use this command.");
                 return true;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -125,7 +125,7 @@ commands:
     description: lol
   getpet:
     description: lol
-  pet:
+  pets:
     description: Opens the pet GUI.
     default: true
   setpetlevel:


### PR DESCRIPTION
## Summary
- rename `/pet` command to `/pets`
- update plugin configuration and command checks accordingly

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688a4da52b6c8332a77b3d9919f69c3b