### PR TITLE
Enhance harvest notifications with rarity effects

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/FarmingEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/FarmingEvent.java
@@ -15,6 +15,7 @@ import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
 import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentManager;
+import goat.minecraft.minecraftnew.subsystems.fishing.Rarity;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.Ageable;
@@ -358,31 +359,31 @@ public class FarmingEvent implements Listener {
                 if (roll < 0.50) {
                     ItemStack item = ItemRegistry.getWheatSeeder();
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, false);
+                    notifyHarvest(player, item, Rarity.COMMON);
                 } else if (roll < 0.80) {
                     ItemStack item = ItemRegistry.getWheatSeeder();
                     item.setAmount(4);
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, false);
+                    notifyHarvest(player, item, Rarity.UNCOMMON);
                 } else if (roll < 0.90) {
                     ItemStack item = ItemRegistry.getEnchantedHayBale();
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, true);
+                     notifyHarvest(player, item, Rarity.RARE);
                 } else if (roll < 0.975) {
                     ItemStack item = ItemRegistry.getEnchantedHayBale();
                     item.setAmount(4);
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, true);
+                    notifyHarvest(player, item, Rarity.EPIC);
                 } else {
                     PetManager petManager = PetManager.getInstance(plugin);
                     if (petManager.getPet(player, "Scarecrow") == null) {
                         new PetRegistry().addPetByName(player, "Scarecrow");
-                        notifyHarvest(player, ChatColor.GOLD + "Scarecrow pet", 1, true);
+                        notifyHarvest(player, ChatColor.GOLD + "Scarecrow pet", 1, Rarity.LEGENDARY);
                     } else {
                         ItemStack item = ItemRegistry.getEnchantedHayBale();
                         item.setAmount(16);
                         block.getWorld().dropItemNaturally(dropLoc, item);
-                        notifyHarvest(player, item, true);
+                        notifyHarvest(player, item, Rarity.LEGENDARY);
                     }
                 }
             }
@@ -390,31 +391,31 @@ public class FarmingEvent implements Listener {
                 if (roll < 0.50) {
                     ItemStack item = ItemRegistry.getCarrotSeeder();
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, false);
+                    notifyHarvest(player, item, Rarity.COMMON);
                 } else if (roll < 0.80) {
                     ItemStack item = ItemRegistry.getCarrotSeeder();
                     item.setAmount(4);
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, false);
+                    notifyHarvest(player, item, Rarity.UNCOMMON);
                 } else if (roll < 0.90) {
                     ItemStack item = ItemRegistry.getEnchantedGoldenCarrot();
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, true);
+                    notifyHarvest(player, item, Rarity.RARE);
                 } else if (roll < 0.975) {
                     ItemStack item = ItemRegistry.getEnchantedGoldenCarrot();
                     item.setAmount(4);
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, true);
+                    notifyHarvest(player, item, Rarity.EPIC);
                 } else {
                     PetManager petManager = PetManager.getInstance(plugin);
                     if (petManager.getPet(player, "Killer Rabbit") == null) {
                         new PetRegistry().addPetByName(player, "Killer Rabbit");
-                        notifyHarvest(player, ChatColor.GOLD + "Killer Rabbit pet", 1, true);
+                        notifyHarvest(player, ChatColor.GOLD + "Killer Rabbit pet", 1, Rarity.LEGENDARY);
                     } else {
                         ItemStack item = ItemRegistry.getEnchantedGoldenCarrot();
                         item.setAmount(16);
                         block.getWorld().dropItemNaturally(dropLoc, item);
-                        notifyHarvest(player, item, true);
+                        notifyHarvest(player, item, Rarity.LEGENDARY);
                     }
                 }
             }
@@ -422,31 +423,31 @@ public class FarmingEvent implements Listener {
                 if (roll < 0.50) {
                     ItemStack item = ItemRegistry.getBeetrootSeeder();
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, false);
+                    notifyHarvest(player, item, Rarity.COMMON);
                 } else if (roll < 0.80) {
                     ItemStack item = ItemRegistry.getBeetrootSeeder();
                     item.setAmount(4);
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, false);
+                    notifyHarvest(player, item, Rarity.UNCOMMON);
                 } else if (roll < 0.90) {
                     ItemStack item = ItemRegistry.getHeartRoot();
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, true);
+                    notifyHarvest(player, item, Rarity.RARE);
                 } else if (roll < 0.975) {
                     ItemStack item = ItemRegistry.getHeartRoot();
                     item.setAmount(4);
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, true);
+                    notifyHarvest(player, item, Rarity.EPIC);
                 } else {
                     PetManager petManager = PetManager.getInstance(plugin);
                     if (petManager.getPet(player, "Baron") == null) {
                         new PetRegistry().addPetByName(player, "Baron");
-                        notifyHarvest(player, ChatColor.GOLD + "Baron pet", 1, true);
+                        notifyHarvest(player, ChatColor.GOLD + "Baron pet", 1, Rarity.LEGENDARY);
                     } else {
                         ItemStack item = ItemRegistry.getHeartRoot();
                         item.setAmount(16);
                         block.getWorld().dropItemNaturally(dropLoc, item);
-                        notifyHarvest(player, item, true);
+                        notifyHarvest(player, item, Rarity.LEGENDARY);
                     }
                 }
             }
