### PR TITLE
Add farming harvest reward items and rolling system

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/FarmingEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/FarmingEvent.java
@@ -209,6 +209,9 @@ public class FarmingEvent implements Listener {
 
             }
 
+            // Roll for custom harvest rewards (seeders, smithing items, pets)
+            handleHarvestRewards(block, player, blockType);
+
             handleRareItemDrop(block, player, blockType);
         }
     }
@@ -238,7 +241,119 @@ public class FarmingEvent implements Listener {
                             && name.contains(ChatColor.GOLD + "Festival");
                 })
                 .count();
+
+    private void handleHarvestRewards(Block block, Player player, Material blockType) {
+        double roll = random.nextDouble();
+        Location dropLoc = block.getLocation().add(0.5, 0.5, 0.5);
+
+        switch (blockType) {
+            case WHEAT -> {
+                if (roll < 0.50) {
+                    block.getWorld().dropItemNaturally(dropLoc, ItemRegistry.getWheatSeeder());
+                } else if (roll < 0.80) {
+                    ItemStack item = ItemRegistry.getWheatSeeder();
+                    item.setAmount(4);
+                    block.getWorld().dropItemNaturally(dropLoc, item);
+                } else if (roll < 0.90) {
+                    block.getWorld().dropItemNaturally(dropLoc, ItemRegistry.getEnchantedHayBale());
+                } else if (roll < 0.975) {
+                    ItemStack item = ItemRegistry.getEnchantedHayBale();
+                    item.setAmount(4);
+                    block.getWorld().dropItemNaturally(dropLoc, item);
+                } else {
+                    player.sendMessage(ChatColor.GOLD + "You got the Scarecrow pet!");
+                }
+            }
+            case CARROTS -> {
+                if (roll < 0.50) {
+                    block.getWorld().dropItemNaturally(dropLoc, ItemRegistry.getCarrotSeeder());
+                } else if (roll < 0.80) {
+                    ItemStack item = ItemRegistry.getCarrotSeeder();
+                    item.setAmount(4);
+                    block.getWorld().dropItemNaturally(dropLoc, item);
+                } else if (roll < 0.90) {
+                    block.getWorld().dropItemNaturally(dropLoc, ItemRegistry.getEnchantedGoldenCarrot());
+                } else if (roll < 0.975) {
+                    ItemStack item = ItemRegistry.getEnchantedGoldenCarrot();
+                    item.setAmount(4);
+                    block.getWorld().dropItemNaturally(dropLoc, item);
+                } else {
+                    player.sendMessage(ChatColor.GOLD + "You got the Killer Rabbit pet!");
+                }
+            }
+            case BEETROOTS -> {
+                if (roll < 0.50) {
+                    block.getWorld().dropItemNaturally(dropLoc, ItemRegistry.getBeetrootSeeder());
+                } else if (roll < 0.80) {
+                    ItemStack item = ItemRegistry.getBeetrootSeeder();
+                    item.setAmount(4);
+                    block.getWorld().dropItemNaturally(dropLoc, item);
+                } else if (roll < 0.90) {
+                    block.getWorld().dropItemNaturally(dropLoc, ItemRegistry.getHeartRoot());
+                } else if (roll < 0.975) {
+                    ItemStack item = ItemRegistry.getHeartRoot();
+                    item.setAmount(4);
+                    block.getWorld().dropItemNaturally(dropLoc, item);
+                } else {
+                    player.sendMessage(ChatColor.GOLD + "You got the Baron pet!");
+                }
+            }
+            case POTATOES -> {
+                if (roll < 0.50) {
+                    block.getWorld().dropItemNaturally(dropLoc, ItemRegistry.getPotatoSeeder());
+                } else if (roll < 0.80) {
+                    ItemStack item = ItemRegistry.getPotatoSeeder();
+                    item.setAmount(4);
+                    block.getWorld().dropItemNaturally(dropLoc, item);
+                } else if (roll < 0.90) {
+                    block.getWorld().dropItemNaturally(dropLoc, ItemRegistry.getImmortalPotato());
+                } else if (roll < 0.975) {
+                    ItemStack item = ItemRegistry.getImmortalPotato();
+                    item.setAmount(4);
+                    block.getWorld().dropItemNaturally(dropLoc, item);
+                } else {
+                    player.sendMessage(ChatColor.GOLD + "You got the Mole pet!");
+                }
+            }
+            case MELON -> {
+                if (roll < 0.50) {
+                    ItemStack item = new ItemStack(Material.MELON_SLICE, 16);
+                    block.getWorld().dropItemNaturally(dropLoc, item);
+                } else if (roll < 0.80) {
+                    ItemStack item = new ItemStack(Material.MELON_SLICE, 64);
+                    block.getWorld().dropItemNaturally(dropLoc, item);
+                } else if (roll < 0.90) {
+                    block.getWorld().dropItemNaturally(dropLoc, ItemRegistry.getWatermelon());
+                } else if (roll < 0.975) {
+                    ItemStack item = ItemRegistry.getWatermelon();
+                    item.setAmount(4);
+                    block.getWorld().dropItemNaturally(dropLoc, item);
+                } else {
+                    block.getWorld().dropItemNaturally(dropLoc, ItemRegistry.getWorldsLargestWatermelon());
+                }
+            }
+            case PUMPKIN -> {
+                if (roll < 0.50) {
+                    ItemStack item = new ItemStack(Material.PUMPKIN, 16);
+                    block.getWorld().dropItemNaturally(dropLoc, item);
+                } else if (roll < 0.80) {
+                    ItemStack item = new ItemStack(Material.PUMPKIN, 64);
+                    block.getWorld().dropItemNaturally(dropLoc, item);
+                } else if (roll < 0.90) {
+                    block.getWorld().dropItemNaturally(dropLoc, ItemRegistry.getJackOLantern());
+                } else if (roll < 0.975) {
+                    ItemStack item = ItemRegistry.getJackOLantern();
+                    item.setAmount(4);
+                    block.getWorld().dropItemNaturally(dropLoc, item);
+                } else {
+                    block.getWorld().dropItemNaturally(dropLoc, ItemRegistry.getWorldsLargestPumpkin());
+                }
+            }
+            default -> {
+            }
+        }
     }
