### PR TITLE
Store corpse level in metadata

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/damage/strategies/CorpseLevelDamageStrategy.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/damage/strategies/CorpseLevelDamageStrategy.java
@@ -4,12 +4,13 @@ import goat.minecraft.minecraftnew.subsystems.combat.config.CombatConfiguration;
 import goat.minecraft.minecraftnew.subsystems.combat.damage.DamageCalculationContext;
 import goat.minecraft.minecraftnew.subsystems.combat.damage.DamageCalculationResult;
 import goat.minecraft.minecraftnew.subsystems.combat.damage.DamageCalculationStrategy;
-import goat.minecraft.minecraftnew.subsystems.combat.utils.EntityLevelExtractor;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
+import org.bukkit.metadata.MetadataValue;
 
+import java.util.List;
 import java.util.logging.Logger;
 
 /**
@@ -21,11 +22,9 @@ public class CorpseLevelDamageStrategy implements DamageCalculationStrategy {
     private static final Logger logger = Logger.getLogger(CorpseLevelDamageStrategy.class.getName());
 
     private final CombatConfiguration.DamageConfig config;
-    private final EntityLevelExtractor levelExtractor;
 
     public CorpseLevelDamageStrategy(CombatConfiguration.DamageConfig config) {
         this.config = config;
-        this.levelExtractor = new EntityLevelExtractor();
     }
 
     @Override
@@ -41,7 +40,7 @@ public class CorpseLevelDamageStrategy implements DamageCalculationStrategy {
 
         double originalDamage = context.getBaseDamage();
         try {
-            int level = levelExtractor.extractLevelFromPlayerName(corpse);
+            int level = getCorpseLevel(corpse);
             if (level <= 0) {
                 return DamageCalculationResult.noChange(originalDamage);
             }
@@ -77,6 +76,16 @@ public class CorpseLevelDamageStrategy implements DamageCalculationStrategy {
     @Override
     public String getName() {
         return "Corpse Level Damage Scaling";
+    }
+
+    private int getCorpseLevel(LivingEntity corpse) {
+        if (corpse.hasMetadata("CORPSE_LEVEL")) {
+            List<MetadataValue> meta = corpse.getMetadata("CORPSE_LEVEL");
+            if (!meta.isEmpty()) {
+                return meta.get(0).asInt();
+            }
+        }
+        return 0;
     }
 
     private LivingEntity getCorpseAttacker(DamageCalculationContext context) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/utils/EntityLevelExtractor.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/utils/EntityLevelExtractor.java
@@ -1,7 +1,9 @@
 package goat.minecraft.minecraftnew.subsystems.combat.utils;
 
 import org.bukkit.entity.Entity;
+import org.bukkit.metadata.MetadataValue;
 
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.logging.Logger;
@@ -28,23 +30,33 @@ public class EntityLevelExtractor {
     
     /**
      * Extracts the level from an entity's display name.
-     * 
+     *
      * @param entity The entity to extract level from
      * @return The level found in the name, or 0 if no level is found
      */
     public int extractLevelFromName(Entity entity) {
+        int metaLevel = extractLevelFromMetadata(entity);
+        if (metaLevel > 0) {
+            return metaLevel;
+        }
+
         if (entity == null) {
             return 0;
         }
-        
+
         String name = entity.getCustomName();
         if (name == null || name.trim().isEmpty()) {
             name = entity.getName();
         }
-        
+
         return extractLevelFromString(name);
     }
     public int extractLevelFromPlayerName(Entity entity) {
+        int metaLevel = extractLevelFromMetadata(entity);
+        if (metaLevel > 0) {
+            return metaLevel;
+        }
+
         if (entity == null) {
             return 0;
         }
@@ -55,6 +67,22 @@ public class EntityLevelExtractor {
         }
 
         return extractLevelFromString(name);
+    }
+
+    private int extractLevelFromMetadata(Entity entity) {
+        if (entity == null) {
+            return 0;
+        }
+        if (entity.hasMetadata("CORPSE_LEVEL")) {
+            List<MetadataValue> meta = entity.getMetadata("CORPSE_LEVEL");
+            if (!meta.isEmpty()) {
+                try {
+                    return meta.get(0).asInt();
+                } catch (Exception ignored) {
+                }
+            }
+        }
+        return 0;
     }
     
     /**

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/corpses/CorpseEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/corpses/CorpseEvent.java
@@ -141,6 +141,7 @@ public class CorpseEvent {
         npc.addTrait(new CorpseTrait(plugin, corpse.getRarity(), corpse.usesBow(),
                 corpse.getDisplayName().equalsIgnoreCase("Duskblood") ? 100 : 0));
         npc.getEntity().setMetadata("CORPSE", new FixedMetadataValue(plugin, corpse.getDisplayName()));
+        npc.getEntity().setMetadata("CORPSE_LEVEL", new FixedMetadataValue(plugin, corpse.getLevel()));
         playSpawnSound(loc, corpse.getRarity());
     }
 


### PR DESCRIPTION
## Summary
- Track corpse level directly via entity metadata when spawning an NPC
- Read corpse level metadata instead of parsing names for damage scaling
- Allow level extractor to pull level values from metadata before name parsing

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_688e7ff9de688332ab46267893f7057a