### PR TITLE
fix: restrict grave spawning to dirt and stone

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
@@ -94,7 +94,11 @@ public class Gravedigging implements Listener {
         // Only surface blocks
         int highest = world.getHighestBlockYAt(loc);
         if (loc.getBlockY() < highest) return;
-        if(loc.getBlock().getType().equals(Material.DIRT) || loc.getBlock().getType().equals(Material.GRASS_BLOCK)) return;
+
+        // Graves should only spawn when dirt or stone is broken
+        Material type = block.getType();
+        if (type != Material.DIRT && type != Material.STONE) return;
+
         // Calculate chance via StatsCalculator to keep logic centralized
         StatsCalculator calc = StatsCalculator.getInstance(plugin);
         double chance = calc.getGraveChance(player) / 100.0;


### PR DESCRIPTION
## Summary
- only allow graves to spawn when breaking dirt or stone

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891736a27848332b56c4ac0b88daddc