### PR TITLE
Use shears logic for farmer relic curing

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerWorkCycleManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerWorkCycleManager.java
@@ -317,12 +317,9 @@ public class VillagerWorkCycleManager implements Listener, CommandExecutor {
         sendHarvestToChest(villager, harvestYield);
         villager.getWorld().playSound(villager.getLocation(), Sound.BLOCK_ROOTED_DIRT_BREAK, 1.0f, 1.0f);
 
-        // Always cure overgrown relics anywhere in this world while a farmer works
+        // Always cure Overgrown relics anywhere in this world while a farmer works
         VerdantRelicsSubsystem relics = VerdantRelicsSubsystem.getInstance(MinecraftNew.getInstance());
-        int cured = relics.cureOvergrownInWorld(villager.getWorld());
-        if (cured > 0) {
-            villager.getWorld().playSound(villager.getLocation(), Sound.ITEM_HOE_TILL, 1.0f, 1.0f);
-        }
+        relics.shearOvergrownInWorld(villager.getWorld());
     }
 
 


### PR DESCRIPTION
## Summary
- add helper to apply shears-style Overgrown cleanup to loaded relics
- trigger new cleanup method during farmer work cycles

## Testing
- `mvn -q test` *(fails: Could not transfer artifact maven-resources-plugin due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689436213d9c8332917b63b03792c195