### PR TITLE
Refactor dragon behavior into phases

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/CustomPhase.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/CustomPhase.java
@@ -1,0 +1,24 @@
+package goat.minecraft.minecraftnew.subsystems.dragons;
+
+/**
+ * Represents both vanilla Ender Dragon phases and custom extension phases.
+ */
+public enum CustomPhase {
+    // Vanilla phases
+    CIRCLING,
+    STRAFING,
+    FLY_TO_PORTAL,
+    LAND_ON_PORTAL,
+    LEAVE_PORTAL,
+    BREATH_ATTACK,
+    SEARCH_FOR_BREATH_ATTACK_TARGET,
+    ROAR_BEFORE_ATTACK,
+    CHARGE_PLAYER,
+    DYING,
+    HOVER,
+    // Custom phases
+    HEALING,
+    SMITE,
+    LAUNCH,
+    FURY
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/WaterDragonTrait.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/WaterDragonTrait.java
@@ -1,39 +1,21 @@
 package goat.minecraft.minecraftnew.subsystems.dragons;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
-import goat.minecraft.minecraftnew.subsystems.dragons.behaviors.PerformBasicAttack;
+import goat.minecraft.minecraftnew.subsystems.dragons.phases.*;
+import org.bukkit.event.entity.EnderDragonChangePhaseEvent;
 import net.citizensnpcs.api.trait.Trait;
 import net.citizensnpcs.api.util.DataKey;
 import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.Particle;
-import org.bukkit.Sound;
-import org.bukkit.entity.ArmorStand;
-import org.bukkit.entity.EnderCrystal;
 import org.bukkit.entity.EnderDragon;
-import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.entity.EntityRegainHealthEvent;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.SkullMeta;
-import org.bukkit.profile.PlayerProfile;
-import org.bukkit.profile.PlayerTextures;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
-import org.bukkit.util.EulerAngle;
 import org.bukkit.util.Vector;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.UUID;
+import java.util.Random;
 
 /**
  * Trait handling the Water Dragon's behaviour including flight control,
@@ -47,8 +29,6 @@ import java.util.UUID;
  */
 public class WaterDragonTrait extends Trait implements Listener {
 
-    private static final String CRYSTAL_TEXTURE = "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQyMzI4OTUxMGM1NGI2N2RmMDIzNTgwOTc5YzQ2NWQwNDgxYzc2OWM4NjViZjRiNDY1Y2Y0Nzg3NDlmMWM0ZiJ9fX0=";
-
     private final MinecraftNew plugin;
     private final DragonFight fight;
 
@@ -57,6 +37,15 @@ public class WaterDragonTrait extends Trait implements Listener {
     private BukkitTask flightTask;
     private BukkitTask decisionTask;
     private boolean attacking;
+    private CustomPhase currentPhase;
+    private long furyCooldownEnd;
+    private long launchCooldownEnd;
+    private long smiteCooldownEnd;
+    private final Random random = new Random();
+
+    private static final long FURY_COOLDOWN = 60000L;
+    private static final long LAUNCH_COOLDOWN = 20000L;
+    private static final long SMITE_COOLDOWN = 10000L;
 
     public WaterDragonTrait(MinecraftNew plugin, DragonFight fight) {
         super("water_dragon_trait");
@@ -98,146 +87,33 @@ public class WaterDragonTrait extends Trait implements Listener {
         Bukkit.getScheduler().runTask(plugin, this::checkHealTrigger);
     }
 
+    @EventHandler
+    public void onPhaseChange(EnderDragonChangePhaseEvent event) {
+        if (!event.getEntity().getUniqueId().equals(fight.getDragonEntity().getUniqueId())) {
+            return;
+        }
+        EnderDragon.Phase phase = event.getNewPhase();
+        switch (phase) {
+            case LAND_ON_PORTAL:
+            case FLY_TO_PORTAL:
+            case LEAVE_PORTAL:
+            case HOVER:
+            case BREATH_ATTACK:
+            case SEARCH_FOR_BREATH_ATTACK_TARGET:
+                event.setNewPhase(EnderDragon.Phase.CIRCLING);
+                break;
+            default:
+                break;
+        }
+    }
+
     private void checkHealTrigger() {
         double missing = 1.0 - fight.getHealth().getHealthPercentage();
         double threshold = 1.0 / crystalBias;
         if (missing >= threshold) {
-            startHeal();
+            currentPhase = CustomPhase.HEALING;
+            new HealPhase(plugin, fight, this).start();
         }
-    }
-
-    private void startHeal() {
-        EnderDragon dragon = fight.getDragonEntity();
-        EnderCrystal crystal = findNearestCrystal(dragon);
-        if (crystal == null || crystal.isDead()) {
-            return; // cannot heal without a crystal
-        }
-
-        attacking = true;
-        Location freezeLoc = dragon.getLocation().clone();
-        npc.getNavigator().cancelNavigation();
-        dragon.setVelocity(new Vector(0, 0, 0));
-
-        Location start = crystal.getLocation().clone();
-        crystal.remove();
-
-        ArmorStand stand = (ArmorStand) dragon.getWorld().spawnEntity(start, EntityType.ARMOR_STAND);
-        stand.setInvisible(true);
-        stand.setMarker(true);
-        stand.setGravity(false);
-        stand.setSmall(true);
-        stand.getEquipment().setHelmet(createCrystalSkull());
-
-        healTask = new BukkitRunnable() {
-            @Override
-            public void run() {
-                if (!npc.isSpawned() || !stand.isValid() || dragon.isDead()) {
-                    if (stand.isValid()) stand.remove();
-                    attacking = false;
-                    healTask = null;
-                    cancel();
-                    return;
-                }
-
-                dragon.teleport(freezeLoc);
-                dragon.setVelocity(new Vector(0, 0, 0));
-
-                Location sLoc = stand.getLocation();
-                Vector dir = freezeLoc.toVector().subtract(sLoc.toVector()).normalize().multiply(0.5);
-                stand.teleport(sLoc.add(dir));
-                stand.setHeadPose(stand.getHeadPose().add(0, Math.toRadians(20), 0));
-                stand.getWorld().spawnParticle(Particle.END_ROD, sLoc, 2, 0, 0, 0, 0);
-
-                if (sLoc.distanceSquared(freezeLoc) <= 64) { // within 8 blocks
-                    stand.getWorld().createExplosion(sLoc, 6F, false, false);
-                    stand.getWorld().spawnParticle(Particle.DRAGON_BREATH, sLoc, 200, 1, 1, 1, 0.01);
-                    stand.getWorld().playSound(sLoc, Sound.ENTITY_ENDER_DRAGON_GROWL, 10f, 1f);
-                    stand.remove();
-                    startSmoothHeal(dragon, freezeLoc);
-                    cancel();
-                }
-            }
-        }.runTaskTimer(plugin, 0L, 1L);
-    }
-
-    private void startSmoothHeal(EnderDragon dragon, Location freezeLoc) {
-        double missing = fight.getHealth().getMaxHealth() - fight.getHealth().getCurrentHealth();
-        if (missing <= 0) {
-            attacking = false;
-            healTask = null;
-            return;
-        }
-        int steps = 100;
-        double amountPerStep = missing / steps;
-        healTask = new BukkitRunnable() {
-            int step = 0;
-            @Override
-            public void run() {
-                if (!npc.isSpawned() || dragon.isDead()) {
-                    attacking = false;
-                    healTask = null;
-                    cancel();
-                    return;
-                }
-
-                dragon.teleport(freezeLoc);
-                dragon.setVelocity(new Vector(0, 0, 0));
-
-                if (step++ >= steps) {
-                    crystalBias = Math.max(0, crystalBias - 1);
-                    attacking = false;
-                    healTask = null;
-                    cancel();
-                    return;
-                }
-
-                EntityRegainHealthEvent event = new EntityRegainHealthEvent(
-                        dragon, amountPerStep, EntityRegainHealthEvent.RegainReason.CUSTOM);
-                Bukkit.getPluginManager().callEvent(event);
-            }
-        }.runTaskTimer(plugin, 0L, 1L);
-    }
-
-    private EnderCrystal findNearestCrystal(EnderDragon dragon) {
-        EnderCrystal nearest = null;
-        double best = Double.MAX_VALUE;
-        Location loc = dragon.getLocation();
-        for (EnderCrystal crystal : dragon.getWorld().getEntitiesByClass(EnderCrystal.class)) {
-            double dist = crystal.getLocation().distanceSquared(loc);
-            if (dist < best) {
-                best = dist;
-                nearest = crystal;
-            }
-        }
-        return nearest;
-    }
-
-    private ItemStack createCrystalSkull() {
-        ItemStack head = new ItemStack(Material.PLAYER_HEAD);
-        SkullMeta meta = (SkullMeta) head.getItemMeta();
-        setCustomSkullTexture(meta, CRYSTAL_TEXTURE);
-        head.setItemMeta(meta);
-        return head;
-    }
-
-    private SkullMeta setCustomSkullTexture(SkullMeta skullMeta, String base64Json) {
-        if (skullMeta == null || base64Json == null || base64Json.isEmpty()) {
-            return skullMeta;
-        }
-        try {
-            byte[] decoded = Base64.getDecoder().decode(base64Json);
-            String json = new String(decoded, StandardCharsets.UTF_8);
-            JsonObject root = JsonParser.parseString(json).getAsJsonObject();
-            String urlText = root.getAsJsonObject("textures").getAsJsonObject("SKIN").get("url").getAsString();
-            PlayerProfile profile = Bukkit.createPlayerProfile(UUID.randomUUID());
-            PlayerTextures textures = profile.getTextures();
-            textures.setSkin(new URL(urlText), PlayerTextures.SkinModel.CLASSIC);
-            profile.setTextures(textures);
-            skullMeta.setOwnerProfile(profile);
-        } catch (Exception ex) {
-            ex.printStackTrace();
-        }
-        return skullMeta;
     }
 
     private void startFlightTask() {
@@ -272,14 +148,48 @@ public class WaterDragonTrait extends Trait implements Listener {
                 if (!npc.isSpawned() || attacking) {
                     return;
                 }
+                if (random.nextBoolean()) {
+                    attacking = true;
+                    Bukkit.getScheduler().runTaskLater(plugin, () -> attacking = false, interval);
+                    return; // decision fails
+                }
+                long now = System.currentTimeMillis();
                 attacking = true;
-                new PerformBasicAttack(plugin, fight, WaterDragonTrait.this).run();
+                if (fight.getHealth().getHealthPercentage() < 0.5 && now >= furyCooldownEnd) {
+                    currentPhase = CustomPhase.FURY;
+                    new FuryPhase(plugin, fight, WaterDragonTrait.this).start();
+                    furyCooldownEnd = now + FURY_COOLDOWN;
+                } else if (now >= launchCooldownEnd) {
+                    currentPhase = CustomPhase.LAUNCH;
+                    new LaunchPhase(plugin, fight, WaterDragonTrait.this).start();
+                    launchCooldownEnd = now + LAUNCH_COOLDOWN;
+                } else {
+                    currentPhase = CustomPhase.SMITE;
+                    new SmitePhase(plugin, fight, WaterDragonTrait.this).start();
+                    smiteCooldownEnd = now + SMITE_COOLDOWN;
+                }
             }
         }.runTaskTimer(plugin, interval, interval);
     }
 
-    public void onAttackComplete() {
+    public void onPhaseComplete() {
         attacking = false;
+    }
+
+    public void setHealTask(BukkitTask task) {
+        this.healTask = task;
+    }
+
+    public void setAttacking(boolean attacking) {
+        this.attacking = attacking;
+    }
+
+    public int getCrystalBias() {
+        return crystalBias;
+    }
+
+    public void setCrystalBias(int crystalBias) {
+        this.crystalBias = crystalBias;
     }
 
     @Override public void load(DataKey key) { }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/phases/FuryPhase.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/phases/FuryPhase.java
@@ -1,0 +1,48 @@
+package goat.minecraft.minecraftnew.subsystems.dragons.phases;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.dragons.DragonFight;
+import goat.minecraft.minecraftnew.subsystems.dragons.WaterDragonTrait;
+import org.bukkit.World;
+import org.bukkit.entity.EnderDragon;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+
+/**
+ * Ultimate phase striking all players repeatedly with lightning.
+ */
+public class FuryPhase implements Phase {
+
+    private final MinecraftNew plugin;
+    private final DragonFight fight;
+    private final WaterDragonTrait trait;
+
+    public FuryPhase(MinecraftNew plugin, DragonFight fight, WaterDragonTrait trait) {
+        this.plugin = plugin;
+        this.fight = fight;
+        this.trait = trait;
+    }
+
+    @Override
+    public void start() {
+        EnderDragon dragon = fight.getDragonEntity();
+        World world = dragon.getWorld();
+        dragon.setAI(false);
+        new BukkitRunnable() {
+            int count = 0;
+            @Override
+            public void run() {
+                if (count++ >= 50 || dragon.isDead()) {
+                    dragon.setAI(true);
+                    trait.onPhaseComplete();
+                    cancel();
+                    return;
+                }
+                for (Player p : world.getPlayers()) {
+                    world.strikeLightning(p.getLocation());
+                    p.damage(5.0, dragon);
+                }
+            }
+        }.runTaskTimer(plugin, 0L, 2L);
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/phases/HealPhase.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/phases/HealPhase.java
@@ -1,0 +1,182 @@
+package goat.minecraft.minecraftnew.subsystems.dragons.phases;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.dragons.DragonFight;
+import goat.minecraft.minecraftnew.subsystems.dragons.WaterDragonTrait;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.EnderCrystal;
+import org.bukkit.entity.EnderDragon;
+import org.bukkit.entity.EntityType;
+import org.bukkit.event.entity.EntityRegainHealthEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.profile.PlayerProfile;
+import org.bukkit.profile.PlayerTextures;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.util.Vector;
+
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.UUID;
+
+/**
+ * Phase handling the healing animation and health restoration using end crystals.
+ */
+public class HealPhase implements Phase {
+
+    private static final String CRYSTAL_TEXTURE = "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQyMzI4OTUxMGM1NGI2N2RmMDIzNTgwOTc5YzQ2NWQwNDgxYzc2OWM4NjViZjRiNDY1Y2Y0Nzg3NDlmMWM0ZiJ9fX0=";
+
+    private final MinecraftNew plugin;
+    private final DragonFight fight;
+    private final WaterDragonTrait trait;
+
+    public HealPhase(MinecraftNew plugin, DragonFight fight, WaterDragonTrait trait) {
+        this.plugin = plugin;
+        this.fight = fight;
+        this.trait = trait;
+    }
+
+    @Override
+    public void start() {
+        EnderDragon dragon = fight.getDragonEntity();
+        EnderCrystal crystal = findNearestCrystal(dragon);
+        if (crystal == null || crystal.isDead()) {
+            trait.onPhaseComplete();
+            return; // cannot heal without a crystal
+        }
+
+        trait.setAttacking(true);
+        Location freezeLoc = dragon.getLocation().clone();
+        trait.getNPC().getNavigator().cancelNavigation();
+        dragon.setVelocity(new Vector(0, 0, 0));
+
+        Location start = crystal.getLocation().clone();
+        crystal.remove();
+
+        ArmorStand stand = (ArmorStand) dragon.getWorld().spawnEntity(start, EntityType.ARMOR_STAND);
+        stand.setInvisible(true);
+        stand.setMarker(true);
+        stand.setGravity(false);
+        stand.setSmall(true);
+        stand.getEquipment().setHelmet(createCrystalSkull());
+
+        BukkitTask task = new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!trait.getNPC().isSpawned() || !stand.isValid() || dragon.isDead()) {
+                    if (stand.isValid()) stand.remove();
+                    trait.onPhaseComplete();
+                    cancel();
+                    return;
+                }
+
+                dragon.teleport(freezeLoc);
+                dragon.setVelocity(new Vector(0, 0, 0));
+
+                Location sLoc = stand.getLocation();
+                Vector dir = freezeLoc.toVector().subtract(sLoc.toVector()).normalize().multiply(0.5);
+                stand.teleport(sLoc.add(dir));
+                stand.setHeadPose(stand.getHeadPose().add(0, Math.toRadians(20), 0));
+                stand.getWorld().spawnParticle(Particle.END_ROD, sLoc, 2, 0, 0, 0, 0);
+
+                if (sLoc.distanceSquared(freezeLoc) <= 64) {
+                    stand.getWorld().createExplosion(sLoc, 6F, false, false);
+                    stand.getWorld().spawnParticle(Particle.DRAGON_BREATH, sLoc, 200, 1, 1, 1, 0.01);
+                    stand.getWorld().playSound(sLoc, Sound.ENTITY_ENDER_DRAGON_GROWL, 10f, 1f);
+                    stand.remove();
+                    startSmoothHeal(dragon, freezeLoc);
+                    cancel();
+                }
+            }
+        }.runTaskTimer(plugin, 0L, 1L);
+        trait.setHealTask(task);
+    }
+
+    private void startSmoothHeal(EnderDragon dragon, Location freezeLoc) {
+        double missing = fight.getHealth().getMaxHealth() - fight.getHealth().getCurrentHealth();
+        if (missing <= 0) {
+            trait.onPhaseComplete();
+            trait.setHealTask(null);
+            return;
+        }
+        int steps = 100;
+        double amountPerStep = missing / steps;
+        BukkitTask task = new BukkitRunnable() {
+            int step = 0;
+            @Override
+            public void run() {
+                if (!trait.getNPC().isSpawned() || dragon.isDead()) {
+                    trait.onPhaseComplete();
+                    trait.setHealTask(null);
+                    cancel();
+                    return;
+                }
+
+                dragon.teleport(freezeLoc);
+                dragon.setVelocity(new Vector(0, 0, 0));
+
+                if (step++ >= steps) {
+                    trait.setCrystalBias(Math.max(0, trait.getCrystalBias() - 1));
+                    trait.onPhaseComplete();
+                    trait.setHealTask(null);
+                    cancel();
+                    return;
+                }
+
+                EntityRegainHealthEvent event = new EntityRegainHealthEvent(
+                        dragon, amountPerStep, EntityRegainHealthEvent.RegainReason.CUSTOM);
+                Bukkit.getPluginManager().callEvent(event);
+            }
+        }.runTaskTimer(plugin, 0L, 1L);
+        trait.setHealTask(task);
+    }
+
+    private EnderCrystal findNearestCrystal(EnderDragon dragon) {
+        EnderCrystal nearest = null;
+        double best = Double.MAX_VALUE;
+        Location loc = dragon.getLocation();
+        for (EnderCrystal crystal : dragon.getWorld().getEntitiesByClass(EnderCrystal.class)) {
+            double dist = crystal.getLocation().distanceSquared(loc);
+            if (dist < best) {
+                best = dist;
+                nearest = crystal;
+            }
+        }
+        return nearest;
+    }
+
+    private ItemStack createCrystalSkull() {
+        ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+        SkullMeta meta = (SkullMeta) head.getItemMeta();
+        setCustomSkullTexture(meta, CRYSTAL_TEXTURE);
+        head.setItemMeta(meta);
+        return head;
+    }
+
+    private SkullMeta setCustomSkullTexture(SkullMeta skullMeta, String base64Json) {
+        if (skullMeta == null || base64Json == null || base64Json.isEmpty()) {
+            return skullMeta;
+        }
+        try {
+            byte[] decoded = Base64.getDecoder().decode(base64Json);
+            String json = new String(decoded, StandardCharsets.UTF_8);
+            var root = com.google.gson.JsonParser.parseString(json).getAsJsonObject();
+            String urlText = root.getAsJsonObject("textures").getAsJsonObject("SKIN").get("url").getAsString();
+            PlayerProfile profile = Bukkit.createPlayerProfile(UUID.randomUUID());
+            PlayerTextures textures = profile.getTextures();
+            textures.setSkin(new URL(urlText), PlayerTextures.SkinModel.CLASSIC);
+            profile.setTextures(textures);
+            skullMeta.setOwnerProfile(profile);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+        return skullMeta;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/phases/LaunchPhase.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/phases/LaunchPhase.java
@@ -1,0 +1,52 @@
+package goat.minecraft.minecraftnew.subsystems.dragons.phases;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.dragons.DragonFight;
+import goat.minecraft.minecraftnew.subsystems.dragons.WaterDragonTrait;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.entity.EnderDragon;
+import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
+
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Phase that launches a random player high into the air.
+ */
+public class LaunchPhase implements Phase {
+
+    private final MinecraftNew plugin;
+    private final DragonFight fight;
+    private final WaterDragonTrait trait;
+    private final Random random = new Random();
+
+    public LaunchPhase(MinecraftNew plugin, DragonFight fight, WaterDragonTrait trait) {
+        this.plugin = plugin;
+        this.fight = fight;
+        this.trait = trait;
+    }
+
+    @Override
+    public void start() {
+        EnderDragon dragon = fight.getDragonEntity();
+        World world = dragon.getWorld();
+        List<Player> players = world.getPlayers();
+        if (players.isEmpty()) {
+            trait.onPhaseComplete();
+            return;
+        }
+        Player target = players.get(random.nextInt(players.size()));
+        Location loc = target.getLocation();
+        world.playSound(loc, Sound.ITEM_TRIDENT_RIPTIDE_3, 2.0f, 1.0f);
+        target.setVelocity(new Vector(0, 5, 0));
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            target.setVelocity(new Vector(0, 5, 0));
+            target.teleport(target.getLocation().add(0, 100, 0));
+            trait.onPhaseComplete();
+        });
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/phases/Phase.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/phases/Phase.java
@@ -1,0 +1,11 @@
+package goat.minecraft.minecraftnew.subsystems.dragons.phases;
+
+/**
+ * Represents a custom dragon phase or action.
+ */
+public interface Phase {
+    /**
+     * Begin executing the phase.
+     */
+    void start();
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/phases/SmitePhase.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/phases/SmitePhase.java
@@ -1,0 +1,61 @@
+package goat.minecraft.minecraftnew.subsystems.dragons.phases;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.dragons.DragonFight;
+import goat.minecraft.minecraftnew.subsystems.dragons.WaterDragonTrait;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.entity.EnderDragon;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.Vector;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Phase representing the Water Dragon's basic lightning attack.
+ */
+public class SmitePhase implements Phase {
+
+    private final MinecraftNew plugin;
+    private final DragonFight fight;
+    private final WaterDragonTrait trait;
+
+    public SmitePhase(MinecraftNew plugin, DragonFight fight, WaterDragonTrait trait) {
+        this.plugin = plugin;
+        this.fight = fight;
+        this.trait = trait;
+    }
+
+    @Override
+    public void start() {
+        EnderDragon dragon = fight.getDragonEntity();
+        World world = dragon.getWorld();
+        Location origin = dragon.getLocation();
+
+        dragon.setAI(false);
+        dragon.setVelocity(new Vector(0, 0, 0));
+
+        world.playSound(origin, Sound.ENTITY_LIGHTNING_BOLT_THUNDER, 10.0f, 1.0f);
+
+        List<Player> targets = new ArrayList<>(world.getPlayers());
+        for (Player p : targets) {
+            world.spawnParticle(Particle.FLASH, p.getLocation(), 1);
+        }
+
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                for (Player p : targets) {
+                    world.strikeLightning(p.getLocation());
+                    p.damage(50.0, dragon);
+                }
+                dragon.setAI(true);
+                trait.onPhaseComplete();
+            }
+        }.runTaskLater(plugin, 60L);
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce phase package with Heal, Smite, Launch, and Fury phases
- Add CustomPhase enum covering vanilla and new dragon phases
- Rework WaterDragonTrait to drive phase-based abilities, enforce no-perch behaviour, and randomised decision logic

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f093785c88332af9663a06df3514b