### PR TITLE
Add gilded heirloom smithing items

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -100,6 +100,7 @@ import goat.minecraft.minecraftnew.other.armorsets.LostLegionSetBonus;
 import goat.minecraft.minecraftnew.other.armorsets.CountershotSetBonus;
 import goat.minecraft.minecraftnew.other.armorsets.StriderSetBonus;
 import goat.minecraft.minecraftnew.other.durability.CustomDurabilityManager;
+import goat.minecraft.minecraftnew.other.durability.HeirloomManager;
 import goat.minecraft.minecraftnew.other.skilltree.SwiftStepMasteryBonus;
 import goat.minecraft.minecraftnew.other.skilltree.FastFarmerBonus;
 import goat.minecraft.minecraftnew.other.skilltree.SpectralArmorBonus;
@@ -262,6 +263,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
 
         new SetDurabilityCommand(this);
         CustomDurabilityManager.init(this);
+        HeirloomManager.init(this);
         new SetCustomDurabilityCommand(this);
         new AddGoldenDurabilityCommand(this);
         this.getCommand("skin").setExecutor(new SkinCommand());

--- a/src/main/java/goat/minecraft/minecraftnew/other/durability/CustomDurabilityManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/durability/CustomDurabilityManager.java
@@ -119,6 +119,16 @@ public class CustomDurabilityManager implements Listener {
     }
 
     /**
+     * Checks if the item has custom durability data stored.
+     */
+    public boolean hasCustomDurability(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return false;
+        PersistentDataContainer data = meta.getPersistentDataContainer();
+        return data.has(currentKey, PersistentDataType.INTEGER) && data.has(maxKey, PersistentDataType.INTEGER);
+    }
+
+    /**
      * Returns true if the item currently has golden durability applied.
      */
     public boolean hasGoldenDurability(ItemStack item) {
@@ -163,6 +173,28 @@ public class CustomDurabilityManager implements Listener {
         int max = getMaxDurability(item);
         updateLore(item, current, max);
         updateVanillaDamage(item, current, max);
+    }
+
+    /**
+     * Adds to the existing golden durability values on the item.
+     */
+    public void addGoldenDurability(ItemStack item, int amount) {
+        if (item == null || amount <= 0) return;
+        int cur = getGoldenDurability(item);
+        int max = getGoldenMaxDurability(item);
+        int newCur = cur + amount;
+        int newMax = max + amount;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        PersistentDataContainer data = meta.getPersistentDataContainer();
+        data.set(goldenKey, PersistentDataType.INTEGER, newCur);
+        data.set(goldenMaxKey, PersistentDataType.INTEGER, newMax);
+        item.setItemMeta(meta);
+
+        int current = getCurrentDurability(item);
+        int maxDur = getMaxDurability(item);
+        updateLore(item, current, maxDur);
+        updateVanillaDamage(item, current, maxDur);
     }
 
     /**

--- a/src/main/java/goat/minecraft/minecraftnew/other/durability/HeirloomManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/durability/HeirloomManager.java
@@ -1,0 +1,118 @@
+package goat.minecraft.minecraftnew.other.durability;
+
+import goat.minecraft.minecraftnew.utils.devtools.ItemLoreFormatter;
+import org.bukkit.ChatColor;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Manages gild values for special heirloom items.
+ */
+public class HeirloomManager {
+    private static HeirloomManager instance;
+    private final NamespacedKey gildKey;
+    private final NamespacedKey maxGildKey;
+
+    private HeirloomManager(JavaPlugin plugin) {
+        this.gildKey = new NamespacedKey(plugin, "heirloom_gild");
+        this.maxGildKey = new NamespacedKey(plugin, "heirloom_gild_max");
+    }
+
+    public static void init(JavaPlugin plugin) {
+        if (instance == null) {
+            instance = new HeirloomManager(plugin);
+        }
+    }
+
+    public static HeirloomManager getInstance() {
+        return instance;
+    }
+
+    public boolean isHeirloom(ItemStack item) {
+        if (item == null) return false;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return false;
+        PersistentDataContainer data = meta.getPersistentDataContainer();
+        return data.has(maxGildKey, PersistentDataType.INTEGER);
+    }
+
+    public int getGild(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return 0;
+        Integer val = meta.getPersistentDataContainer().get(gildKey, PersistentDataType.INTEGER);
+        return val != null ? val : 0;
+    }
+
+    public int getMaxGild(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return 0;
+        Integer val = meta.getPersistentDataContainer().get(maxGildKey, PersistentDataType.INTEGER);
+        return val != null ? val : 0;
+    }
+
+    public void setGild(ItemStack item, int amount, int max) {
+        if (item == null) return;
+        if (amount < 0) amount = 0;
+        if (amount > max) amount = max;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        PersistentDataContainer data = meta.getPersistentDataContainer();
+        data.set(gildKey, PersistentDataType.INTEGER, amount);
+        data.set(maxGildKey, PersistentDataType.INTEGER, max);
+        item.setItemMeta(meta);
+        updateLore(item, amount, max);
+        updateDurabilityBar(item, amount, max);
+    }
+
+    public void addGild(ItemStack item, int amount) {
+        int current = getGild(item);
+        int max = getMaxGild(item);
+        setGild(item, current + amount, max);
+    }
+
+    private void updateLore(ItemStack item, int amount, int max) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        List<String> lore = meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
+        String line = ChatColor.GOLD + "Gild: " + amount + "/" + max;
+        int index = -1;
+        for (int i = 0; i < lore.size(); i++) {
+            String stripped = ChatColor.stripColor(lore.get(i));
+            if (stripped.startsWith("Gild:")) {
+                index = i;
+                break;
+            }
+        }
+        if (index >= 0) {
+            lore.set(index, line);
+        } else {
+            lore.add(line);
+        }
+        meta.setLore(lore);
+        item.setItemMeta(meta);
+        ItemLoreFormatter.formatLore(item);
+    }
+
+    private void updateDurabilityBar(ItemStack item, int amount, int max) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta instanceof Damageable damageable) {
+            int vanillaMax = item.getType().getMaxDurability();
+            if (vanillaMax > 0 && max > 0) {
+                int newDamage = vanillaMax - (int)Math.round(((double) amount / max) * vanillaMax);
+                if (newDamage < 0) newDamage = 0;
+                if (newDamage > vanillaMax) newDamage = vanillaMax;
+                damageable.setDamage(newDamage);
+                item.setItemMeta(meta);
+            }
+        }
+    }
+}
+

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/corpses/CorpseDeathEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/corpses/CorpseDeathEvent.java
@@ -20,6 +20,8 @@ import org.bukkit.metadata.MetadataValue;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
+import org.bukkit.inventory.ItemStack;
 
 /**
  * Handles drops and cleanup when a Corpse NPC dies.
@@ -75,6 +77,20 @@ public class CorpseDeathEvent implements Listener {
                 }
             }
         });
+
+        // 4% chance to drop a random heirloom
+        if (new Random().nextDouble() < 0.04) {
+            ItemStack heirloom;
+            int r = new Random().nextInt(3);
+            if (r == 0) {
+                heirloom = ItemRegistry.getGoldenRing();
+            } else if (r == 1) {
+                heirloom = ItemRegistry.getGoldenChalice();
+            } else {
+                heirloom = ItemRegistry.getGoldenCrown();
+            }
+            entity.getWorld().dropItemNaturally(entity.getLocation(), heirloom);
+        }
 
         Player killer = event.getEntity().getKiller();
         if (killer != null) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
@@ -3,6 +3,7 @@ package goat.minecraft.minecraftnew.subsystems.smithing;
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentManager;
 import goat.minecraft.minecraftnew.other.durability.CustomDurabilityManager;
+import goat.minecraft.minecraftnew.other.durability.HeirloomManager;
 import goat.minecraft.minecraftnew.subsystems.mining.MiningGemManager;
 import goat.minecraft.minecraftnew.subsystems.smithing.tierreforgelisteners.ReforgeManager;
 import goat.minecraft.minecraftnew.subsystems.smithing.ReforgeSubsystem;
@@ -845,7 +846,28 @@ public class AnvilRepair implements Listener {
             repairAmount = repairAmount + 150;
         }
         // Determine the type of repair material and set the repair amount accordingly
-        if (billItem.getType() == Material.IRON_INGOT) {
+        if (billItem.getType() == Material.GOLD_INGOT) {
+            if (HeirloomManager.getInstance().isHeirloom(repairee)) {
+                StatsCalculator statsCalculator = StatsCalculator.getInstance(MinecraftNew.getInstance());
+                double quality = statsCalculator.getGoldenRepairQuality(player);
+                double max = statsCalculator.getGoldenRepairAmount(player);
+                double roll = max > quality ? quality + new Random().nextDouble(max - quality + 1) : quality;
+                int gild = (int) roll;
+                HeirloomManager.getInstance().addGild(repairee, gild);
+                billItem.setAmount(billItem.getAmount() - 1);
+                xpManager.addXP(player, "Smithing", roll);
+                player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
+            }
+            return;
+        } else if (HeirloomManager.getInstance().isHeirloom(billItem)
+                && CustomDurabilityManager.getInstance().hasCustomDurability(repairee)
+                && HeirloomManager.getInstance().getGild(billItem) > 0) {
+            int gild = HeirloomManager.getInstance().getGild(billItem);
+            CustomDurabilityManager.getInstance().addGoldenDurability(repairee, gild);
+            HeirloomManager.getInstance().setGild(billItem, 0, HeirloomManager.getInstance().getMaxGild(billItem));
+            player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
+            return;
+        } else if (billItem.getType() == Material.IRON_INGOT) {
             StatsCalculator statsCalculator = StatsCalculator.getInstance(MinecraftNew.getInstance());
             double quality = statsCalculator.getRepairQuality(player);
             double roll = quality;

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -3,6 +3,7 @@ package goat.minecraft.minecraftnew.utils.devtools;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.other.structureblocks.StructureBlockManager;
+import goat.minecraft.minecraftnew.other.durability.HeirloomManager;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -4653,6 +4654,62 @@ public class ItemRegistry {
                 false,
                 true
         );
+    }
+
+    // ===== Heirlooms =====
+
+    public static ItemStack getGoldenRing() {
+        ItemStack item = createCustomItem(
+                Material.LEATHER_CHESTPLATE,
+                ChatColor.GOLD + "Golden Ring",
+                Arrays.asList(
+                        ChatColor.DARK_PURPLE + "Smithing Item"
+                ),
+                1,
+                false,
+                true
+        );
+        HeirloomManager mgr = HeirloomManager.getInstance();
+        if (mgr != null) {
+            mgr.setGild(item, 0, 100);
+        }
+        return item;
+    }
+
+    public static ItemStack getGoldenChalice() {
+        ItemStack item = createCustomItem(
+                Material.LEATHER_CHESTPLATE,
+                ChatColor.GOLD + "Golden Chalice",
+                Arrays.asList(
+                        ChatColor.DARK_PURPLE + "Smithing Item"
+                ),
+                1,
+                false,
+                true
+        );
+        HeirloomManager mgr = HeirloomManager.getInstance();
+        if (mgr != null) {
+            mgr.setGild(item, 0, 250);
+        }
+        return item;
+    }
+
+    public static ItemStack getGoldenCrown() {
+        ItemStack item = createCustomItem(
+                Material.LEATHER_CHESTPLATE,
+                ChatColor.GOLD + "Golden Crown",
+                Arrays.asList(
+                        ChatColor.DARK_PURPLE + "Smithing Item"
+                ),
+                1,
+                false,
+                true
+        );
+        HeirloomManager mgr = HeirloomManager.getInstance();
+        if (mgr != null) {
+            mgr.setGild(item, 0, 500);
+        }
+        return item;
     }
 
     /** Legendary melon artifact. */


### PR DESCRIPTION
## Summary
- Introduce Golden Ring, Chalice, and Crown heirlooms with gild storage and lore-driven durability.
- Allow gilding with gold ingots and transferring gild to items as Golden Durability via the anvil.
- Corpses now have a 4% chance to drop a random heirloom.

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6890678582208332820a011f531612e9