### PR TITLE
Add flytome command to direct Ender Dragons

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -376,6 +376,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getCommand("previewflow").setExecutor(new PreviewFlowCommand(this));
         new RedVignetteCommand(this);
         new GlowingOresCommand(this);
+        new FlyToMeCommand(this);
         FlowManager.getInstance(this);
         getCommand("flowdebug").setExecutor(new FlowDebugCommand(flowManager));
         getCommand("debugplayer").setExecutor(new DebugPlayerCommand(this));

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/FlyToMeCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/FlyToMeCommand.java
@@ -1,0 +1,46 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.World;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.EnderDragon;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Developer command that directs all Ender Dragons on the server to fly toward the issuer.
+ * Usage: /flytome
+ */
+public class FlyToMeCommand implements CommandExecutor {
+    private final JavaPlugin plugin;
+
+    public FlyToMeCommand(JavaPlugin plugin) {
+        this.plugin = plugin;
+        plugin.getCommand("flytome").setExecutor(this);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be used by players.");
+            return true;
+        }
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You do not have permission to use this command.");
+            return true;
+        }
+
+        for (World world : Bukkit.getWorlds()) {
+            for (EnderDragon dragon : world.getEntitiesByClass(EnderDragon.class)) {
+                dragon.setTarget(player);
+                dragon.setPhase(EnderDragon.Phase.CHARGE_PLAYER);
+            }
+        }
+
+        player.sendMessage(ChatColor.GRAY + "Summoning dragons to your location...");
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -293,3 +293,7 @@ commands:
     description: Highlights nearby ores with a colored glow
     usage: /glowingores <seconds>
     permission: continuity.admin
+  flytome:
+    description: Calls every Ender Dragon to your location
+    usage: /flytome
+    permission: continuity.admin


### PR DESCRIPTION
## Summary
- Add `/flytome` developer command to call every Ender Dragon to the player
- Register the new command and expose it via plugin.yml

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68919e835d3883329fbedf8170ce2476