### PR TITLE
Implement Dragon AI flight speed and decision logic

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -110,6 +110,7 @@ import goat.minecraft.minecraftnew.other.warpgate.WarpGateManager;
 import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentPreferences;
 import goat.minecraft.minecraftnew.other.additionalfunctionality.EnvironmentSidebarPreferences;
 import goat.minecraft.minecraftnew.subsystems.dragons.DragonFightManager;
+import goat.minecraft.minecraftnew.subsystems.dragons.RefreshEndCommand;
 
 import goat.minecraft.minecraftnew.subsystems.music.PigStepArena;
 import goat.minecraft.minecraftnew.other.realms.Tropic;
@@ -360,6 +361,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getCommand("nether").setExecutor(new NetherCommand());
         getCommand("overworld").setExecutor(new OverworldCommand());
         getCommand("resetend").setExecutor(new ResetEndCommand());
+        getCommand("refreshend").setExecutor(new RefreshEndCommand(this, dragonFightManager));
         getCommand("generatecontinuityisland").setExecutor(new GenerateContinuityIslandCommand());
         getCommand("continuitytp").setExecutor(new ContinuityTpCommand());
         getCommand("warp").setExecutor(new WarpCommand());

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/RefreshEndCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/RefreshEndCommand.java
@@ -1,0 +1,43 @@
+package goat.minecraft.minecraftnew.subsystems.dragons;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import org.bukkit.ChatColor;
+import org.bukkit.World;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Command to remove any existing dragons in the custom End and spawn a fresh one.
+ */
+public class RefreshEndCommand implements CommandExecutor {
+
+    private final MinecraftNew plugin;
+    private final DragonFightManager fightManager;
+
+    public RefreshEndCommand(MinecraftNew plugin, DragonFightManager fightManager) {
+        this.plugin = plugin;
+        this.fightManager = fightManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        World world = player.getWorld();
+        if (!"custom_end".equalsIgnoreCase(world.getName())) {
+            player.sendMessage(ChatColor.RED + "You must be in the custom End to use this command.");
+            return true;
+        }
+
+        plugin.getLogger().info("[DragonAI] /refreshEnd invoked by " + player.getName());
+        fightManager.refreshEnd(world);
+        player.sendMessage(ChatColor.GREEN + "Spawned a new dragon in the End.");
+        return true;
+    }
+}
+

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -73,6 +73,10 @@ commands:
   resetend:
     description: Resets The End dimension.
     usage: /resetend
+  refreshend:
+    description: Respawns a fresh dragon in The End.
+    usage: /refreshEnd
+    permission: continuity.admin
   end:
     description: Teleports the player to The End.
     usage: /end


### PR DESCRIPTION
## Summary
- scale dragon flight velocity and apply periodic acceleration or deceleration with detailed debug logs
- derive AI decision cooldowns from baseRage and roll decision chances, logging each attempt
- add `/refreshEnd` admin command to respawn a random End dragon and notify players on defeat countdown

## Testing
- `mvn -q -e -DskipTests package` *(fails: Could not transfer artifact maven-resources-plugin due to network unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_688ed2a1ecdc8332ace3b4ec66c1bffc