### PR TITLE
Prevent graves from spawning on liquid blocks

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
@@ -130,7 +130,7 @@ public class Gravedigging implements Listener {
             Location target = base.clone().add(dx, 0, dz);
             int y = world.getHighestBlockYAt(target) + 1;
             Block block = world.getBlockAt(target.getBlockX(), y - 1, target.getBlockZ());
-            if (!block.getType().isAir() && !graves.containsKey(block.getLocation())) {
+            if (!block.getType().isAir() && !block.isLiquid() && !graves.containsKey(block.getLocation())) {
                 // Particle marker & sound when grave appears
                 startParticle(block.getLocation(), indicator);
                 break;


### PR DESCRIPTION
## Summary
- avoid spawning grave particles on liquid blocks

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_689430c0bc688332b41a4b12d9a4cf7e