### PR TITLE
Add golden repair stats, talents, and durability framework

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -67,6 +67,7 @@ import goat.minecraft.minecraftnew.utils.commands.TogglePotionEffectsCommand;
 import goat.minecraft.minecraftnew.utils.commands.ToggleBarsCommand;
 import goat.minecraft.minecraftnew.utils.developercommands.*;
 import goat.minecraft.minecraftnew.utils.developercommands.SetCustomDurabilityCommand;
+import goat.minecraft.minecraftnew.utils.developercommands.AddGoldenDurabilityCommand;
 import goat.minecraft.minecraftnew.utils.stats.StatsCalculator;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
 import goat.minecraft.minecraftnew.utils.developercommands.AddTalentPointCommand;
@@ -263,6 +264,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         new SetDurabilityCommand(this);
         CustomDurabilityManager.init(this);
         new SetCustomDurabilityCommand(this);
+        new AddGoldenDurabilityCommand(this);
         this.getCommand("skin").setExecutor(new SkinCommand());
         PetManager petManager = PetManager.getInstance(this);
         this.getCommand("testpet").setExecutor(new PetTestCommand(petManager));

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -376,8 +376,10 @@ public class SkillTreeManager implements Listener {
                 return ChatColor.YELLOW + "+" + (level * 1.5) + "% Chance to increase Max Durability";
             case NOVICE_SMITH:
                 return ChatColor.YELLOW + "+" + (level * 25) + "% Common Reforge Chance";
-            case SCRAPS_I:
-                return ChatColor.YELLOW + "-" + (level * 3) + " Mats required to start a Reforge";
+            case GOLDEN_REPAIR_I:
+                return ChatColor.GOLD + "+" + (level * 2) + ChatColor.GRAY + " Golden Repair Amount";
+            case GOLDSMITH_I:
+                return ChatColor.GOLD + "+" + (level * 2) + ChatColor.GRAY + " Golden Repair Quality";
             case NOVICE_FOUNDATIONS:
                 return ChatColor.YELLOW + "-" + (level * 25) + "% Anvil Degrade Chance";
 
@@ -389,8 +391,10 @@ public class SkillTreeManager implements Listener {
                 return ChatColor.YELLOW + "+" + (level * 1.5) + "% Chance to increase Max Durability";
             case APPRENTICE_SMITH:
                 return ChatColor.YELLOW + "+" + (level * 25) + "% Uncommon Reforge Chance";
-            case SCRAPS_II:
-                return ChatColor.YELLOW + "-" + (level * 3) + " Mats required to start a Reforge";
+            case GOLDEN_REPAIR_II:
+                return ChatColor.GOLD + "+" + (level * 2) + ChatColor.GRAY + " Golden Repair Amount";
+            case GOLDSMITH_II:
+                return ChatColor.GOLD + "+" + (level * 2) + ChatColor.GRAY + " Golden Repair Quality";
             case APPRENTICE_FOUNDATIONS:
                 return ChatColor.YELLOW + "-" + (level * 25) + "% Anvil Degrade Chance";
 
@@ -402,8 +406,10 @@ public class SkillTreeManager implements Listener {
                 return ChatColor.YELLOW + "+" + (level * 1.5) + "% Chance to increase Max Durability";
             case JOURNEYMAN_SMITH:
                 return ChatColor.YELLOW + "+" + (level * 25) + "% Rare Reforge Chance";
-            case SCRAPS_III:
-                return ChatColor.YELLOW + "-" + (level * 3) + " Mats required to start a Reforge";
+            case GOLDEN_REPAIR_III:
+                return ChatColor.GOLD + "+" + (level * 2) + ChatColor.GRAY + " Golden Repair Amount";
+            case GOLDSMITH_III:
+                return ChatColor.GOLD + "+" + (level * 2) + ChatColor.GRAY + " Golden Repair Quality";
             case JOURNEYMAN_FOUNDATIONS:
                 return ChatColor.YELLOW + "-" + (level * 25) + "% Anvil Degrade Chance";
 
@@ -415,8 +421,10 @@ public class SkillTreeManager implements Listener {
                 return ChatColor.YELLOW + "+" + (level * 1.5) + "% Chance to increase Max Durability";
             case EXPERT_SMITH:
                 return ChatColor.YELLOW + "+" + (level * 25) + "% Epic Reforge Chance";
-            case SCRAPS_IV:
-                return ChatColor.YELLOW + "-" + (level * 3) + " Mats required to start a Reforge";
+            case GOLDEN_REPAIR_IV:
+                return ChatColor.GOLD + "+" + (level * 2) + ChatColor.GRAY + " Golden Repair Amount";
+            case GOLDSMITH_IV:
+                return ChatColor.GOLD + "+" + (level * 2) + ChatColor.GRAY + " Golden Repair Quality";
             case EXPERT_FOUNDATIONS:
                 return ChatColor.YELLOW + "-" + (level * 25) + "% Anvil Degrade Chance";
 
@@ -428,8 +436,10 @@ public class SkillTreeManager implements Listener {
                 return ChatColor.YELLOW + "+" + (level * 0.5) + "% Chance to increase Max Durability";
             case MASTER_SMITH:
                 return ChatColor.YELLOW + "+" + (level * 25) + "% Legendary Reforge Chance";
-            case SCRAPS_V:
-                return ChatColor.YELLOW + "-" + (level * 3) + " Mats required to start a Reforge";
+            case GOLDEN_REPAIR_V:
+                return ChatColor.GOLD + "+" + (level * 2) + ChatColor.GRAY + " Golden Repair Amount";
+            case GOLDSMITH_V:
+                return ChatColor.GOLD + "+" + (level * 2) + ChatColor.GRAY + " Golden Repair Quality";
             case MASTER_FOUNDATIONS:
                 return ChatColor.YELLOW + "-" + (level * 25) + "% Anvil Degrade Chance";
             case FORGE_LABORATORIES_I:

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -589,13 +589,21 @@ public enum Talent {
             1,
             Material.STONE_PICKAXE
     ),
-    SCRAPS_I(
-            "Scraps I",
-            ChatColor.GRAY + "Reuse leftover materials",
-            ChatColor.YELLOW + "-3 Reforge Mats",
-            3,
+    GOLDEN_REPAIR_I(
+            "Golden Repair I",
+            ChatColor.GRAY + "Improve gilding capacity",
+            ChatColor.GOLD + "+2 Golden Repair Amount",
+            2,
             1,
-            Material.COBBLESTONE
+            Material.GOLD_INGOT
+    ),
+    GOLDSMITH_I(
+            "Goldsmith I",
+            ChatColor.GRAY + "Refine golden craftsmanship",
+            ChatColor.GOLD + "+2 Golden Repair Quality",
+            1,
+            1,
+            Material.GOLD_BLOCK
     ),
     NOVICE_FOUNDATIONS(
             "Novice Foundations",
@@ -638,13 +646,21 @@ public enum Talent {
             20,
             Material.IRON_PICKAXE
     ),
-    SCRAPS_II(
-            "Scraps II",
-            ChatColor.GRAY + "Reduce material waste",
-            ChatColor.YELLOW + "-3 Reforge Mats",
-            3,
+    GOLDEN_REPAIR_II(
+            "Golden Repair II",
+            ChatColor.GRAY + "Improve gilding capacity",
+            ChatColor.GOLD + "+2 Golden Repair Amount",
+            2,
             20,
-            Material.IRON_NUGGET
+            Material.GOLD_INGOT
+    ),
+    GOLDSMITH_II(
+            "Goldsmith II",
+            ChatColor.GRAY + "Refine golden craftsmanship",
+            ChatColor.GOLD + "+2 Golden Repair Quality",
+            1,
+            20,
+            Material.GOLD_BLOCK
     ),
     APPRENTICE_FOUNDATIONS(
             "Apprentice Foundations",
@@ -687,13 +703,21 @@ public enum Talent {
             40,
             Material.GOLDEN_PICKAXE
     ),
-    SCRAPS_III(
-            "Scraps III",
-            ChatColor.GRAY + "Efficient recycling",
-            ChatColor.YELLOW + "-3 Reforge Mats",
-            3,
+    GOLDEN_REPAIR_III(
+            "Golden Repair III",
+            ChatColor.GRAY + "Improve gilding capacity",
+            ChatColor.GOLD + "+2 Golden Repair Amount",
+            2,
             40,
-            Material.GOLD_NUGGET
+            Material.GOLD_INGOT
+    ),
+    GOLDSMITH_III(
+            "Goldsmith III",
+            ChatColor.GRAY + "Refine golden craftsmanship",
+            ChatColor.GOLD + "+2 Golden Repair Quality",
+            1,
+            40,
+            Material.GOLD_BLOCK
     ),
     JOURNEYMAN_FOUNDATIONS(
             "Journeyman Foundations",
@@ -736,13 +760,21 @@ public enum Talent {
             60,
             Material.DIAMOND_PICKAXE
     ),
-    SCRAPS_IV(
-            "Scraps IV",
-            ChatColor.GRAY + "Minimal waste",
-            ChatColor.YELLOW + "-3 Reforge Mats",
-            3,
+    GOLDEN_REPAIR_IV(
+            "Golden Repair IV",
+            ChatColor.GRAY + "Improve gilding capacity",
+            ChatColor.GOLD + "+2 Golden Repair Amount",
+            2,
             60,
-            Material.DIAMOND
+            Material.GOLD_INGOT
+    ),
+    GOLDSMITH_IV(
+            "Goldsmith IV",
+            ChatColor.GRAY + "Refine golden craftsmanship",
+            ChatColor.GOLD + "+2 Golden Repair Quality",
+            1,
+            60,
+            Material.GOLD_BLOCK
     ),
     EXPERT_FOUNDATIONS(
             "Expert Foundations",
@@ -785,13 +817,21 @@ public enum Talent {
             80,
             Material.NETHERITE_PICKAXE
     ),
-    SCRAPS_V(
-            "Scraps V",
-            ChatColor.GRAY + "Zero waste",
-            ChatColor.YELLOW + "-3 Reforge Mats",
-            3,
+    GOLDEN_REPAIR_V(
+            "Golden Repair V",
+            ChatColor.GRAY + "Improve gilding capacity",
+            ChatColor.GOLD + "+2 Golden Repair Amount",
+            2,
             80,
-            Material.NETHERITE_SCRAP
+            Material.GOLD_INGOT
+    ),
+    GOLDSMITH_V(
+            "Goldsmith V",
+            ChatColor.GRAY + "Refine golden craftsmanship",
+            ChatColor.GOLD + "+2 Golden Repair Quality",
+            1,
+            80,
+            Material.GOLD_BLOCK
     ),
     MASTER_FOUNDATIONS(
             "Master Foundations",

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/TalentRegistry.java
@@ -72,31 +72,36 @@ public final class TalentRegistry {
                         Talent.REPAIR_AMOUNT_I,
                         Talent.QUALITY_MATERIALS_I,
                         Talent.ALLOY_I,
-                        Talent.SCRAPS_I,
+                        Talent.GOLDEN_REPAIR_I,
+                        Talent.GOLDSMITH_I,
                         Talent.FORGE_LABORATORIES_I,
 
                         Talent.REPAIR_AMOUNT_II,
                         Talent.QUALITY_MATERIALS_II,
                         Talent.ALLOY_II,
-                        Talent.SCRAPS_II,
+                        Talent.GOLDEN_REPAIR_II,
+                        Talent.GOLDSMITH_II,
                         Talent.FORGE_LABORATORIES_II,
 
                         Talent.REPAIR_AMOUNT_III,
                         Talent.QUALITY_MATERIALS_III,
                         Talent.ALLOY_III,
-                        Talent.SCRAPS_III,
+                        Talent.GOLDEN_REPAIR_III,
+                        Talent.GOLDSMITH_III,
                         Talent.FORGE_LABORATORIES_III,
 
                         Talent.REPAIR_AMOUNT_IV,
                         Talent.QUALITY_MATERIALS_IV,
                         Talent.ALLOY_IV,
-                        Talent.SCRAPS_IV,
+                        Talent.GOLDEN_REPAIR_IV,
+                        Talent.GOLDSMITH_IV,
                         Talent.FORGE_LABORATORIES_IV,
 
                         Talent.REPAIR_AMOUNT_V,
                         Talent.QUALITY_MATERIALS_V,
                         Talent.ALLOY_V,
-                        Talent.SCRAPS_V,
+                        Talent.GOLDEN_REPAIR_V,
+                        Talent.GOLDSMITH_V,
                         Talent.FORGE_LABORATORIES_V
 
                 )

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
@@ -247,15 +247,6 @@ public class AnvilRepair implements Listener {
                     case TIER_5 -> needed = Material.DIAMOND;
                 }
                 int matsCount = 64;
-                SkillTreeManager mgr = SkillTreeManager.getInstance();
-                if (mgr != null) {
-                    UUID uid = player.getUniqueId();
-                    matsCount -= mgr.getTalentLevel(uid, Skill.SMITHING, Talent.SCRAPS_I) * 3;
-                    matsCount -= mgr.getTalentLevel(uid, Skill.SMITHING, Talent.SCRAPS_II) * 3;
-                    matsCount -= mgr.getTalentLevel(uid, Skill.SMITHING, Talent.SCRAPS_III) * 3;
-                    matsCount -= mgr.getTalentLevel(uid, Skill.SMITHING, Talent.SCRAPS_IV) * 3;
-                    matsCount -= mgr.getTalentLevel(uid, Skill.SMITHING, Talent.SCRAPS_V) * 3;
-                }
                 lore.add(ChatColor.GRAY + "Next: " + next.getColor() + next.name());
                 lore.add(ChatColor.GRAY + "Cost: " + matsCount + " " + formatMaterial(needed));
             }
@@ -1870,15 +1861,6 @@ public class AnvilRepair implements Listener {
         }
 
         int matsCount = 64;
-        SkillTreeManager mgr = SkillTreeManager.getInstance();
-        if (mgr != null) {
-            UUID uid = player.getUniqueId();
-            matsCount -= mgr.getTalentLevel(uid, Skill.SMITHING, Talent.SCRAPS_I) * 3;
-            matsCount -= mgr.getTalentLevel(uid, Skill.SMITHING, Talent.SCRAPS_II) * 3;
-            matsCount -= mgr.getTalentLevel(uid, Skill.SMITHING, Talent.SCRAPS_III) * 3;
-            matsCount -= mgr.getTalentLevel(uid, Skill.SMITHING, Talent.SCRAPS_IV) * 3;
-            matsCount -= mgr.getTalentLevel(uid, Skill.SMITHING, Talent.SCRAPS_V) * 3;
-        }
 
         if (mats.getType() != needed || mats.getAmount() < matsCount) {
             player.sendMessage(ChatColor.RED + "Not enough materials");

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/StatsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/StatsCommand.java
@@ -89,6 +89,8 @@ public class StatsCommand implements CommandExecutor, Listener {
         addStatItem(inv, slots[index++], Material.WHEAT, "Double Crop Chance", String.format("%.1f%%", calculator.getDoubleCropChance(player)));
         addStatItem(inv, slots[index++], Material.ANVIL, "Repair Amount", String.format("%.1f", calculator.getRepairAmount(player)));
         addStatItem(inv, slots[index++], Material.ENCHANTED_BOOK, "Repair Quality", String.format("%.1f", calculator.getRepairQuality(player)));
+        addStatItem(inv, slots[index++], Material.GOLD_INGOT, "Golden Repair Amount", String.format("%.1f", calculator.getGoldenRepairAmount(player)));
+        addStatItem(inv, slots[index++], Material.GOLD_BLOCK, "Golden Repair Quality", String.format("%.1f", calculator.getGoldenRepairQuality(player)));
 
         player.openInventory(inv);
     }

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/AddGoldenDurabilityCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/AddGoldenDurabilityCommand.java
@@ -1,0 +1,56 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import goat.minecraft.minecraftnew.other.durability.CustomDurabilityManager;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Admin command to assign Golden Durability to the item in the player's main hand.
+ * Usage: /addgoldendurability <amount>
+ */
+public class AddGoldenDurabilityCommand implements CommandExecutor {
+    public AddGoldenDurabilityCommand(JavaPlugin plugin) {
+        plugin.getCommand("addgoldendurability").setExecutor(this);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You don't have permission to use this command.");
+            return true;
+        }
+
+        if (args.length < 1) {
+            player.sendMessage(ChatColor.RED + "Usage: /" + label + " <amount>");
+            return true;
+        }
+
+        int amount;
+        try {
+            amount = Integer.parseInt(args[0]);
+        } catch (NumberFormatException e) {
+            player.sendMessage(ChatColor.RED + "Amount must be an integer.");
+            return true;
+        }
+
+        ItemStack item = player.getInventory().getItemInMainHand();
+        if (item == null || item.getType().isAir()) {
+            player.sendMessage(ChatColor.RED + "You must be holding an item.");
+            return true;
+        }
+
+        CustomDurabilityManager.getInstance().setGoldenDurability(item, amount);
+        player.sendMessage(ChatColor.GOLD + "Set golden durability to " + amount + ".");
+        return true;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/stats/StatsCalculator.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/stats/StatsCalculator.java
@@ -415,4 +415,38 @@ public class StatsCalculator {
         }
         return quality;
     }
+
+    /**
+     * Golden repair amount from smithing talents.
+     * Base amount is 10.
+     */
+    public double getGoldenRepairAmount(Player player) {
+        double amount = 10.0; // base
+        if (SkillTreeManager.getInstance() != null) {
+            SkillTreeManager mgr = SkillTreeManager.getInstance();
+            amount += mgr.getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.GOLDEN_REPAIR_I) * 2;
+            amount += mgr.getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.GOLDEN_REPAIR_II) * 2;
+            amount += mgr.getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.GOLDEN_REPAIR_III) * 2;
+            amount += mgr.getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.GOLDEN_REPAIR_IV) * 2;
+            amount += mgr.getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.GOLDEN_REPAIR_V) * 2;
+        }
+        return amount;
+    }
+
+    /**
+     * Golden repair quality from smithing talents.
+     * Base quality is 0.
+     */
+    public double getGoldenRepairQuality(Player player) {
+        double quality = 0.0; // base
+        if (SkillTreeManager.getInstance() != null) {
+            SkillTreeManager mgr = SkillTreeManager.getInstance();
+            quality += mgr.getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.GOLDSMITH_I) * 2;
+            quality += mgr.getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.GOLDSMITH_II) * 2;
+            quality += mgr.getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.GOLDSMITH_III) * 2;
+            quality += mgr.getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.GOLDSMITH_IV) * 2;
+            quality += mgr.getTalentLevel(player.getUniqueId(), Skill.SMITHING, Talent.GOLDSMITH_V) * 2;
+        }
+        return quality;
+    }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -47,6 +47,10 @@ commands:
     description: Sets custom durability values on the held item
     usage: /setcustomdurability <current> <max>
     permission: continuity.admin
+  addgoldendurability:
+    description: Sets Golden Durability on the held item
+    usage: /addgoldendurability <amount>
+    permission: continuity.admin
   forceworkcycle:
     description: Forces the villager work cycle timer to 1 second.
     usage: /<command>


### PR DESCRIPTION
## Summary
- Extend custom durability manager with Golden Durability support that freezes normal durability and uses lore/unbreakable indicators.
- Provide `/addgoldendurability` admin command and register it in the plugin for testing.

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6890485f079c83329c175169576ed09f