### PR TITLE
Ensure farmer work cycles cure overgrown relics

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerWorkCycleManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerWorkCycleManager.java
@@ -317,9 +317,9 @@ public class VillagerWorkCycleManager implements Listener, CommandExecutor {
         sendHarvestToChest(villager, harvestYield);
         villager.getWorld().playSound(villager.getLocation(), Sound.BLOCK_ROOTED_DIRT_BREAK, 1.0f, 1.0f);
 
-        // Always cure overgrown relics in a 500 block radius
+        // Always cure overgrown relics anywhere in this world while a farmer works
         VerdantRelicsSubsystem relics = VerdantRelicsSubsystem.getInstance(MinecraftNew.getInstance());
-        int cured = relics.cureOvergrownNearby(villager.getLocation(), 500);
+        int cured = relics.cureOvergrownInWorld(villager.getWorld());
         if (cured > 0) {
             villager.getWorld().playSound(villager.getLocation(), Sound.ITEM_HOE_TILL, 1.0f, 1.0f);
         }


### PR DESCRIPTION
## Summary
- Cure overgrown relics across an entire world via new helper
- Farmer work cycles now cleanse all world relics instead of a local radius

## Testing
- `mvn -q test` *(fails: Network is unreachable when resolving maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_689434b1c50c8332a19f44dcacfd299e