### PR TITLE
Use Citizens NPC for custom End dragon fights

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/DragonFight.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/DragonFight.java
@@ -1,5 +1,6 @@
 package goat.minecraft.minecraftnew.subsystems.dragons;
 
+import net.citizensnpcs.api.npc.NPC;
 import org.bukkit.entity.EnderDragon;
 
 /**
@@ -8,12 +9,14 @@ import org.bukkit.entity.EnderDragon;
  */
 public class DragonFight {
 
+    private final NPC npc;
     private final EnderDragon dragonEntity;
     private final Dragon dragonType;
     private final DragonHealthInstance health;
 
-    public DragonFight(EnderDragon dragonEntity, Dragon dragonType) {
-        this.dragonEntity = dragonEntity;
+    public DragonFight(NPC npc, Dragon dragonType) {
+        this.npc = npc;
+        this.dragonEntity = (EnderDragon) npc.getEntity();
         this.dragonType = dragonType;
         this.health = new DragonHealthInstance(dragonEntity.getUniqueId(), dragonType.getMaxHealth());
     }
@@ -24,6 +27,10 @@ public class DragonFight {
 
     public Dragon getDragonType() {
         return dragonType;
+    }
+
+    public NPC getNpc() {
+        return npc;
     }
 
     public DragonHealthInstance getHealth() {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/DragonHealthInstance.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/DragonHealthInstance.java
@@ -35,6 +35,10 @@ public class DragonHealthInstance {
         currentHealth = Math.max(0, currentHealth - amount);
     }
 
+    public void heal(double amount) {
+        currentHealth = Math.min(maxHealth, currentHealth + amount);
+    }
+
     public double getHealthPercentage() {
         return currentHealth / maxHealth;
     }


### PR DESCRIPTION
## Summary
- Spawn Ender Dragons as Citizens NPCs chosen randomly from the dragon registry and ensure only one is active per custom End world
- Handle dragon health exclusively through `DragonHealthInstance`, canceling vanilla damage and healing events
- Destroy the NPC when defeated and keep existing flight speed logic

## Testing
- `mvn -q test` *(fails: Could not transfer artifact maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688ed6b6540c8332b6c086b4a8ae8b0a