@@ -454,31 +455,31 @@ public class FarmingEvent implements Listener {
                 if (roll < 0.50) {
                     ItemStack item = ItemRegistry.getPotatoSeeder();
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, false);
+                    notifyHarvest(player, item, Rarity.COMMON);
                 } else if (roll < 0.80) {
                     ItemStack item = ItemRegistry.getPotatoSeeder();
                     item.setAmount(4);
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, false);
+                    notifyHarvest(player, item, Rarity.UNCOMMON);
                 } else if (roll < 0.90) {
                     ItemStack item = ItemRegistry.getImmortalPotato();
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, true);
+                    notifyHarvest(player, item, Rarity.RARE);
                 } else if (roll < 0.975) {
                     ItemStack item = ItemRegistry.getImmortalPotato();
                     item.setAmount(4);
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, true);
+                    notifyHarvest(player, item, Rarity.EPIC);
                 } else {
                     PetManager petManager = PetManager.getInstance(plugin);
                     if (petManager.getPet(player, "Mole") == null) {
                         new PetRegistry().addPetByName(player, "Mole");
-                        notifyHarvest(player, ChatColor.GOLD + "Mole pet", 1, true);
+                        notifyHarvest(player, ChatColor.GOLD + "Mole pet", 1, Rarity.LEGENDARY);
                     } else {
                         ItemStack item = ItemRegistry.getImmortalPotato();
                         item.setAmount(16);
                         block.getWorld().dropItemNaturally(dropLoc, item);
-                        notifyHarvest(player, item, true);
+                        notifyHarvest(player, item, Rarity.LEGENDARY);
                     }
                 }
             }
