### PR TITLE
Persist shelf inventory during villager work cycles

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/culinary/ShelfManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/culinary/ShelfManager.java
@@ -32,6 +32,8 @@ public class ShelfManager implements Listener {
     private final Map<String, UUID> displayStands = new HashMap<>();
     // locKey -> facing direction for persistence
     private final Map<String, String> shelfDirections = new HashMap<>();
+    // flag to ensure shelves are loaded before we attempt to save
+    private boolean hasLoaded = false;
 
     public ShelfManager(JavaPlugin plugin) {
         this.plugin = plugin;
@@ -79,10 +81,11 @@ public class ShelfManager implements Listener {
             displayStands.put(locKey, stand.getUniqueId());
         }
         plugin.getLogger().info("[ShelfManager] Loaded " + shelfContents.size() + " shelf(s).");
+        hasLoaded = true;
     }
 
-
-    private void saveAllShelves() {
+    public void saveAllShelves() {
+        if (!hasLoaded) return; // avoid overriding data before we've loaded existing shelves
         // clear old
         for (String key : dataConfig.getKeys(false)) {
             dataConfig.set(key, null);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerWorkCycleManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerWorkCycleManager.java
@@ -153,6 +153,11 @@ public class VillagerWorkCycleManager implements Listener, CommandExecutor {
             }
 
         }
+        // Persist shelf inventories in case of abrupt shutdown
+        ShelfManager shelfManager = MinecraftNew.getInstance().getShelfManager();
+        if (shelfManager != null) {
+            shelfManager.saveAllShelves();
+        }
     }
 
     private void performVillagerWork(Villager villager) {


### PR DESCRIPTION
## Summary
- track when shelf data has been loaded and expose `saveAllShelves` for external use
- save shelf inventories after each villager work cycle to protect against abrupt shutdowns

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68940dff56008332819df83639a835b3