### PR TITLE
Enable right-click relic digging on graves

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -581,7 +581,7 @@ public class ItemRegistry {
     /**
      * Returns a random Verdant Relic seed.
      */
-    public static ItemStack getRandomVerdantRelicSeed() {
+    public static ItemStack getRandomVerdantRelic() {
         Random random = new Random();
         List<ItemStack> seeds = Arrays.asList(
                 getVerdantRelicEntionPlastSeed(),


### PR DESCRIPTION
## Summary
- Allow graves to yield a random Verdant Relic seed when right-clicked
- Breaking a grave now always triggers corpse events; removed treasure chance
- Added `getRandomVerdantRelic` helper in ItemRegistry

## Testing
- `mvn -q -e test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894288ab0d88332ae8b390bf78bc515