@@ -486,48 +487,48 @@ public class FarmingEvent implements Listener {
                 if (roll < 0.50) {
                     ItemStack item = new ItemStack(Material.MELON_SLICE, 16);
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, false);
+                    notifyHarvest(player, item, Rarity.COMMON);
                 } else if (roll < 0.80) {
                     ItemStack item = new ItemStack(Material.MELON_SLICE, 64);
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, false);
+                    notifyHarvest(player, item, Rarity.UNCOMMON);
                 } else if (roll < 0.90) {
                     ItemStack item = ItemRegistry.getWatermelon();
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, true);
+                    notifyHarvest(player, item, Rarity.RARE);
                 } else if (roll < 0.975) {
                     ItemStack item = ItemRegistry.getWatermelon();
                     item.setAmount(4);
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, true);
+                    notifyHarvest(player, item, Rarity.EPIC);
                 } else {
                     ItemStack item = ItemRegistry.getWorldsLargestWatermelon();
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, true);
+                    notifyHarvest(player, item, Rarity.LEGENDARY);
                 }
             }
             case PUMPKIN -> {
                 if (roll < 0.50) {
                     ItemStack item = new ItemStack(Material.PUMPKIN, 16);
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, false);
+                    notifyHarvest(player, item, Rarity.COMMON);
                 } else if (roll < 0.80) {
                     ItemStack item = new ItemStack(Material.PUMPKIN, 64);
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, false);
+                    notifyHarvest(player, item, Rarity.UNCOMMON);
                 } else if (roll < 0.90) {
                     ItemStack item = ItemRegistry.getJackOLantern();
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, true);
+                    notifyHarvest(player, item, Rarity.RARE);
                 } else if (roll < 0.975) {
                     ItemStack item = ItemRegistry.getJackOLantern();
                     item.setAmount(4);
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, true);
+                    notifyHarvest(player, item, Rarity.EPIC);
                 } else {
                     ItemStack item = ItemRegistry.getWorldsLargestPumpkin();
                     block.getWorld().dropItemNaturally(dropLoc, item);
-                    notifyHarvest(player, item, true);
+                    notifyHarvest(player, item, Rarity.LEGENDARY);
                 }
             }
             default -> {
@@ -556,7 +557,7 @@ public class FarmingEvent implements Listener {
  //yup
                     // Optional: Play a unique sound to indicate a rare drop
                     player.playSound(player.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1.0f, 1.0f);
-                    notifyHarvest(player, rareItem, true);
+                    notifyHarvest(player, rareItem, Rarity.LEGENDARY);
                 } else {
                     // Log a warning if the rare item is not defined
                     plugin.getLogger().warning("Rare item is not defined in ItemRegistry.getRareItem(Material). Crop: " + blockType.name());
@@ -565,22 +566,93 @@ public class FarmingEvent implements Listener {
         }
     }
 
-    private void notifyHarvest(Player player, ItemStack item, boolean rareOrAbove) {
+    private void notifyHarvest(Player player, ItemStack item, Rarity rarity) {
         String name;
         if (item.hasItemMeta() && item.getItemMeta().hasDisplayName()) {
             name = item.getItemMeta().getDisplayName();
         } else {
             name = ChatColor.YELLOW + formatMaterialName(item.getType());
         }
-        notifyHarvest(player, name, item.getAmount(), rareOrAbove);
+        notifyHarvest(player, name, item.getAmount(), rarity);
     }
 
-    private void notifyHarvest(Player player, String itemName, int amount, boolean rareOrAbove) {
+    private void notifyHarvest(Player player, String itemName, int amount, Rarity rarity) {
         String amountText = amount > 1 ? ChatColor.YELLOW + "" + amount + "x " : "";
-        player.sendMessage(ChatColor.GREEN + "Harvest Reward: " + amountText + itemName);
-        player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_CHIME, 1.0f, 1.0f);
+        ChatColor rarityColor = switch (rarity) {
+            case COMMON -> ChatColor.WHITE;
+            case UNCOMMON -> ChatColor.GREEN;
+            case RARE -> ChatColor.BLUE;
+            case EPIC -> ChatColor.DARK_PURPLE;
+            case LEGENDARY, MYTHIC -> ChatColor.GOLD;
+        };
+
+        // Send chat message
+        player.sendMessage(ChatColor.GREEN + "Harvest Reward: " + amountText + rarityColor + ChatColor.stripColor(itemName));
+
+        // Play sound based on rarity
+        playRaritySound(player, rarity);
+
+        // Title animation durations
+        int fadeIn;
+        int stay;
+        int fadeOut;
+        switch (rarity) {
+            case COMMON -> {
+                fadeIn = 5; stay = 40; fadeOut = 10;
+            }
+            case UNCOMMON -> {
+                fadeIn = 5; stay = 60; fadeOut = 15;
+            }
+            case RARE -> {
+                fadeIn = 10; stay = 70; fadeOut = 20;
+            }
+            case EPIC -> {
+                fadeIn = 15; stay = 80; fadeOut = 25;
+            }
+            case LEGENDARY, MYTHIC -> {
+                fadeIn = 20; stay = 100; fadeOut = 30;
+            }
+        }
+
         String subtitle = amount > 1 ? ChatColor.YELLOW + "" + amount + "x" : "";
-        player.sendTitle(itemName, subtitle, 10, 70, 20);
+        String title = rarityColor + ChatColor.stripColor(itemName);
+        if (rarity.ordinal() >= Rarity.RARE.ordinal()) {
+            title = ChatColor.BOLD + title;
+        }
+        if (rarity.ordinal() >= Rarity.EPIC.ordinal()) {
+            title = ChatColor.ITALIC + title;
+        }
+
+        player.sendTitle(title, subtitle, fadeIn, stay, fadeOut);
+    }
+
+    private void playRaritySound(Player player, Rarity rarity) {
+        Sound sound;
+        float volume;
+        float pitch;
+        switch (rarity) {
+            case COMMON -> {
+                sound = Sound.BLOCK_NOTE_BLOCK_CHIME;
+                volume = 0.5f; pitch = 1.0f;
+            }
+            case UNCOMMON -> {
+                sound = Sound.BLOCK_NOTE_BLOCK_CHIME;
+                volume = 0.7f; pitch = 1.2f;
+            }
+            case RARE -> {
+                sound = Sound.BLOCK_NOTE_BLOCK_BELL;
+                volume = 0.9f; pitch = 1.5f;
+            }
+            case EPIC -> {
+                sound = Sound.BLOCK_NOTE_BLOCK_BELL;
+                volume = 1.0f; pitch = 1.8f;
+            }
+            case LEGENDARY, MYTHIC -> {
+                sound = Sound.UI_TOAST_CHALLENGE_COMPLETE;
+                volume = 1.0f; pitch = 1.0f;
+            }
+        }
+        player.playSound(player.getLocation(), sound, volume, pitch);
     }
 
     private String formatMaterialName(Material material) {


### PR DESCRIPTION
## Summary
- color-code harvest titles by item rarity and animate titles with escalating flair
- intensify sound cues as rarity increases for better feedback
- pass explicit rarity values when notifying harvest rewards

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892dbd6d6b88332b58e9cd3046c4d05