### PR TITLE
Nerf fertilizer growth and Harvest Festival rewards

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/ignoreme
+++ b/src/main/java/goat/minecraft/minecraftnew/ignoreme
@@ -529,7 +529,7 @@ Festival Bees II: +0.25% Chance for Harvesting to spawn a Festival Bee for 30s, 
 Epic:
 Extra Crop Chance IV: +32% per level, Max level 3
 Reaper IV: -1% Crop Count Requirement for Harvest Rewards, Max level 5
-Fertilizer Efficiency: +20% Chance to gain Double Growth from Fertilizer, Max level 5
+Fertilizer Efficiency: +5% Fertilizer growth chance per level, Max level 5
 Festival Bee Duration II: +10s Festival Bee Duration, Max level 5
 Festival Bees III: +0.25% Chance for Harvesting to spawn a Festival Bee for 30s, Max level 2
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/RightClickArtifacts.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/RightClickArtifacts.java
@@ -476,32 +476,18 @@ public class RightClickArtifacts implements Listener {
                         }
                     }
 
+                    int fert = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.FARMING, Talent.FERTILIZER_EFFICIENCY);
+                    double chance = 0.10 + fert * 0.05;
                     int grown = 0;
-                    for(Block farmland : farmlandBlocks) {
+                    for (Block farmland : farmlandBlocks) {
                         Block cropBlock = farmland.getRelative(BlockFace.UP);
-                        if(cropBlock.getBlockData() instanceof Ageable crop) {
+                        if (cropBlock.getBlockData() instanceof Ageable crop) {
                             Material mat = cropBlock.getType();
-                            if(mat == Material.WHEAT || mat == Material.CARROTS || mat == Material.POTATOES || mat == Material.BEETROOTS) {
-                                if(crop.getAge() < crop.getMaximumAge()) {
+                            if (mat == Material.WHEAT || mat == Material.CARROTS || mat == Material.POTATOES || mat == Material.BEETROOTS) {
+                                if (crop.getAge() < crop.getMaximumAge() && Math.random() < chance) {
                                     crop.setAge(Math.min(crop.getAge() + 1, crop.getMaximumAge()));
                                     cropBlock.setBlockData(crop);
                                     grown++;
-                                }
-                            }
-                        }
-                    }
-
-                    int fert = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.FARMING, Talent.FERTILIZER_EFFICIENCY);
-                    if (fert > 0 && Math.random() < fert * 0.20) {
-                        for(Block farmland : farmlandBlocks) {
-                            Block cropBlock = farmland.getRelative(BlockFace.UP);
-                            if(cropBlock.getBlockData() instanceof Ageable crop) {
-                                Material mat = cropBlock.getType();
-                                if(mat == Material.WHEAT || mat == Material.CARROTS || mat == Material.POTATOES || mat == Material.BEETROOTS) {
-                                    if(crop.getAge() < crop.getMaximumAge()) {
-                                        crop.setAge(Math.min(crop.getAge() + 1, crop.getMaximumAge()));
-                                        cropBlock.setBlockData(crop);
-                                    }
                                 }
                             }
                         }

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -771,7 +771,7 @@ public class SkillTreeManager implements Listener {
             case REAPER_IV:
                 return ChatColor.YELLOW + "-" + level + "% " + ChatColor.GRAY + "Harvest requirement";
             case FERTILIZER_EFFICIENCY:
-                return ChatColor.YELLOW + "+" + (level * 20) + "% " + ChatColor.GRAY + "double growth chance";
+                return ChatColor.YELLOW + "+" + (level * 5) + "% " + ChatColor.GRAY + "fertilizer growth chance";
             case FESTIVAL_BEE_DURATION_II:
                 return ChatColor.YELLOW + "+" + (level * 10) + "s Festival Bee Duration";
             case FESTIVAL_BEES_III:

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -2209,8 +2209,8 @@ public enum Talent {
     ),
     FERTILIZER_EFFICIENCY(
             "Fertilizer Efficiency",
-            ChatColor.GRAY + "Chance for double fertilizer growth",
-            ChatColor.YELLOW + "+(20*level)% " + ChatColor.GRAY + "double growth chance",
+            ChatColor.GRAY + "Improves fertilizer success rate",
+            ChatColor.YELLOW + "+(5*level)% " + ChatColor.GRAY + "fertilizer growth chance",
             5,
             60,
             Material.BONE_MEAL

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
@@ -847,8 +847,7 @@ public class PetManager implements Listener {
                 int requiredMaterialsOrganic = Math.max(256 - (level - 1) * (256 - 64) / 99, 64);
                 return ChatColor.GRAY + "Compacts " + requiredMaterialsOrganic + " crops into " + ChatColor.GREEN + "Organic Soil";
             case HARVEST_FESTIVAL:
-                int requiredMaterialsFertilizer = Math.max(256 - (level - 1) * (256 - 64) / 99, 64);
-                return ChatColor.GRAY + "Compacts " + requiredMaterialsFertilizer + " crops into " + ChatColor.YELLOW + "Fertilizer";
+                return ChatColor.GRAY + "Compacts 2000 crops into " + ChatColor.YELLOW + "Fertilizer";
             case LUMBERJACK:
                 return "Drops " + ChatColor.GREEN + "+2 logs " + ChatColor.GRAY + "when chopping trees.";
             case EARTHWORM:

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/AutoComposter.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/AutoComposter.java
@@ -218,8 +218,8 @@ public class AutoComposter {
         }
         if (removed > 0) {
             int tally = composterTally.getOrDefault(player, 0) + removed;
-            while (tally >= 1000) {
-                tally -= 1000;
+            while (tally >= 2000) {
+                tally -= 2000;
                 player.getWorld().dropItemNaturally(player.getLocation(), ItemRegistry.getFertilizer().clone());
             }
             composterTally.put(player, tally);


### PR DESCRIPTION
## Summary
- Scale fertilizer growth to a base 10% success rate plus 5% per Fertilizer Efficiency level
- Update Fertilizer Efficiency talent description and dynamic text
- Harvest Festival pets now need 2000 crops for 1 Fertilizer and show the higher cost

## Testing
- `mvn -q test` *(fails: PluginResolutionException – network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892dabf68d4833289e95cb6667d1038