### PR TITLE
Add composter seeder drops and compostable lore

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/FarmingEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/FarmingEvent.java
@@ -24,7 +24,10 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.potion.PotionEffectType;
@@ -86,6 +89,48 @@ public class FarmingEvent implements Listener {
                 }
             }
         }
+    }
+
+    @EventHandler
+    public void onSeederCompost(PlayerInteractEvent event) {
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
+        if (event.getHand() != EquipmentSlot.HAND) return;
+
+        Block block = event.getClickedBlock();
+        if (block == null || block.getType() != Material.COMPOSTER) return;
+
+        ItemStack item = event.getItem();
+        if (item == null) return;
+
+        ItemStack seeder = null;
+        if (item.isSimilar(ItemRegistry.getEnchantedHayBale())) {
+            seeder = ItemRegistry.getWheatSeeder();
+        } else if (item.isSimilar(ItemRegistry.getEnchantedGoldenCarrot())) {
+            seeder = ItemRegistry.getCarrotSeeder();
+        } else if (item.isSimilar(ItemRegistry.getHeartRoot())) {
+            seeder = ItemRegistry.getBeetrootSeeder();
+        } else if (item.isSimilar(ItemRegistry.getImmortalPotato())) {
+            seeder = ItemRegistry.getPotatoSeeder();
+        }
+
+        if (seeder == null) return;
+
+        event.setCancelled(true);
+
+        if (item.getAmount() > 1) {
+            item.setAmount(item.getAmount() - 1);
+        } else {
+            event.getPlayer().getInventory().setItem(event.getHand(), null);
+        }
+
+        int amount = random.nextInt(4) + 1;
+        seeder.setAmount(amount);
+        Location dropLoc = block.getLocation().add(0.5, 1.0, 0.5);
+        block.getWorld().dropItemNaturally(dropLoc, seeder);
+
+        World world = block.getWorld();
+        world.playSound(dropLoc, Sound.BLOCK_COMPOSTER_FILL_SUCCESS, 1.0f, 1.0f);
+        world.spawnParticle(Particle.COMPOSTER, dropLoc, 10, 0.25, 0.25, 0.25, 0.01);
     }
 
     @EventHandler

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -2849,7 +2849,8 @@ public class ItemRegistry {
                 ChatColor.YELLOW + "Enchanted Hay Bale",
                 Arrays.asList(
                         ChatColor.GRAY + "Adds one level of Cornfield to Hoes.",
-                        ChatColor.DARK_PURPLE + "Smithing Item"
+                        ChatColor.DARK_PURPLE + "Smithing Item",
+                        ChatColor.DARK_PURPLE + "Compostable"
                 ),
                 1,
                 false,
@@ -2864,7 +2865,8 @@ public class ItemRegistry {
                 ChatColor.YELLOW + "Enchanted Golden Carrot",
                 Arrays.asList(
                         ChatColor.GRAY + "Adds one level of What's Up Doc to Hoes.",
-                        ChatColor.DARK_PURPLE + "Smithing Item"
+                        ChatColor.DARK_PURPLE + "Smithing Item",
+                        ChatColor.DARK_PURPLE + "Compostable"
                 ),
                 1,
                 false,
@@ -2879,7 +2881,8 @@ public class ItemRegistry {
                 ChatColor.YELLOW + "HeartRoot",
                 Arrays.asList(
                         ChatColor.GRAY + "Adds one level of Venerate to Hoes.",
-                        ChatColor.DARK_PURPLE + "Smithing Item"
+                        ChatColor.DARK_PURPLE + "Smithing Item",
+                        ChatColor.DARK_PURPLE + "Compostable"
                 ),
                 1,
                 false,
@@ -2894,7 +2897,8 @@ public class ItemRegistry {
                 ChatColor.YELLOW + "Immortal Potato",
                 Arrays.asList(
                         ChatColor.GRAY + "Adds one level of Legend to Hoes.",
-                        ChatColor.DARK_PURPLE + "Smithing Item"
+                        ChatColor.DARK_PURPLE + "Smithing Item",
+                        ChatColor.DARK_PURPLE + "Compostable"
                 ),
                 1,
                 false,


### PR DESCRIPTION
## Summary
- Mark Enchanted Hay Bale, Enchanted Golden Carrot, HeartRoot, and Immortal Potato as both **Smithing Item** and **Compostable**
- Allow right-clicking a composter with those relics to consume the item and drop 1-4 matching seeder items with sound and particle effects

## Testing
- `mvn -q -e -ntp test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6892ce5a38bc8332b5702caccaeb30ba