### PR TITLE
Implement initial Golden Durability system

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -263,6 +263,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         new SetDurabilityCommand(this);
         CustomDurabilityManager.init(this);
         new SetCustomDurabilityCommand(this);
+        new AddGoldenDurabilityCommand(this);
         this.getCommand("skin").setExecutor(new SkinCommand());
         PetManager petManager = PetManager.getInstance(this);
         this.getCommand("testpet").setExecutor(new PetTestCommand(petManager));

--- a/src/main/java/goat/minecraft/minecraftnew/other/durability/CustomDurabilityManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/durability/CustomDurabilityManager.java
@@ -32,12 +32,16 @@ public class CustomDurabilityManager implements Listener {
     private final NamespacedKey currentKey;
     private final NamespacedKey maxKey;
     private final NamespacedKey bonusKey;
+    private final NamespacedKey goldenKey;
+    private final NamespacedKey goldenMaxKey;
 
     private CustomDurabilityManager(JavaPlugin plugin) {
         this.plugin = plugin;
         this.currentKey = new NamespacedKey(plugin, "custom_durability");
         this.maxKey = new NamespacedKey(plugin, "custom_max_durability");
         this.bonusKey = new NamespacedKey(plugin, "custom_bonus_durability");
+        this.goldenKey = new NamespacedKey(plugin, "golden_durability");
+        this.goldenMaxKey = new NamespacedKey(plugin, "golden_max_durability");
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
     }
 
@@ -115,6 +119,86 @@ public class CustomDurabilityManager implements Listener {
     }
 
     /**
+     * Returns true if the item currently has golden durability applied.
+     */
+    public boolean hasGoldenDurability(ItemStack item) {
+        return getGoldenDurability(item) > 0;
+    }
+
+    /**
+     * Gets the current golden durability on the item.
+     */
+    public int getGoldenDurability(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return 0;
+        PersistentDataContainer data = meta.getPersistentDataContainer();
+        Integer value = data.get(goldenKey, PersistentDataType.INTEGER);
+        return value != null ? value : 0;
+    }
+
+    /**
+     * Gets the max golden durability on the item.
+     */
+    public int getGoldenMaxDurability(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return 0;
+        PersistentDataContainer data = meta.getPersistentDataContainer();
+        Integer value = data.get(goldenMaxKey, PersistentDataType.INTEGER);
+        return value != null ? value : 0;
+    }
+
+    /**
+     * Applies golden durability to the item.
+     */
+    public void setGoldenDurability(ItemStack item, int amount) {
+        if (item == null || amount <= 0) return;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        PersistentDataContainer data = meta.getPersistentDataContainer();
+        data.set(goldenKey, PersistentDataType.INTEGER, amount);
+        data.set(goldenMaxKey, PersistentDataType.INTEGER, amount);
+        item.setItemMeta(meta);
+
+        int current = getCurrentDurability(item);
+        int max = getMaxDurability(item);
+        updateLore(item, current, max);
+        updateVanillaDamage(item, current, max);
+    }
+
+    /**
+     * Updates the current golden durability while keeping the max the same.
+     */
+    private void setGoldenCurrent(ItemStack item, int amount) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        PersistentDataContainer data = meta.getPersistentDataContainer();
+        data.set(goldenKey, PersistentDataType.INTEGER, Math.max(0, amount));
+        item.setItemMeta(meta);
+
+        int current = getCurrentDurability(item);
+        int max = getMaxDurability(item);
+        updateLore(item, current, max);
+        updateVanillaDamage(item, current, max);
+    }
+
+    /**
+     * Removes all golden durability data from the item.
+     */
+    public void removeGoldenDurability(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        PersistentDataContainer data = meta.getPersistentDataContainer();
+        data.remove(goldenKey);
+        data.remove(goldenMaxKey);
+        item.setItemMeta(meta);
+
+        int current = getCurrentDurability(item);
+        int max = getMaxDurability(item);
+        updateLore(item, current, max);
+        updateVanillaDamage(item, current, max);
+    }
+
+    /**
      * Adds bonus max durability to the item and updates lore.
      */
     public void addMaxDurabilityBonus(ItemStack item, int amount) {
@@ -154,6 +238,17 @@ public class CustomDurabilityManager implements Listener {
     public void applyDamage(Player player, ItemStack item, int amount) {
         convertVanillaUnbreaking(item);
         ensureUnbreakingBonus(item);
+        int golden = getGoldenDurability(item);
+        if (golden > 0) {
+            int newGolden = golden - amount;
+            if (newGolden > 0) {
+                setGoldenCurrent(item, newGolden);
+            } else {
+                removeGoldenDurability(item);
+                repairFully(item);
+            }
+            return;
+        }
 
         int current = getCurrentDurability(item);
         int max = getMaxDurability(item);
@@ -217,12 +312,34 @@ public class CustomDurabilityManager implements Listener {
         ItemMeta meta = item.getItemMeta();
         if (meta == null) return;
         List<String> lore = meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
-        String line = ChatColor.GRAY + "Durability: " + current + "/" + max;
-        if (!lore.isEmpty() && ChatColor.stripColor(lore.get(lore.size() - 1)).startsWith("Durability:")) {
-            lore.set(lore.size() - 1, line);
+
+        String line;
+        if (hasGoldenDurability(item)) {
+            int gCur = getGoldenDurability(item);
+            int gMax = getGoldenMaxDurability(item);
+            line = ChatColor.GOLD + "Golden Durability: " + gCur + "/" + gMax;
+        } else {
+            line = ChatColor.GRAY + "Durability: " + current + "/" + max;
+        }
+
+        int index = -1;
+        for (int i = 0; i < lore.size(); i++) {
+            String stripped = ChatColor.stripColor(lore.get(i));
+            if (stripped.startsWith("Durability:") || stripped.startsWith("Golden Durability:")) {
+                if (index == -1) {
+                    index = i;
+                } else {
+                    lore.remove(i--);
+                }
+            }
+        }
+
+        if (index != -1) {
+            lore.set(index, line);
         } else {
             lore.add(line);
         }
+
         meta.setLore(lore);
         item.setItemMeta(meta);
         goat.minecraft.minecraftnew.utils.devtools.ItemLoreFormatter.formatLore(item);
@@ -233,11 +350,15 @@ public class CustomDurabilityManager implements Listener {
         if (meta instanceof Damageable damageable) {
             int vanillaMax = item.getType().getMaxDurability();
             if (vanillaMax > 0) {
-                double ratio = 1.0 - ((double) current / max);
-                int newDamage = (int) Math.round(ratio * vanillaMax);
-                if (newDamage < 0) newDamage = 0;
-                if (newDamage > vanillaMax) newDamage = vanillaMax;
-                damageable.setDamage(newDamage);
+                if (hasGoldenDurability(item)) {
+                    damageable.setDamage(0);
+                } else {
+                    double ratio = 1.0 - ((double) current / max);
+                    int newDamage = (int) Math.round(ratio * vanillaMax);
+                    if (newDamage < 0) newDamage = 0;
+                    if (newDamage > vanillaMax) newDamage = vanillaMax;
+                    damageable.setDamage(newDamage);
+                }
                 item.setItemMeta(meta);
             }
         }

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/AddGoldenDurabilityCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/AddGoldenDurabilityCommand.java
@@ -1,0 +1,69 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import goat.minecraft.minecraftnew.other.durability.CustomDurabilityManager;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Developer command to apply Golden Durability to the item in the player's
+ * main hand. Usage: /addgoldendurability <amount>
+ */
+public class AddGoldenDurabilityCommand implements CommandExecutor {
+    private final JavaPlugin plugin;
+
+    public AddGoldenDurabilityCommand(JavaPlugin plugin) {
+        this.plugin = plugin;
+        plugin.getCommand("addgoldendurability").setExecutor(this);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You don't have permission to use this command.");
+            return true;
+        }
+
+        if (args.length < 1) {
+            player.sendMessage(ChatColor.RED + "Usage: /" + label + " <amount>");
+            return true;
+        }
+
+        int amount;
+        try {
+            amount = Integer.parseInt(args[0]);
+        } catch (NumberFormatException e) {
+            player.sendMessage(ChatColor.RED + "Amount must be an integer.");
+            return true;
+        }
+        if (amount <= 0) {
+            player.sendMessage(ChatColor.RED + "Amount must be positive.");
+            return true;
+        }
+
+        ItemStack item = player.getInventory().getItemInMainHand();
+        if (item == null || item.getType().isAir()) {
+            player.sendMessage(ChatColor.RED + "You must be holding an item.");
+            return true;
+        }
+
+        CustomDurabilityManager mgr = CustomDurabilityManager.getInstance();
+        if (mgr.hasGoldenDurability(item)) {
+            player.sendMessage(ChatColor.RED + "This item already has Golden Durability.");
+            return true;
+        }
+
+        mgr.setGoldenDurability(item, amount);
+        player.sendMessage(ChatColor.GOLD + "Added Golden Durability: " + amount + "/" + amount);
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -47,6 +47,10 @@ commands:
     description: Sets custom durability values on the held item
     usage: /setcustomdurability <current> <max>
     permission: continuity.admin
+  addgoldendurability:
+    description: Adds Golden Durability to the held item
+    usage: /addgoldendurability <amount>
+    permission: continuity.admin
   forceworkcycle:
     description: Forces the villager work cycle timer to 1 second.
     usage: /<command>


### PR DESCRIPTION
## Summary
- implement Golden Durability overlay system with lore, damage interception and durability bar suppression
- add admin command `/addgoldendurability <amount>` for testing
- fix Golden Durability line replacement to update in place and restore normal durability when depleted

## Testing
- `mvn -q test` *(fails: Network is unreachable for maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68905cf47ecc8332b75d5e52d093ea8d