### PR TITLE
feat: dynamic dragon fights with custom health

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/Dragon.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/Dragon.java
@@ -50,6 +50,26 @@ public interface Dragon {
     int getBaseRage();
 
     /**
+     * @return the maximum amount of health this dragon should have.
+     */
+    int getMaxHealth();
+
+    /**
+     * How often (in ticks) the dragon should reconsider its actions.  This is
+     * purely a placeholder for future AI work and is currently unused.
+     */
+    int getDecisionInterval();
+
+    /**
+     * Placeholder hook for future decision making logic.  Implementations can
+     * override this method to provide custom AI behaviour when the decision
+     * interval elapses.
+     */
+    default void decide(EnderDragon dragon) {
+        // no-op for now
+    }
+
+    /**
      * Apply basic attributes to the supplied EnderDragon entity.
      * Implementations should avoid ability logic – this method is only for
      * name and simple attribute assignment.

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/DragonFight.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/DragonFight.java
@@ -1,0 +1,32 @@
+package goat.minecraft.minecraftnew.subsystems.dragons;
+
+import org.bukkit.entity.EnderDragon;
+
+/**
+ * Represents an active dragon fight.  It links the spawned EnderDragon entity
+ * with its logical dragon type and associated {@link DragonHealthInstance}.
+ */
+public class DragonFight {
+
+    private final EnderDragon dragonEntity;
+    private final Dragon dragonType;
+    private final DragonHealthInstance health;
+
+    public DragonFight(EnderDragon dragonEntity, Dragon dragonType) {
+        this.dragonEntity = dragonEntity;
+        this.dragonType = dragonType;
+        this.health = new DragonHealthInstance(dragonEntity.getUniqueId(), dragonType.getMaxHealth());
+    }
+
+    public EnderDragon getDragonEntity() {
+        return dragonEntity;
+    }
+
+    public Dragon getDragonType() {
+        return dragonType;
+    }
+
+    public DragonHealthInstance getHealth() {
+        return health;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/DragonHealthInstance.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/DragonHealthInstance.java
@@ -1,0 +1,45 @@
+package goat.minecraft.minecraftnew.subsystems.dragons;
+
+import java.util.UUID;
+
+/**
+ * Simple container for tracking a dragon's custom health.  All damage to the
+ * dragon is redirected here, allowing us to control death and boss bar updates
+ * independent from the vanilla Ender Dragon health system.
+ */
+public class DragonHealthInstance {
+
+    private final UUID dragonId;
+    private final double maxHealth;
+    private double currentHealth;
+
+    public DragonHealthInstance(UUID dragonId, double maxHealth) {
+        this.dragonId = dragonId;
+        this.maxHealth = maxHealth;
+        this.currentHealth = maxHealth;
+    }
+
+    public UUID getDragonId() {
+        return dragonId;
+    }
+
+    public double getMaxHealth() {
+        return maxHealth;
+    }
+
+    public double getCurrentHealth() {
+        return currentHealth;
+    }
+
+    public void damage(double amount) {
+        currentHealth = Math.max(0, currentHealth - amount);
+    }
+
+    public double getHealthPercentage() {
+        return currentHealth / maxHealth;
+    }
+
+    public boolean isDead() {
+        return currentHealth <= 0;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/WaterDragon.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/WaterDragon.java
@@ -16,6 +16,8 @@ public class WaterDragon implements Dragon {
     private static final int CRYSTAL_BIAS = 7;
     private static final int FLIGHT_SPEED = 4;
     private static final int BASE_RAGE = 2;
+    private static final int MAX_HEALTH = 25_000;
+    private static final int DECISION_INTERVAL = 100; // placeholder
 
     @Override
     public ChatColor getNameColor() {
@@ -51,6 +53,21 @@ public class WaterDragon implements Dragon {
     @Override
     public int getBaseRage() {
         return BASE_RAGE;
+    }
+
+    @Override
+    public int getMaxHealth() {
+        return MAX_HEALTH;
+    }
+
+    @Override
+    public int getDecisionInterval() {
+        return DECISION_INTERVAL;
+    }
+
+    @Override
+    public void decide(EnderDragon dragon) {
+        // Future AI for the Water Dragon will be implemented here.
     }
 
     @Override


### PR DESCRIPTION
## Summary
- add max health, decision timing and AI hooks to Dragon interface
- manage fights with DragonFightManager that spawns a random dragon on entering the custom End, handles portal countdown, tracks health and defeat logic
- introduce DragonHealthInstance and DragonFight classes for custom health tracking and boss bar updates

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688ecca3a35883328bf075a3a7b45c38