### PR TITLE
Add command to set Verdant relic growth percentage

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -225,6 +225,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         potionBrewingSubsystem = PotionBrewingSubsystem.getInstance(this);
 
         verdantRelicsSubsystem = VerdantRelicsSubsystem.getInstance(this);
+        new SetVerdantRelicGrowthPercentageCommand(this, verdantRelicsSubsystem);
         reforgeSubsystem = ReforgeSubsystem.getInstance(this);
 
         this.getCommand("pasteSchem").setExecutor(new PasteSchemCommand(this));

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/VerdantRelicsSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/farming/VerdantRelicsSubsystem.java
@@ -293,6 +293,24 @@ public class VerdantRelicsSubsystem implements Listener {
     }
 
     /**
+     * Sets the growth progress of every loaded relic to the provided
+     * percentage. Values are clamped between 0 and 100. Any relic set to
+     * 100% will be marked ready for harvest.
+     *
+     * @param percent percentage grown for all relics
+     */
+    public void setAllRelicsGrowthPercentage(int percent) {
+        int clamped = Math.max(0, Math.min(100, percent));
+        for (RelicSession session : activeSessions.values()) {
+            int newRemaining = session.totalGrowthDuration * (100 - clamped) / 100;
+            session.growthTimeRemaining = newRemaining;
+            session.readyForHarvest = newRemaining <= 0;
+            session.updateDisplayName();
+        }
+        saveAllRelics();
+    }
+
+    /**
      * Removes all active complications from every loaded relic.
      * Used by music discs or other effects that grant temporary immunity
      * to negative farming events.

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/SetVerdantRelicGrowthPercentageCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/SetVerdantRelicGrowthPercentageCommand.java
@@ -1,0 +1,47 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import goat.minecraft.minecraftnew.subsystems.farming.VerdantRelicsSubsystem;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class SetVerdantRelicGrowthPercentageCommand implements CommandExecutor {
+    private final VerdantRelicsSubsystem subsystem;
+
+    public SetVerdantRelicGrowthPercentageCommand(JavaPlugin plugin, VerdantRelicsSubsystem subsystem) {
+        this.subsystem = subsystem;
+        plugin.getCommand("setverdantrelicgrowthpercentage").setExecutor(this);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Only players can use this command.");
+            return true;
+        }
+        Player player = (Player) sender;
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You do not have permission to use this command.");
+            return true;
+        }
+        if (args.length != 1) {
+            player.sendMessage(ChatColor.RED + "Usage: /setverdantrelicgrowthpercentage <1-100>");
+            return true;
+        }
+        try {
+            int percent = Integer.parseInt(args[0]);
+            if (percent < 1 || percent > 100) {
+                player.sendMessage(ChatColor.RED + "Percentage must be between 1 and 100.");
+                return true;
+            }
+            subsystem.setAllRelicsGrowthPercentage(percent);
+            player.sendMessage(ChatColor.GREEN + "Set all Verdant relics to " + percent + "% grown.");
+        } catch (NumberFormatException e) {
+            player.sendMessage(ChatColor.RED + "Invalid number.");
+        }
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -297,3 +297,7 @@ commands:
     description: Calls every Ender Dragon to your location
     usage: /flytome
     permission: continuity.admin
+  setverdantrelicgrowthpercentage:
+    description: Sets all Verdant relics to a growth percentage
+    usage: /setverdantrelicgrowthpercentage <1-100>
+    permission: continuity.admin


### PR DESCRIPTION
## Summary
- Add `/setverdantrelicgrowthpercentage` dev command to adjust growth progress of all Verdant relics
- Implement subsystem support for setting relic growth to a specific percentage
- Register the new command and expose it in plugin.yml

## Testing
- `mvn -q -e test` *(failed: Could not resolve org.apache.maven.plugins:maven-resources-plugin:3.3.1; Network is unreachable)*
- `mvn -q -e -DskipTests package` *(failed: Could not resolve org.apache.maven.plugins:maven-resources-plugin:3.3.1; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68943f808b9483329cf5dbd793d41802