### PR TITLE
Disable taming XP actionbar animation

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/XPManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/XPManager.java
@@ -283,6 +283,20 @@ public class XPManager implements CommandExecutor {
         // Create a key for stacking animations.
         String key = player.getUniqueId().toString() + ":" + skill;
 
+        // Taming XP does not use an actionbar animation.
+        if (skill.equalsIgnoreCase("Taming")) {
+            activeAnimations.remove(key);
+            String bonusMessage = "";
+            if (bonusXP > 0) {
+                bonusMessage = ChatColor.LIGHT_PURPLE + " + Bonus: " + (int) bonusXP + " XP";
+            }
+            String message = ChatColor.AQUA + "[+" + finalXP + " XP " + ChatColor.DARK_AQUA + "(" +
+                    String.format("%.2f", finalProgressPercentage) + "%)]" +
+                    bonusMessage + " " + ChatColor.GREEN + skill;
+            player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(message));
+            return;
+        }
+
         // If an animation is already active for this skill, update it.
         if(activeAnimations.containsKey(key)) {
             HotbarAnimation anim = activeAnimations.get(key);


### PR DESCRIPTION
## Summary
- skip actionbar animation when taming XP is gained

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: The following artifacts could not be resolved: org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 (absent): Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892e192b18083329ae7019d67cbbd02