### PR TITLE
Handle dragon damage via custom health

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/DragonFightManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/DragonFightManager.java
@@ -17,6 +17,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent;
@@ -371,13 +372,16 @@ public class DragonFightManager implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDragonDamage(EntityDamageEvent event) {
         if (activeFight == null) return;
         if (!event.getEntity().getUniqueId().equals(activeFight.getDragonEntity().getUniqueId())) return;
+
+        double damage = event.getFinalDamage();
         event.setCancelled(true);
+
         DragonHealthInstance health = activeFight.getHealth();
-        health.damage(event.getFinalDamage());
+        health.damage(damage);
         if (dragonBar != null) {
             dragonBar.setProgress(health.getHealthPercentage());
             dragonBar.setTitle(buildBossBarTitle());


### PR DESCRIPTION
## Summary
- capture final Ender Dragon damage after all modifications
- cancel vanilla damage and apply it to the fight's DragonHealthInstance

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f114d1fd48332994b162f8c9fce49