### PR TITLE
Add dinosaur bones drop for epic corpses

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/corpses/CorpseDeathEvent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/corpses/CorpseDeathEvent.java
@@ -76,6 +76,14 @@ public class CorpseDeathEvent implements Listener {
                     killer.playSound(killer.getLocation(), Sound.UI_TOAST_CHALLENGE_COMPLETE, 1.0f, 1.0f);
                 }
             }
+
+            // Epic corpses have a 50% chance to drop Dinosaur Bones
+            if (corpse.getRarity() == Rarity.EPIC && new Random().nextDouble() < 0.5) {
+                entity.getWorld().dropItemNaturally(
+                        entity.getLocation(),
+                        ItemRegistry.getDinosaurBones()
+                );
+            }
         });
 
         // 4% chance to drop a random heirloom


### PR DESCRIPTION
## Summary
- Allow epic corpses to drop dinosaur bones half of the time

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894224e455083329eb8758938dab2c6