### PR TITLE
Align golden durability lore with standard durability

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemLoreFormatter.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemLoreFormatter.java
@@ -66,7 +66,7 @@ public class ItemLoreFormatter {
             } else if (stripped.startsWith("Damage Increase") || stripped.startsWith("Damage Reduction") ||
                        stripped.startsWith("Chance to repair durability") || stripped.startsWith("Max Durability")) {
                 reforge.add(line);
-            } else if (stripped.startsWith("Durability:")) {
+            } else if (stripped.startsWith("Durability:") || stripped.startsWith("Golden Durability:")) {
                 durability = line;
             } else if (stripped.contains("Full Set Bonus")) {
                 bless = line;


### PR DESCRIPTION
## Summary
- Treat `Golden Durability` lore lines as durability in the lore formatter so they appear in the standard location.

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689063216d448332992ec7a91e0ebc63