### PR TITLE
Implement crop double-count enchantments and mass murderer artifacts

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -700,6 +700,12 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         CustomEnchantmentManager.registerEnchantment("Velocity", 3, true);
         CustomEnchantmentManager.registerEnchantment("Defenestration", 1, true);
         CustomEnchantmentManager.registerEnchantment("Lynch", 4, true);
+        CustomEnchantmentManager.registerEnchantment("Cornfield", 10, true);
+        CustomEnchantmentManager.registerEnchantment("What's Up Doc", 10, true);
+        CustomEnchantmentManager.registerEnchantment("Venerate", 10, true);
+        CustomEnchantmentManager.registerEnchantment("Legend", 10, true);
+        CustomEnchantmentManager.registerEnchantment("Clean Cut", 10, true);
+        CustomEnchantmentManager.registerEnchantment("Gourd", 10, true);
 
 
         getServer().getPluginManager().registerEvents(new KnightMob(this), this);

--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/RightClickArtifacts.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/RightClickArtifacts.java
@@ -11,6 +11,7 @@ import goat.minecraft.minecraftnew.utils.biomeutils.StructureUtils;
 import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
 import goat.minecraft.minecraftnew.utils.devtools.VillagerNameRepository;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import goat.minecraft.minecraftnew.subsystems.gravedigging.corpses.CorpseEvent;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -761,6 +762,16 @@ public class RightClickArtifacts implements Listener {
             if (displayName.equals(ChatColor.YELLOW + "Iron Golem")) {
                 player.playSound(player.getLocation(), Sound.ENTITY_IRON_GOLEM_DEATH, 1.0f, 1.0f);
                 player.getWorld().spawnEntity(player.getLocation(), EntityType.IRON_GOLEM);
+                decrementItemAmount(itemInHand, player);
+                return;
+            }
+            if (displayName.equals(ChatColor.GOLD + "World's Largest Watermelon™")) {
+                new CorpseEvent(MinecraftNew.getInstance()).triggerLegendary(player.getLocation());
+                decrementItemAmount(itemInHand, player);
+                return;
+            }
+            if (displayName.equals(ChatColor.GOLD + "World's Largest Pumpkin™")) {
+                new CorpseEvent(MinecraftNew.getInstance()).triggerLegendary(player.getLocation());
                 decrementItemAmount(itemInHand, player);
                 return;
             }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/FarmingEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/FarmingEvent.java
@@ -12,6 +12,7 @@ import goat.minecraft.minecraftnew.subsystems.farming.FestivalBeeManager;
 import goat.minecraft.minecraftnew.subsystems.farming.CropCountManager;
 import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
+import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentManager;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.Ageable;
@@ -127,6 +128,60 @@ public class FarmingEvent implements Listener {
                     blockType == Material.BEETROOTS || blockType == Material.PUMPKIN ||
                     blockType == Material.MELON || blockType == Material.COCOA) {
                 harvest = CropCountManager.getInstance(plugin).increment(player, blockType);
+
+                ItemStack tool = player.getInventory().getItemInMainHand();
+                switch (blockType) {
+                    case WHEAT, WHEAT_SEEDS -> {
+                        int level = CustomEnchantmentManager.getEnchantmentLevel(tool, "Cornfield");
+                        if (level > 0 && random.nextDouble() < level * 0.10) {
+                            if (CropCountManager.getInstance(plugin).increment(player, blockType)) {
+                                harvest = true;
+                            }
+                        }
+                    }
+                    case CARROTS -> {
+                        int level = CustomEnchantmentManager.getEnchantmentLevel(tool, "What's Up Doc");
+                        if (level > 0 && random.nextDouble() < level * 0.10) {
+                            if (CropCountManager.getInstance(plugin).increment(player, blockType)) {
+                                harvest = true;
+                            }
+                        }
+                    }
+                    case POTATOES -> {
+                        int level = CustomEnchantmentManager.getEnchantmentLevel(tool, "Legend");
+                        if (level > 0 && random.nextDouble() < level * 0.10) {
+                            if (CropCountManager.getInstance(plugin).increment(player, blockType)) {
+                                harvest = true;
+                            }
+                        }
+                    }
+                    case BEETROOTS -> {
+                        int level = CustomEnchantmentManager.getEnchantmentLevel(tool, "Venerate");
+                        if (level > 0 && random.nextDouble() < level * 0.10) {
+                            if (CropCountManager.getInstance(plugin).increment(player, blockType)) {
+                                harvest = true;
+                            }
+                        }
+                    }
+                    case MELON -> {
+                        int level = CustomEnchantmentManager.getEnchantmentLevel(tool, "Clean Cut");
+                        if (level > 0 && random.nextDouble() < level * 0.10) {
+                            if (CropCountManager.getInstance(plugin).increment(player, blockType)) {
+                                harvest = true;
+                            }
+                        }
+                    }
+                    case PUMPKIN -> {
+                        int level = CustomEnchantmentManager.getEnchantmentLevel(tool, "Gourd");
+                        if (level > 0 && random.nextDouble() < level * 0.10) {
+                            if (CropCountManager.getInstance(plugin).increment(player, blockType)) {
+                                harvest = true;
+                            }
+                        }
+                    }
+                    default -> {
+                    }
+                }
             }
 
             StatsCalculator calc = StatsCalculator.getInstance(plugin);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/corpses/CorpseEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/corpses/CorpseEvent.java
@@ -21,6 +21,9 @@ import org.bukkit.potion.PotionEffectType;
 
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
 
 /**
  * Spawns a random Corpse from the registry with an emergence animation.
@@ -41,6 +44,20 @@ public class CorpseEvent {
             return;
         }
         spawnCorpse(optional.get(), location);
+    }
+
+    /**
+     * Spawns a random legendary corpse at the given location.
+     */
+    public void triggerLegendary(Location location) {
+        List<Corpse> legendary = CorpseRegistry.getCorpses().stream()
+                .filter(c -> c.getRarity() == Rarity.LEGENDARY)
+                .collect(Collectors.toList());
+        if (legendary.isEmpty()) {
+            return;
+        }
+        Corpse corpse = legendary.get(new Random().nextInt(legendary.size()));
+        spawnCorpse(corpse, location);
     }
 
     private void applyAttributes(NPC npc, Rarity rarity) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
@@ -322,6 +322,14 @@ public class AnvilRepair implements Listener {
         return item.getType().toString().toUpperCase().endsWith("HOE");
     }
 
+    public boolean isAxe(ItemStack item) {
+        if (item == null || item.getType() == Material.AIR) {
+            return false;
+        }
+        String type = item.getType().toString().toUpperCase();
+        return type.endsWith("_AXE") && !type.endsWith("PICKAXE");
+    }
+
     public boolean isBow(ItemStack item) {
         if (item == null || item.getType() == Material.AIR) {
             return false; // Check for null or empty items
@@ -1149,6 +1157,30 @@ public class AnvilRepair implements Listener {
             return;
         }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Water Aspect") && isSword(repairee)){
             CustomEnchantmentManager.addEnchantment(player, billItem, repairee, "Water Aspect", CustomEnchantmentManager.getEnchantmentLevel(repairee, "Water Aspect") +1);
+            player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
+            return;
+        }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Enchanted Hay Bale") && isHoe(repairee)){
+            CustomEnchantmentManager.addEnchantment(player, billItem, repairee, "Cornfield", CustomEnchantmentManager.getEnchantmentLevel(repairee, "Cornfield") +1);
+            player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
+            return;
+        }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Enchanted Golden Carrot") && isHoe(repairee)){
+            CustomEnchantmentManager.addEnchantment(player, billItem, repairee, "What's Up Doc", CustomEnchantmentManager.getEnchantmentLevel(repairee, "What's Up Doc") +1);
+            player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
+            return;
+        }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "HeartRoot") && isHoe(repairee)){
+            CustomEnchantmentManager.addEnchantment(player, billItem, repairee, "Venerate", CustomEnchantmentManager.getEnchantmentLevel(repairee, "Venerate") +1);
+            player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
+            return;
+        }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Immortal Potato") && isHoe(repairee)){
+            CustomEnchantmentManager.addEnchantment(player, billItem, repairee, "Legend", CustomEnchantmentManager.getEnchantmentLevel(repairee, "Legend") +1);
+            player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
+            return;
+        }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Jack o' Lantern") && isAxe(repairee)){
+            CustomEnchantmentManager.addEnchantment(player, billItem, repairee, "Gourd", CustomEnchantmentManager.getEnchantmentLevel(repairee, "Gourd") +1);
+            player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
+            return;
+        }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Watermelon") && isAxe(repairee)){
+            CustomEnchantmentManager.addEnchantment(player, billItem, repairee, "Clean Cut", CustomEnchantmentManager.getEnchantmentLevel(repairee, "Clean Cut") +1);
             player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
             return;
         }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "The Law of Gravity") && TOOLS.contains(repairee.getType())){

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/ToggleCustomEnchantmentsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/ToggleCustomEnchantmentsCommand.java
@@ -94,6 +94,24 @@ public class ToggleCustomEnchantmentsCommand implements CommandExecutor, Listene
         descriptions.put("Water Aspect", Arrays.asList(
                 "Deals bonus damage to certain",
                 "mobs like guardians or endermen."));
+        descriptions.put("Cornfield", Arrays.asList(
+                "10% * level chance to",
+                "double-count wheat."));
+        descriptions.put("What's Up Doc", Arrays.asList(
+                "10% * level chance to",
+                "double-count carrots."));
+        descriptions.put("Venerate", Arrays.asList(
+                "10% * level chance to",
+                "double-count beetroot."));
+        descriptions.put("Legend", Arrays.asList(
+                "10% * level chance to",
+                "double-count potatoes."));
+        descriptions.put("Clean Cut", Arrays.asList(
+                "10% * level chance to",
+                "double-count melons."));
+        descriptions.put("Gourd", Arrays.asList(
+                "10% * level chance to",
+                "double-count pumpkins."));
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Add new crop double-count enchantments for hoes and axes with 10% per-level chance
- Register enchantments and smithing items to apply them
- Implement artifacts that summon random legendary corpses

## Testing
- `mvn -q -e -DskipTests package` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688dd3f064948332bac96b3ea6c02e2c