### PR TITLE
Ensure farmer workcycles cure all overgrown relics

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/VerdantRelicsSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/VerdantRelicsSubsystem.java
@@ -192,6 +192,47 @@ public class VerdantRelicsSubsystem implements Listener {
     }
 
     /**
+     * Removes the Overgrown complication from every relic located in the
+     * provided world. This mirrors {@link #cureOvergrownNearby(Location, double)}
+     * but without any distance checks, ensuring global curing when needed.
+     *
+     * @param world World to cure relics in
+     * @return number of relics cured
+     */
+    public int cureOvergrownInWorld(World world) {
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(dataFile);
+        int cured = 0;
+        for (String key : config.getKeys(false)) {
+            Location relicLoc = fromLocKey(key);
+            if (relicLoc.getWorld() == null || !relicLoc.getWorld().equals(world)) continue;
+
+            List<String> comps = config.getStringList(key + ".complications");
+            boolean removed = comps.removeIf(c -> c.equalsIgnoreCase("overgrown"));
+            if (!removed) continue;
+
+            RelicSession session = activeSessions.get(key);
+            if (session != null) {
+                session.activeComplications.removeIf(c -> c.equalsIgnoreCase("overgrown"));
+                session.spawnComplicationStands();
+                session.updateDisplayName();
+            }
+
+            config.set(key + ".complications", comps);
+            cured++;
+        }
+
+        if (cured > 0) {
+            try {
+                config.save(dataFile);
+            } catch (IOException ex) {
+                ex.printStackTrace();
+            }
+            dataConfig = config;
+        }
+        return cured;
+    }
+
+    /**
      * Accelerates growth of all active relics by the given amount of seconds.
      * Used by certain music discs to temporarily speed up farming progress.
      *

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerWorkCycleManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerWorkCycleManager.java
@@ -317,9 +317,9 @@ public class VillagerWorkCycleManager implements Listener, CommandExecutor {
         sendHarvestToChest(villager, harvestYield);
         villager.getWorld().playSound(villager.getLocation(), Sound.BLOCK_ROOTED_DIRT_BREAK, 1.0f, 1.0f);
 
-        // Always cure overgrown relics in a 500 block radius
+        // Always cure overgrown relics anywhere in this world
         VerdantRelicsSubsystem relics = VerdantRelicsSubsystem.getInstance(MinecraftNew.getInstance());
-        int cured = relics.cureOvergrownNearby(villager.getLocation(), 500);
+        int cured = relics.cureOvergrownInWorld(villager.getWorld());
         if (cured > 0) {
             villager.getWorld().playSound(villager.getLocation(), Sound.ITEM_HOE_TILL, 1.0f, 1.0f);
         }


### PR DESCRIPTION
## Summary
- add `cureOvergrownInWorld` to VerdantRelicsSubsystem to remove overgrown complication from all relics in a world
- use new world-wide cure in VillagerWorkCycleManager so farmer workcycles cure every relic in their world

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689434b1c50c8332a19f44dcacfd299e