### PR TITLE
Add dragon eye placement tracking

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -109,6 +109,7 @@ import goat.minecraft.minecraftnew.other.structureblocks.SetStructureBlockPowerC
 import goat.minecraft.minecraftnew.other.warpgate.WarpGateManager;
 import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentPreferences;
 import goat.minecraft.minecraftnew.other.additionalfunctionality.EnvironmentSidebarPreferences;
+import goat.minecraft.minecraftnew.subsystems.dragons.DragonFightManager;
 
 import goat.minecraft.minecraftnew.subsystems.music.PigStepArena;
 import goat.minecraft.minecraftnew.other.realms.Tropic;
@@ -141,6 +142,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
     private ShelfManager shelfManager;
     private DoubleEnderchest doubleEnderchest;
     private WarpGateManager warpGateManager;
+    private DragonFightManager dragonFightManager;
     private BeaconPassiveEffects beaconPassiveEffects;
     private MonolithSetBonus monolithSetBonus;
     private DuskbloodSetBonus duskbloodSetBonus;
@@ -214,6 +216,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
 
         this.shelfManager = new ShelfManager(this);
         this.warpGateManager = new WarpGateManager(this);
+        this.dragonFightManager = new DragonFightManager(this);
 
 
         Tropic tropicCommand = new Tropic(this);
