### PR TITLE
Respect unbreakable tools in durability manager

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/durability/CustomDurabilityManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/durability/CustomDurabilityManager.java
@@ -269,6 +269,11 @@ public class CustomDurabilityManager implements Listener {
      * Applies damage using the custom durability system.
      */
     public void applyDamage(Player player, ItemStack item, int amount) {
+        if (item == null || amount <= 0) return;
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null && meta.isUnbreakable()) return;
+
         convertVanillaUnbreaking(item);
         ensureUnbreakingBonus(item);
         int golden = getGoldenDurability(item);


### PR DESCRIPTION
## Summary
- Prevent custom durability from reducing on items marked unbreakable

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68942533a2688332b8e3360ffb2664b2