### PR TITLE
Restore flight time near catalysts

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/beacon/FlightCatalystListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/beacon/FlightCatalystListener.java
@@ -13,6 +13,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Logger;
 
+import goat.minecraft.minecraftnew.subsystems.pets.perks.Flight;
+
 /**
  * Listener for handling Flight Catalyst creative flight abilities.
  * Grants creative flight to players within range of Flight catalysts.
@@ -51,6 +53,14 @@ public class FlightCatalystListener implements Listener {
                 UUID playerId = player.getUniqueId();
                 boolean nearFlightCatalyst = catalystManager.isNearCatalyst(player.getLocation(), CatalystType.FLIGHT);
                 boolean hadCatalystFlight = playersWithCatalystFlight.contains(playerId);
+
+                // Restore flight time while within range
+                if (nearFlightCatalyst) {
+                    Flight flight = Flight.getInstance();
+                    if (flight != null) {
+                        flight.restoreFlightSeconds(player, 1); // 1s every 0.5s => 2s per second
+                    }
+                }
                 
                 // Player entered catalyst range
                 if (nearFlightCatalyst && !hadCatalystFlight && player.getGameMode() != GameMode.CREATIVE && player.getGameMode() != GameMode.SPECTATOR) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/Flight.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/Flight.java
@@ -22,6 +22,9 @@ import java.util.UUID;
 
 public class Flight implements Listener {
 
+    // Singleton instance for access from other systems
+    private static Flight instance;
+
     private static final int MAX_FLIGHT_SECONDS_AT_LEVEL_100 = 60; // Max flight time at level 100 in seconds
     private static final int DRAIN_RATE_PER_SECOND = 1; // Drain rate in seconds
     private static final int TICKS_PER_SECOND = 20; // Number of ticks in one second
@@ -34,6 +37,30 @@ public class Flight implements Listener {
     public Flight(JavaPlugin plugin) {
         this.petManager = PetManager.getInstance(plugin);
         this.plugin = plugin;
+
+        // store instance for global access
+        instance = this;
+    }
+
+    /**
+     * Gets the active Flight instance.
+     */
+    public static Flight getInstance() {
+        return instance;
+    }
+
+    /**
+     * Restores a number of flown seconds for the given player.
+     * @param player the player whose flight time should be restored
+     * @param seconds amount of seconds to restore
+     */
+    public void restoreFlightSeconds(Player player, int seconds) {
+        if (seconds <= 0) return;
+
+        UUID playerId = player.getUniqueId();
+        int flown = dailyFlightTracker.getOrDefault(playerId, 0);
+        flown = Math.max(0, flown - seconds);
+        dailyFlightTracker.put(playerId, flown);
     }
 
     @EventHandler


### PR DESCRIPTION
## Summary
- add singleton access to `Flight` perk and expose method to restore flight time
- make `FlightCatalystListener` restore flight seconds when near a flight catalyst

## Testing
- `mvn -q -e -DskipTests package` *(fails: could not resolve maven-resources-plugin)*
- `mvn -q test` *(fails: could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_688a4dde3310833299b37c852bc64e98