### PR TITLE
Add charging phase for Water Dragon

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/CustomPhase.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/CustomPhase.java
@@ -18,6 +18,7 @@ public enum CustomPhase {
     HOVER,
     // Custom phases
     HEALING,
+    CHARGE,
     SMITE,
     LAUNCH,
     FURY,

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/WaterDragon.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/WaterDragon.java
@@ -17,7 +17,7 @@ public class WaterDragon implements Dragon {
     private static final int FLIGHT_SPEED = 4;
     private static final int BASE_RAGE = 2;
     private static final int MAX_HEALTH = 1_000;
-    private static final int DECISION_INTERVAL = 30*20; // placeholder
+    private static final int DECISION_INTERVAL = 15*20; // 15 seconds
 
     @Override
     public ChatColor getNameColor() {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/WaterDragonTrait.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/WaterDragonTrait.java
@@ -2,9 +2,10 @@ package goat.minecraft.minecraftnew.subsystems.dragons;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.dragons.phases.*;
-import org.bukkit.event.entity.EnderDragonChangePhaseEvent;
 import net.citizensnpcs.api.trait.Trait;
 import net.citizensnpcs.api.util.DataKey;
+import net.citizensnpcs.api.npc.NPC;
+import org.bukkit.event.entity.EnderDragonChangePhaseEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.EnderDragon;
 import org.bukkit.event.EventHandler;
@@ -40,12 +41,10 @@ public class WaterDragonTrait extends Trait implements Listener {
     private CustomPhase currentPhase;
     private long furyCooldownEnd;
     private long launchCooldownEnd;
-    private long smiteCooldownEnd;
     private final Random random = new Random();
 
     private static final long FURY_COOLDOWN = 60000L;
     private static final long LAUNCH_COOLDOWN = 20000L;
-    private static final long SMITE_COOLDOWN = 1000L;
 
     public WaterDragonTrait(MinecraftNew plugin, DragonFight fight) {
         super("water_dragon_trait");
@@ -165,9 +164,8 @@ public class WaterDragonTrait extends Trait implements Listener {
                     new LaunchPhase(plugin, fight, WaterDragonTrait.this).start();
                     launchCooldownEnd = now + LAUNCH_COOLDOWN;
                 } else {
-                    currentPhase = CustomPhase.SMITE;
-                    new SmitePhase(plugin, fight, WaterDragonTrait.this).start();
-                    smiteCooldownEnd = now + SMITE_COOLDOWN;
+                    currentPhase = CustomPhase.CHARGE;
+                    new ChargePhase(plugin, fight, WaterDragonTrait.this).start();
                 }
             }
         }.runTaskTimer(plugin, interval, interval);
@@ -191,6 +189,10 @@ public class WaterDragonTrait extends Trait implements Listener {
 
     public void setCrystalBias(int crystalBias) {
         this.crystalBias = crystalBias;
+    }
+
+    public NPC getNPC() {
+        return npc;
     }
 
     @Override public void load(DataKey key) { }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/phases/ChargePhase.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/dragons/phases/ChargePhase.java
@@ -1,0 +1,85 @@
+package goat.minecraft.minecraftnew.subsystems.dragons.phases;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.dragons.DragonFight;
+import goat.minecraft.minecraftnew.subsystems.dragons.WaterDragonTrait;
+import net.citizensnpcs.api.ai.Navigator;
+import net.citizensnpcs.api.ai.NavigatorParameters;
+import net.citizensnpcs.api.npc.NPC;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.EnderDragon;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.List;
+
+/**
+ * Phase that has the Water Dragon charge a player, continuously tracking
+ * the player's location.
+ */
+public class ChargePhase implements Phase {
+
+    private final MinecraftNew plugin;
+    private final DragonFight fight;
+    private final WaterDragonTrait trait;
+
+    public ChargePhase(MinecraftNew plugin, DragonFight fight, WaterDragonTrait trait) {
+        this.plugin = plugin;
+        this.fight = fight;
+        this.trait = trait;
+    }
+
+    @Override
+    public void start() {
+        EnderDragon dragon = fight.getDragonEntity();
+        World world = dragon.getWorld();
+        List<Player> players = world.getPlayers();
+        if (players.isEmpty()) {
+            trait.onPhaseComplete();
+            return;
+        }
+        // target nearest player
+        Player target = players.get(0);
+        double closest = target.getLocation().distanceSquared(dragon.getLocation());
+        for (Player p : players) {
+            double dist = p.getLocation().distanceSquared(dragon.getLocation());
+            if (dist < closest) {
+                closest = dist;
+                target = p;
+            }
+        }
+
+        NPC npc = trait.getNPC();
+        npc.data().set(NPC.Metadata.FLYABLE, true);
+        Navigator navigator = npc.getNavigator();
+        NavigatorParameters params = navigator.getLocalParameters();
+        params.range(50.0F);
+        params.speedModifier(3f);
+
+        dragon.setAI(false);
+
+        new BukkitRunnable() {
+            int ticks = 0;
+            @Override
+            public void run() {
+                if (ticks++ > 100 || !target.isValid() || dragon.isDead()) {
+                    navigator.cancelNavigation();
+                    dragon.setAI(true);
+                    trait.onPhaseComplete();
+                    cancel();
+                    return;
+                }
+                Location loc = target.getLocation();
+                navigator.setTarget(loc);
+                if (npc.getEntity().getLocation().distanceSquared(loc) < 4) {
+                    target.damage(20.0, dragon);
+                    navigator.cancelNavigation();
+                    dragon.setAI(true);
+                    trait.onPhaseComplete();
+                    cancel();
+                }
+            }
+        }.runTaskTimer(plugin, 0L, 5L);
+    }
+}


### PR DESCRIPTION
## Summary
- Add ChargePhase that makes the Water Dragon fly toward and track a nearby player
- Run decision loop every 15 seconds and default to the new charge attack
- Expose NPC from WaterDragonTrait and extend custom phase list

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6891a35a71a483329e4cc9393883fa22