### PR TITLE
Move dragon AI into WaterDragonTrait

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/behaviors/Behavior.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/behaviors/Behavior.java
@@ -1,0 +1,11 @@
+package goat.minecraft.minecraftnew.subsystems.dragons.behaviors;
+
+/**
+ * Simple behaviour interface for dragon actions.
+ */
+public interface Behavior {
+    /**
+     * Execute the behaviour.
+     */
+    void run();
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/behaviors/PerformBasicAttack.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/behaviors/PerformBasicAttack.java
@@ -1,0 +1,63 @@
+package goat.minecraft.minecraftnew.subsystems.dragons.behaviors;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.dragons.DragonFight;
+import goat.minecraft.minecraftnew.subsystems.dragons.WaterDragonTrait;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.entity.EnderDragon;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.Vector;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Behaviour representing the Water Dragon's basic lightning attack.
+ */
+public class PerformBasicAttack implements Behavior {
+
+    private final MinecraftNew plugin;
+    private final DragonFight fight;
+    private final WaterDragonTrait trait;
+
+    public PerformBasicAttack(MinecraftNew plugin, DragonFight fight, WaterDragonTrait trait) {
+        this.plugin = plugin;
+        this.fight = fight;
+        this.trait = trait;
+    }
+
+    @Override
+    public void run() {
+        EnderDragon dragon = fight.getDragonEntity();
+        World world = dragon.getWorld();
+        Location origin = dragon.getLocation();
+
+        // Freeze the dragon in place
+        dragon.setAI(false);
+        dragon.setVelocity(new Vector(0, 0, 0));
+
+        world.playSound(origin, Sound.ENTITY_LIGHTNING_BOLT_THUNDER, 10.0f, 1.0f);
+
+        List<Location> targets = new ArrayList<>();
+        for (Player p : world.getPlayers()) {
+            Location loc = p.getLocation().clone();
+            targets.add(loc);
+            world.spawnParticle(Particle.FLASH, loc, 1);
+        }
+
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                for (Location loc : targets) {
+                    world.strikeLightning(loc);
+                }
+                dragon.setAI(true);
+                trait.onAttackComplete();
+            }
+        }.runTaskLater(plugin, 60L); // 3 seconds later
+    }
+}


### PR DESCRIPTION
## Summary
- Relocate flight speed handling and decision loop from DragonFightManager to WaterDragonTrait
- Add basic lightning attack behaviour executed by decision loop
- Introduce simple Behavior interface and PerformBasicAttack implementation

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688ee224f46483328d8e49112cccdd39