### PR TITLE
Ensure legendary corpses drop smithing items

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/corpses/CorpseDeathEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/corpses/CorpseDeathEvent.java
@@ -60,8 +60,14 @@ public class CorpseDeathEvent implements Listener {
                 xpManager.addXP(killer, "Terraforming", terraXP);
             }
 
+            // Legendary corpses have a small chance to drop a random ultimate smithing item.
+            // Using dropItemNaturally ensures the item actually appears in the world
+            // instead of relying on the event drops, which Citizens NPCs may ignore.
             if (corpse.getRarity() == Rarity.LEGENDARY && Math.random() < 0.04) {
-                event.getDrops().add(ItemRegistry.getRandomUltimateSmithingItem());
+                entity.getWorld().dropItemNaturally(
+                        entity.getLocation(),
+                        ItemRegistry.getRandomUltimateSmithingItem()
+                );
             }
         });
 


### PR DESCRIPTION
## Summary
- Fix legendary corpses not dropping ultimate smithing items by spawning the item directly

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688dd822dbe883329e41375eb3e9d3f7