+
     /**
      * Handles the rare item drop for eligible crops with a 1/400 chance.
      *

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -2840,6 +2840,67 @@ public class ItemRegistry {
                 false   // Add enchantment shimmer
         );
     }
+
+    /** Smithing item used to enhance wheat harvests. */
+    public static ItemStack getEnchantedHayBale() {
+        return createCustomItem(
+                Material.HAY_BLOCK,
+                ChatColor.YELLOW + "Enchanted Hay Bale",
+                Arrays.asList(
+                        ChatColor.GRAY + "Adds one level of Cornfield.",
+                        ChatColor.DARK_PURPLE + "Smithing Item"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
+    /** Smithing item used to enhance carrot harvests. */
+    public static ItemStack getEnchantedGoldenCarrot() {
+        return createCustomItem(
+                Material.GOLDEN_CARROT,
+                ChatColor.YELLOW + "Enchanted Golden Carrot",
+                Arrays.asList(
+                        ChatColor.GRAY + "Adds one level of What's Up Doc.",
+                        ChatColor.DARK_PURPLE + "Smithing Item"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
+    /** Smithing item used to enhance beetroot harvests. */
+    public static ItemStack getHeartRoot() {
+        return createCustomItem(
+                Material.BEETROOT,
+                ChatColor.YELLOW + "HeartRoot",
+                Arrays.asList(
+                        ChatColor.GRAY + "Adds one level of Venerate.",
+                        ChatColor.DARK_PURPLE + "Smithing Item"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
+    /** Smithing item used to enhance potato harvests. */
+    public static ItemStack getImmortalPotato() {
+        return createCustomItem(
+                Material.POTATO,
+                ChatColor.YELLOW + "Immortal Potato",
+                Arrays.asList(
+                        ChatColor.GRAY + "Adds one level of Legend.",
+                        ChatColor.DARK_PURPLE + "Smithing Item"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
     public static ItemStack getCalamari() {
         return createCustomItem(
                 Material.INK_SAC,
@@ -4587,6 +4648,36 @@ public class ItemRegistry {
                 Arrays.asList(
                         ChatColor.GRAY + "Adds one level of Clean Cut.",
                         ChatColor.DARK_PURPLE + "Smithing Item"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
+    /** Legendary melon artifact. */
+    public static ItemStack getWorldsLargestWatermelon() {
+        return createCustomItem(
+                Material.MELON,
+                ChatColor.GOLD + "World's Largest Watermelon™",
+                Arrays.asList(
+                        ChatColor.GRAY + "It's bigger than your head.",
+                        ChatColor.DARK_PURPLE + "Artifact"
+                ),
+                1,
+                false,
+                true
+        );
+    }
+
+    /** Legendary pumpkin artifact. */
+    public static ItemStack getWorldsLargestPumpkin() {
+        return createCustomItem(
+                Material.PUMPKIN,
+                ChatColor.GOLD + "World's Largest Pumpkin™",
+                Arrays.asList(
+                        ChatColor.GRAY + "A gargantuan gourd.",
+                        ChatColor.DARK_PURPLE + "Artifact"
                 ),
                 1,
                 false,


### PR DESCRIPTION
## Summary
- add Enchanted Hay Bale, Enchanted Golden Carrot, HeartRoot, Immortal Potato, and legendary melon/pumpkin artifacts to the item registry
- implement weighted harvest reward rolls for crops and trophies, with placeholder pet messages on legendary rolls

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688dbfe4ad4c8332b9926964d3f9a2ee