### PR TITLE
Adjust sapling cooldown to use in-game days

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/PlayerTabListUpdater.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/PlayerTabListUpdater.java
@@ -111,8 +111,8 @@ public class PlayerTabListUpdater {
     }
 
     private String formatSecondsToDDMMSS(int totalSeconds) {
-        int days = totalSeconds / 86400;
-        int minutes = (totalSeconds % 86400) / 60;
+        int days = totalSeconds / (20 * 60);
+        int minutes = (totalSeconds % (20 * 60)) / 60;
         int seconds = totalSeconds % 60;
         return days + "d:" + String.format("%02d:%02d", minutes, seconds);
     }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/SaplingManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/forestry/SaplingManager.java
@@ -35,8 +35,8 @@ public class SaplingManager implements Listener {
     private int cooldownSeconds;
     private BukkitRunnable timerTask;
 
-    private static final int DEFAULT_COOLDOWN = 30 * 24 * 60 * 60; // 30 days
-    private static final int SECONDS_IN_DAY = 24 * 60 * 60;
+    private static final int SECONDS_IN_DAY = 20 * 60; // 1 in-game day = 20 minutes
+    private static final int DEFAULT_COOLDOWN = 30 * SECONDS_IN_DAY; // 30 in-game days
 
     private SaplingManager(JavaPlugin plugin) {
         this.plugin = plugin;


### PR DESCRIPTION
## Summary
- base sapling cooldown on 20-minute in-game days rather than real-world days
- update tab list countdown formatting to respect the shorter day length

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892e31517fc8332be4215552d4fbf0d