### PR TITLE
Refactor composter and Harvest Festival perks to match by name

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/enchanting/enchantingeffects/Composter.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/enchanting/enchantingeffects/Composter.java
@@ -10,37 +10,36 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.EnumSet;
 import java.util.Random;
 import java.util.Set;
 
 public class Composter implements Listener {
 
-    private static final Set<Material> ELIGIBLE_MATERIALS = EnumSet.of(
-            Material.DIRT,
-            Material.GRAVEL,
-            Material.SAND,
-            Material.WHEAT_SEEDS,
-            Material.BEETROOT_SEEDS,
-            Material.MELON_SEEDS,
-            Material.PUMPKIN_SEEDS,
-            Material.DANDELION,
-            Material.POPPY,
-            Material.BLUE_ORCHID,
-            Material.ALLIUM,
-            Material.AZURE_BLUET,
-            Material.RED_TULIP,
-            Material.ORANGE_TULIP,
-            Material.WHITE_TULIP,
-            Material.PINK_TULIP,
-            Material.OXEYE_DAISY,
-            Material.CORNFLOWER,
-            Material.LILY_OF_THE_VALLEY,
-            Material.WITHER_ROSE,
-            Material.SUNFLOWER,
-            Material.LILAC,
-            Material.ROSE_BUSH,
-            Material.PEONY
+    private static final Set<String> ELIGIBLE_MATERIALS = Set.of(
+            "DIRT",
+            "GRAVEL",
+            "SAND",
+            "WHEAT_SEEDS",
+            "BEETROOT_SEEDS",
+            "MELON_SEEDS",
+            "PUMPKIN_SEEDS",
+            "DANDELION",
+            "POPPY",
+            "BLUE_ORCHID",
+            "ALLIUM",
+            "AZURE_BLUET",
+            "RED_TULIP",
+            "ORANGE_TULIP",
+            "WHITE_TULIP",
+            "PINK_TULIP",
+            "OXEYE_DAISY",
+            "CORNFLOWER",
+            "LILY_OF_THE_VALLEY",
+            "WITHER_ROSE",
+            "SUNFLOWER",
+            "LILAC",
+            "ROSE_BUSH",
+            "PEONY"
     );
 
     private final Random random = new Random();
@@ -65,7 +64,11 @@ public class Composter implements Listener {
     }
 
     private void autoCompost(Player player, Location dropLoc) {
-        for (Material mat : ELIGIBLE_MATERIALS) {
+        for (String matName : ELIGIBLE_MATERIALS) {
+            Material mat = Material.matchMaterial(matName);
+            if (mat == null) {
+                continue;
+            }
             int count = countItem(player, mat);
             if (count >= 256) {
                 removeItem(player, mat, 64);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/AutoComposter.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/AutoComposter.java
@@ -15,7 +15,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -27,18 +26,17 @@ public class AutoComposter {
     /**
      * Crops eligible for auto-composting.
      */
-    private final Set<Material> AUTO_COMPOSTER_ELIGIBLE_CROPS = EnumSet.of(
-            Material.POTATO,
-            Material.CARROT,
-            Material.WHEAT,
-            Material.WHEAT_SEEDS,
-            Material.BEETROOT_SEEDS,
-            Material.POISONOUS_POTATO,
-            Material.MELON_SLICE,
-            Material.PUMPKIN,
-            Material.BEETROOT,
-            Material.PUMPKIN_SEEDS
-            // Add more crops if desired
+    private final Set<String> AUTO_COMPOSTER_ELIGIBLE_CROPS = Set.of(
+            "POTATO",
+            "CARROT",
+            "WHEAT",
+            "WHEAT_SEEDS",
+            "BEETROOT_SEEDS",
+            "POISONOUS_POTATO",
+            "MELON_SLICE",
+            "PUMPKIN",
+            "BEETROOT",
+            "PUMPKIN_SEEDS"
     );
 
     private final Map<Player, Location> playerLastLocations = new HashMap<>();
@@ -147,12 +145,12 @@ public class AutoComposter {
         }
 
         // 3) Count how many of each eligible crop the player holds
-        Map<Material, Integer> playerCropCounts = getPlayerCropCounts(player);
+        Map<String, Integer> playerCropCounts = getPlayerCropCounts(player);
 
         // 4) For each eligible crop, see how many conversions we can do
-        for (Material crop : AUTO_COMPOSTER_ELIGIBLE_CROPS) {
-            int playerCropCount = playerCropCounts.getOrDefault(crop, 0);
-            int weight = (crop == Material.PUMPKIN || crop == Material.MELON) ? 8 : 1;
+        for (String cropName : AUTO_COMPOSTER_ELIGIBLE_CROPS) {
+            int playerCropCount = playerCropCounts.getOrDefault(cropName, 0);
+            int weight = ("PUMPKIN".equals(cropName) || "MELON_SLICE".equals(cropName)) ? 8 : 1;
 
             int effective = playerCropCount * weight;
             if (effective >= requiredMaterialsOrganic) {
@@ -160,7 +158,10 @@ public class AutoComposter {
                 int effectiveUsed = conversions * requiredMaterialsOrganic;
                 int itemsToRemove = (int) Math.ceil(effectiveUsed / (double) weight);
 
-                subtractCrops(player, crop, itemsToRemove);
+                Material cropMat = Material.matchMaterial(cropName);
+                if (cropMat != null) {
+                    subtractCrops(player, cropMat, itemsToRemove);
+                }
                 if (perk == PetPerk.COMPOSTER) {
                     addOrganicSoil(player, conversions);
                 } else {
@@ -173,13 +174,16 @@ public class AutoComposter {
     /**
      * Retrieves the count of each eligible crop in the player's inventory.
      */
-    private Map<Material, Integer> getPlayerCropCounts(Player player) {
-        Map<Material, Integer> cropCounts = new HashMap<>();
+    private Map<String, Integer> getPlayerCropCounts(Player player) {
+        Map<String, Integer> cropCounts = new HashMap<>();
 
         for (ItemStack item : player.getInventory().getContents()) {
-            if (item != null && AUTO_COMPOSTER_ELIGIBLE_CROPS.contains(item.getType())) {
-                cropCounts.put(item.getType(),
-                        cropCounts.getOrDefault(item.getType(), 0) + item.getAmount());
+            if (item != null && AUTO_COMPOSTER_ELIGIBLE_CROPS.contains(item.getType().name())) {
+                if (item.hasItemMeta() && (item.getItemMeta().hasDisplayName() || !item.getEnchantments().isEmpty())) {
+                    continue;
+                }
+                String name = item.getType().name();
+                cropCounts.put(name, cropCounts.getOrDefault(name, 0) + item.getAmount());
             }
         }
 
@@ -192,6 +196,9 @@ public class AutoComposter {
     private void subtractCrops(Player player, Material crop, int amount) {
         for (ItemStack item : player.getInventory().getContents()) {
             if (item != null && item.getType() == crop) {
+                if (item.hasItemMeta() && (item.getItemMeta().hasDisplayName() || !item.getEnchantments().isEmpty())) {
+                    continue;
+                }
                 if (item.getAmount() > amount) {
                     item.setAmount(item.getAmount() - amount);
                     break;
@@ -211,7 +218,10 @@ public class AutoComposter {
         int removed = 0;
         for (int i = 0; i < player.getInventory().getSize(); i++) {
             ItemStack item = player.getInventory().getItem(i);
-            if (item != null && AUTO_COMPOSTER_ELIGIBLE_CROPS.contains(item.getType())) {
+            if (item != null && AUTO_COMPOSTER_ELIGIBLE_CROPS.contains(item.getType().name())) {
+                if (item.hasItemMeta() && (item.getItemMeta().hasDisplayName() || !item.getEnchantments().isEmpty())) {
+                    continue;
+                }
                 removed += item.getAmount();
                 player.getInventory().clear(i);
             }


### PR DESCRIPTION
## Summary
- Use string names instead of `Material` types to determine eligible crops in the Harvest Festival and Composter pet perks
- Skip custom named or enchanted items during automatic conversions
- Update Composter enchantment to work off material names as well

## Testing
- `mvn -q -e package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894066deae483328ca796acf95a098d