@@ -765,6 +768,9 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         }
         if (warpGateManager != null) {
             warpGateManager.onDisable();
+        }
+        if (dragonFightManager != null) {
+            dragonFightManager.onDisable();
         }
         if(potionBrewingSubsystem != null){
             potionBrewingSubsystem.onDisable();

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/DragonFightManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/DragonFightManager.java
@@ -1,0 +1,182 @@
+package goat.minecraft.minecraftnew.subsystems.dragons;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import goat.minecraft.minecraftnew.MinecraftNew;
+import org.bukkit.*;
+import org.bukkit.block.data.type.EndPortalFrame;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.profile.PlayerProfile;
+import org.bukkit.profile.PlayerTextures;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+public class DragonFightManager implements Listener {
+
+    private static final String EYE_TEXTURE = "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTk4YTQ5Y2E1NGMzZWE2N2E4NmVjOGI5ZjE2YmRmNDZhYTVlZmM1YWVlZmI3YTE5Y2NjYzc5NjJlODIxYTU5OSJ9fX0=";
+    private final MinecraftNew plugin;
+    private final File gatewaysFile;
+    private final YamlConfiguration gatewaysConfig;
+    private final Map<Location, Integer> portalEyeCounts = new HashMap<>();
+
+    public DragonFightManager(MinecraftNew plugin) {
+        this.plugin = plugin;
+        gatewaysFile = new File(plugin.getDataFolder(), "gateways.yml");
+        if (!gatewaysFile.exists()) {
+            try {
+                gatewaysFile.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        gatewaysConfig = YamlConfiguration.loadConfiguration(gatewaysFile);
+        loadData();
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    private void loadData() {
+        var section = gatewaysConfig.getConfigurationSection("gateways");
+        if (section == null) return;
+        for (String key : section.getKeys(false)) {
+            Location loc = parseLocationKey(key);
+            if (loc != null) {
+                portalEyeCounts.put(loc, section.getInt(key));
+            }
+        }
+    }
+
+    private Location parseLocationKey(String key) {
+        String[] parts = key.split("_");
+        if (parts.length != 4) return null;
+        World world = Bukkit.getWorld(parts[0]);
+        if (world == null) return null;
+        int x = Integer.parseInt(parts[1]);
+        int y = Integer.parseInt(parts[2]);
+        int z = Integer.parseInt(parts[3]);
+        return new Location(world, x, y, z);
+    }
+
+    private String locationKey(Location loc) {
+        return loc.getWorld().getName() + "_" + loc.getBlockX() + "_" + loc.getBlockY() + "_" + loc.getBlockZ();
+    }
+
+    public void onDisable() {
+        saveData();
+    }
+
+    private void saveData() {
+        gatewaysConfig.set("gateways", null);
+        for (Map.Entry<Location, Integer> entry : portalEyeCounts.entrySet()) {
+            gatewaysConfig.set("gateways." + locationKey(entry.getKey()), entry.getValue());
+        }
+        try {
+            gatewaysConfig.save(gatewaysFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @EventHandler
+    public void onPlayerPlaceEye(PlayerInteractEvent e) {
+        if (e.getAction() != Action.RIGHT_CLICK_BLOCK) return;
+        if (e.getClickedBlock() == null) return;
+        if (e.getClickedBlock().getType() != Material.END_PORTAL_FRAME) return;
+        ItemStack item = e.getItem();
+        if (item == null || item.getType() != Material.ENDER_EYE) return;
+        Player player = e.getPlayer();
+        int before = item.getAmount();
+        EquipmentSlot slot = e.getHand();
+        Location blockLoc = e.getClickedBlock().getLocation();
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            ItemStack afterStack = slot == EquipmentSlot.HAND ? player.getInventory().getItemInMainHand() : player.getInventory().getItemInOffHand();
+            int after = afterStack != null && afterStack.getType() == Material.ENDER_EYE ? afterStack.getAmount() : 0;
+            EndPortalFrame frame = (EndPortalFrame) blockLoc.getBlock().getBlockData();
+            boolean placed = before - 1 == after && frame.hasEye();
+            if (placed) {
+                Location portalLoc = findPortal(blockLoc);
+                portalEyeCounts.put(portalLoc, portalEyeCounts.getOrDefault(portalLoc, 0) + 1);
+                saveData();
+                Bukkit.broadcastMessage(ChatColor.DARK_PURPLE + "An Eye of Ender was placed! Total: " + portalEyeCounts.get(portalLoc));
+                blockLoc.getWorld().playSound(blockLoc, Sound.ENTITY_ENDER_DRAGON_GROWL, 1f, 1f);
+                blockLoc.getWorld().spawnParticle(Particle.DRAGON_BREATH, blockLoc.clone().add(0.5, 1, 0.5), 100, 0.3, 0.3, 0.3, 0.01);
+                spawnFallingEye(blockLoc);
+            }
+        }, 1L);
+    }
+
+    private Location findPortal(Location loc) {
+        for (Location stored : portalEyeCounts.keySet()) {
+            if (stored.getWorld().equals(loc.getWorld()) && stored.distanceSquared(loc) <= 400) {
+                return stored;
+            }
+        }
+        return new Location(loc.getWorld(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
+    }
+
+    private void spawnFallingEye(Location frameLoc) {
+        Location start = frameLoc.clone().add(0.5, 1.5, 0.5);
+        ArmorStand stand = (ArmorStand) frameLoc.getWorld().spawnEntity(start, EntityType.ARMOR_STAND);
+        stand.setInvisible(true);
+        stand.setMarker(true);
+        stand.setGravity(false);
+        stand.getEquipment().setHelmet(createEyeSkull());
+        new BukkitRunnable() {
+            int ticks = 0;
+            @Override
+            public void run() {
+                if (!stand.isValid()) { cancel(); return; }
+                stand.getWorld().spawnParticle(Particle.DRAGON_BREATH, stand.getLocation(), 5, 0.1, 0.1, 0.1, 0.01);
+                stand.teleport(stand.getLocation().subtract(0, 0.1, 0));
+                ticks++;
+                if (ticks >= 10) {
+                    stand.remove();
+                    cancel();
+                }
+            }
+        }.runTaskTimer(plugin, 0L, 1L);
+    }
+
+    private ItemStack createEyeSkull() {
+        ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+        SkullMeta meta = (SkullMeta) head.getItemMeta();
+        setCustomSkullTexture(meta, EYE_TEXTURE);
+        head.setItemMeta(meta);
+        return head;
+    }
+
+    private SkullMeta setCustomSkullTexture(SkullMeta skullMeta, String base64Json) {
+        if (skullMeta == null || base64Json == null || base64Json.isEmpty()) {
+            return skullMeta;
+        }
+        try {
+            byte[] decoded = Base64.getDecoder().decode(base64Json);
+            String json = new String(decoded, StandardCharsets.UTF_8);
+            JsonObject root = JsonParser.parseString(json).getAsJsonObject();
+            String urlText = root.getAsJsonObject("textures").getAsJsonObject("SKIN").get("url").getAsString();
+            PlayerProfile profile = Bukkit.createPlayerProfile(UUID.randomUUID());
+            PlayerTextures textures = profile.getTextures();
+            textures.setSkin(new URL(urlText), PlayerTextures.SkinModel.CLASSIC);
+            profile.setTextures(textures);
+            skullMeta.setOwnerProfile(profile);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+        return skullMeta;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add DragonFightManager subsystem to track and animate End Portal eye placements
- persist portal eye counts in gateways.yml and group frames within 20 blocks
- wire manager into main plugin lifecycle

## Testing
- `mvn -q -e -DskipTests package` *(failed: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688d88d2acfc8332bb6b5dfb2bb94537