### PR TITLE
Support satchels in enchanted hopper

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/EnchantedHopperManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/EnchantedHopperManager.java
@@ -30,7 +30,8 @@ import java.util.*;
 /**
  * Handles Enchanted Hopper trinkets. Items placed inside the hopper GUI act as a
  * whitelist. Matching items from the player's inventory are periodically moved
- * to the container directly above the hopper in the backpack.
+ * to the container directly above the hopper in the backpack. Containers may be
+ * shulker boxes, satchels or other special items.
  */
 public class EnchantedHopperManager implements Listener {
     private static EnchantedHopperManager instance;
@@ -227,11 +228,11 @@ public class EnchantedHopperManager implements Listener {
             bsm.setBlockState(box);
             containerItem.setItemMeta(bsm);
         } else {
-            String name = ChatColor.stripColor(meta.getDisplayName());
-            if (name.equals("Blue Satchel") || name.equals("Black Satchel") || name.equals("Green Satchel")) {
+            String name = ChatColor.stripColor(meta != null ? meta.getDisplayName() : null);
+            if (name != null && name.endsWith(" Satchel")) {
                 SatchelManager.getInstance().depositItem(player, name.split(" ")[0], toMove);
                 success = true;
-            } else if (name.equals("Enchanted Lava Bucket")) {
+            } else if ("Enchanted Lava Bucket".equals(name)) {
                 success = true; // item simply deleted
             }
         }


### PR DESCRIPTION
## Summary
- Generalize enchanted hopper container handling to deposit items into any satchel color
- Document that hoppers can route to satchels

## Testing
- `mvn -q -e -ntp test` *(failed: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e71e723d08332b0c6ecb236bed9cf