### PR TITLE
Add Fire Dragon and clean up existing dragons on spawn

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/CustomPhase.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/CustomPhase.java
@@ -20,5 +20,8 @@ public enum CustomPhase {
     HEALING,
     SMITE,
     LAUNCH,
-    FURY
+    FURY,
+    FIREBALL,
+    SCORCH,
+    HELLFIRE
 }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/DragonFightManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/DragonFightManager.java
@@ -143,8 +143,10 @@ public class DragonFightManager implements Listener {
                 npc.destroy();
             }
         }
-        for (EnderDragon d : world.getEntitiesByClass(EnderDragon.class)) {
-            d.remove();
+        for (World w : Bukkit.getWorlds()) {
+            for (EnderDragon d : w.getEntitiesByClass(EnderDragon.class)) {
+                d.remove();
+            }
         }
         Dragon type = DragonRegistry.randomDragon();
         NPC npc = CitizensAPI.getNPCRegistry().createNPC(EntityType.ENDER_DRAGON, type.getDisplayName());
@@ -159,6 +161,8 @@ public class DragonFightManager implements Listener {
         // Attach behaviours specific to the dragon type.
         if (type instanceof WaterDragon) {
             npc.addTrait(new WaterDragonTrait(plugin, activeFight));
+        } else if (type instanceof FireDragon) {
+            npc.addTrait(new FireDragonTrait(plugin, activeFight));
         }
         plugin.getLogger().info("[DragonAI] FlightSpeed=" + type.getFlightSpeed() + ", BaseRage=" + type.getBaseRage());
 

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/DragonRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/DragonRegistry.java
@@ -16,8 +16,9 @@ public final class DragonRegistry {
     private static final Random RANDOM = new Random();
 
     static {
-        // Only the Water Dragon exists currently.
+        // Register available dragon types.
         REGISTERED.add(new WaterDragon());
+        REGISTERED.add(new FireDragon());
     }
 
     private DragonRegistry() {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/FireDragon.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/FireDragon.java
@@ -1,0 +1,78 @@
+package goat.minecraft.minecraftnew.subsystems.dragons;
+
+import org.bukkit.ChatColor;
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarStyle;
+import org.bukkit.entity.EnderDragon;
+
+/**
+ * Concrete implementation for the Fire Dragon.
+ *
+ * <p>The Fire Dragon represents an aggressive counterpart to the healing
+ * focused {@link WaterDragon}. It boasts higher rage, reduced decision
+ * intervals and a larger health pool.</p>
+ */
+public class FireDragon implements Dragon {
+
+    private static final int CRYSTAL_BIAS = 5;
+    private static final int FLIGHT_SPEED = 8;
+    private static final int BASE_RAGE = 7;
+    private static final int MAX_HEALTH = 3_000;
+    private static final int DECISION_INTERVAL = 10 * 20; // 10 seconds
+
+    @Override
+    public ChatColor getNameColor() {
+        return ChatColor.RED;
+    }
+
+    @Override
+    public String getName() {
+        return "Fire Dragon";
+    }
+
+    @Override
+    public BarColor getBarColor() {
+        return BarColor.RED;
+    }
+
+    @Override
+    public BarStyle getBarStyle() {
+        return BarStyle.SEGMENTED_12;
+    }
+
+    @Override
+    public int getCrystalBias() {
+        return CRYSTAL_BIAS;
+    }
+
+    @Override
+    public int getFlightSpeed() {
+        return FLIGHT_SPEED;
+    }
+
+    @Override
+    public int getBaseRage() {
+        return BASE_RAGE;
+    }
+
+    @Override
+    public int getMaxHealth() {
+        return MAX_HEALTH;
+    }
+
+    @Override
+    public int getDecisionInterval() {
+        return DECISION_INTERVAL;
+    }
+
+    @Override
+    public void decide(EnderDragon dragon) {
+        // Future AI for the Fire Dragon will be implemented here.
+    }
+
+    @Override
+    public void applyAttributes(EnderDragon dragon) {
+        dragon.setCustomName(getDisplayName());
+        dragon.setCustomNameVisible(true);
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/FireDragonTrait.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/FireDragonTrait.java
@@ -1,0 +1,133 @@
+package goat.minecraft.minecraftnew.subsystems.dragons;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.dragons.phases.*;
+import net.citizensnpcs.api.trait.Trait;
+import net.citizensnpcs.api.util.DataKey;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.EnderDragon;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.EnderDragonChangePhaseEvent;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.util.Vector;
+
+/**
+ * Trait controlling the Fire Dragon's aggressive behaviour and abilities.
+ */
+public class FireDragonTrait extends Trait implements Listener {
+
+    private final MinecraftNew plugin;
+    private final DragonFight fight;
+
+    private BukkitTask flightTask;
+    private BukkitTask decisionTask;
+    private boolean attacking;
+    private long hellfireCooldownEnd;
+    private long scorchCooldownEnd;
+
+    private static final long HELLFIRE_COOLDOWN = 90_000L; // 1.5 minutes
+    private static final long SCORCH_COOLDOWN = 180_000L; // 3 minutes
+
+    public FireDragonTrait(MinecraftNew plugin, DragonFight fight) {
+        super("fire_dragon_trait");
+        this.plugin = plugin;
+        this.fight = fight;
+    }
+
+    @Override
+    public void onAttach() {
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+        startFlightTask();
+        startDecisionLoop();
+    }
+
+    @Override
+    public void onRemove() {
+        HandlerList.unregisterAll(this);
+        if (flightTask != null) {
+            flightTask.cancel();
+        }
+        if (decisionTask != null) {
+            decisionTask.cancel();
+        }
+    }
+
+    private void startFlightTask() {
+        EnderDragon dragon = fight.getDragonEntity();
+        int speed = fight.getDragonType().getFlightSpeed();
+        double multiplier = speed / 5.0;
+        dragon.setVelocity(dragon.getVelocity().multiply(multiplier));
+        flightTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!npc.isSpawned() || dragon.isDead()) {
+                    cancel();
+                    return;
+                }
+                if (attacking) return;
+                Vector dir = dragon.getLocation().getDirection().normalize();
+                Vector vel = dragon.getVelocity();
+                if (multiplier > 1.0) {
+                    dragon.setVelocity(vel.add(dir.multiply(multiplier)));
+                } else if (multiplier < 1.0) {
+                    dragon.setVelocity(vel.multiply(multiplier));
+                }
+            }
+        }.runTaskTimer(plugin, 0L, 5L);
+    }
+
+    @EventHandler
+    public void onPhaseChange(EnderDragonChangePhaseEvent event) {
+        if (!event.getEntity().getUniqueId().equals(fight.getDragonEntity().getUniqueId())) {
+            return;
+        }
+        EnderDragon.Phase phase = event.getNewPhase();
+        switch (phase) {
+            case LAND_ON_PORTAL:
+            case FLY_TO_PORTAL:
+            case LEAVE_PORTAL:
+            case HOVER:
+            case ROAR_BEFORE_ATTACK:
+            case BREATH_ATTACK:
+            case SEARCH_FOR_BREATH_ATTACK_TARGET:
+                event.setNewPhase(EnderDragon.Phase.CIRCLING);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void startDecisionLoop() {
+        int interval = fight.getDragonType().getDecisionInterval();
+        decisionTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!npc.isSpawned() || attacking) {
+                    return;
+                }
+                long now = System.currentTimeMillis();
+                attacking = true;
+                double hp = fight.getHealth().getHealthPercentage();
+                if (hp <= 0.5 && now >= hellfireCooldownEnd) {
+                    new HellfirePhase(plugin, fight, FireDragonTrait.this).start();
+                    hellfireCooldownEnd = now + HELLFIRE_COOLDOWN;
+                } else if (now >= scorchCooldownEnd) {
+                    new ScorchPhase(plugin, fight, FireDragonTrait.this).start();
+                    scorchCooldownEnd = now + SCORCH_COOLDOWN;
+                } else {
+                    new FireballPhase(plugin, fight, FireDragonTrait.this).start();
+                }
+            }
+        }.runTaskTimer(plugin, interval, interval);
+    }
+
+    public void onPhaseComplete() {
+        attacking = false;
+    }
+
+    @Override public void load(DataKey key) { }
+    @Override public void save(DataKey key) { }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/phases/FireballPhase.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/phases/FireballPhase.java
@@ -1,0 +1,47 @@
+package goat.minecraft.minecraftnew.subsystems.dragons.phases;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.dragons.DragonFight;
+import goat.minecraft.minecraftnew.subsystems.dragons.FireDragonTrait;
+import org.bukkit.World;
+import org.bukkit.entity.EnderDragon;
+import org.bukkit.entity.Fireball;
+import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
+
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Basic attack phase launching a powerful fireball at a player.
+ */
+public class FireballPhase implements Phase {
+
+    private final MinecraftNew plugin;
+    private final DragonFight fight;
+    private final FireDragonTrait trait;
+    private final Random random = new Random();
+
+    public FireballPhase(MinecraftNew plugin, DragonFight fight, FireDragonTrait trait) {
+        this.plugin = plugin;
+        this.fight = fight;
+        this.trait = trait;
+    }
+
+    @Override
+    public void start() {
+        EnderDragon dragon = fight.getDragonEntity();
+        World world = dragon.getWorld();
+        List<Player> players = world.getPlayers();
+        if (players.isEmpty()) {
+            trait.onPhaseComplete();
+            return;
+        }
+        Player target = players.get(random.nextInt(players.size()));
+        Vector dir = target.getLocation().toVector().subtract(dragon.getLocation().toVector()).normalize().multiply(2);
+        Fireball fireball = dragon.launchProjectile(Fireball.class, dir);
+        fireball.setIsIncendiary(true);
+        fireball.setYield(6f);
+        trait.onPhaseComplete();
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/phases/HellfirePhase.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/phases/HellfirePhase.java
@@ -1,0 +1,67 @@
+package goat.minecraft.minecraftnew.subsystems.dragons.phases;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.dragons.DragonFight;
+import goat.minecraft.minecraftnew.subsystems.dragons.FireDragonTrait;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.World;
+import org.bukkit.entity.EnderDragon;
+import org.bukkit.entity.Fireball;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.Vector;
+
+import java.util.Random;
+
+/**
+ * Ultimate phase raining fireballs across the island.
+ */
+public class HellfirePhase implements Phase {
+
+    private final MinecraftNew plugin;
+    private final DragonFight fight;
+    private final FireDragonTrait trait;
+    private final Random random = new Random();
+
+    public HellfirePhase(MinecraftNew plugin, DragonFight fight, FireDragonTrait trait) {
+        this.plugin = plugin;
+        this.fight = fight;
+        this.trait = trait;
+    }
+
+    @Override
+    public void start() {
+        EnderDragon dragon = fight.getDragonEntity();
+        World world = dragon.getWorld();
+        Location freezeLoc = dragon.getLocation().clone();
+        dragon.setAI(false);
+        dragon.setVelocity(new Vector(0, 0, 0));
+
+        // Particle task and unlock after 5 seconds
+        new BukkitRunnable() {
+            int ticks = 0;
+            @Override
+            public void run() {
+                if (ticks++ >= 100 || dragon.isDead()) {
+                    dragon.setAI(true);
+                    trait.onPhaseComplete();
+                    cancel();
+                    return;
+                }
+                dragon.teleport(freezeLoc);
+                world.spawnParticle(Particle.FLAME, freezeLoc, 50, 1, 1, 1, 0.1);
+            }
+        }.runTaskTimer(plugin, 0L, 1L);
+
+        for (int i = 0; i < 1000; i++) {
+            double x = freezeLoc.getX() + random.nextInt(400) - 200;
+            double z = freezeLoc.getZ() + random.nextInt(400) - 200;
+            Location loc = new Location(world, x, 100, z);
+            Fireball fb = world.spawn(loc, Fireball.class);
+            fb.setIsIncendiary(true);
+            fb.setYield(6f);
+            fb.setVelocity(new Vector(0, -1, 0));
+            fb.setShooter(dragon);
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/phases/ScorchPhase.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/phases/ScorchPhase.java
@@ -1,0 +1,70 @@
+package goat.minecraft.minecraftnew.subsystems.dragons.phases;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.dragons.DragonFight;
+import goat.minecraft.minecraftnew.subsystems.dragons.FireDragonTrait;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.World;
+import org.bukkit.entity.EnderDragon;
+import org.bukkit.entity.EntityType;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.Vector;
+
+import java.util.Random;
+
+/**
+ * Special phase summoning waves of ghasts around the dragon.
+ */
+public class ScorchPhase implements Phase {
+
+    private final MinecraftNew plugin;
+    private final DragonFight fight;
+    private final FireDragonTrait trait;
+    private final Random random = new Random();
+
+    public ScorchPhase(MinecraftNew plugin, DragonFight fight, FireDragonTrait trait) {
+        this.plugin = plugin;
+        this.fight = fight;
+        this.trait = trait;
+    }
+
+    @Override
+    public void start() {
+        EnderDragon dragon = fight.getDragonEntity();
+        World world = dragon.getWorld();
+        Location freezeLoc = dragon.getLocation().clone();
+        dragon.setAI(false);
+        dragon.setVelocity(new Vector(0, 0, 0));
+
+        new BukkitRunnable() {
+            int seconds = 0;
+            int spawned = 0;
+
+            @Override
+            public void run() {
+                if (!trait.getNPC().isSpawned() || dragon.isDead()) {
+                    dragon.setAI(true);
+                    trait.onPhaseComplete();
+                    cancel();
+                    return;
+                }
+                dragon.teleport(freezeLoc);
+                world.spawnParticle(Particle.FLAME, freezeLoc, 30, 1, 1, 1, 0.1);
+                seconds++;
+                if (seconds % 3 == 0 && spawned < 16) {
+                    double angle = random.nextDouble() * 2 * Math.PI;
+                    double dist = random.nextDouble() * 20;
+                    Location loc = freezeLoc.clone().add(Math.cos(angle) * dist, 1, Math.sin(angle) * dist);
+                    world.spawnEntity(loc, EntityType.GHAST);
+                    spawned++;
+                    if (spawned >= 16) {
+                        dragon.setAI(true);
+                        trait.onPhaseComplete();
+                        cancel();
+                    }
+                }
+            }
+        }.runTaskTimer(plugin, 0L, 20L);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure spawnFight removes any existing dragons before spawning a new custom dragon
- register and implement aggressive Fire Dragon with Hellfire, Scorch, and Fireball phases
- extend phase enum to support new fire-based phases

## Testing
- `mvn -q test` *(fails: The following artifacts could not be resolved: org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 (absent): Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f1b7e98588332952d48b6c144cebb