### PR TITLE
Add Strength potion to Strength system

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/PotionBrewingSubsystem.java
@@ -326,7 +326,7 @@ public class PotionBrewingSubsystem implements Listener {
         //strength is farmed from Knights
         List<String> strengthIngredients = Arrays.asList("Glass Bottle", "Nether Wart", "Gravity");
         int baseDuration = (60 * 3);
-        List<String> strengthLore = Arrays.asList("Increases melee damage by 25%", "Base Duration of " + baseDuration);
+        List<String> strengthLore = Arrays.asList("Grants +25 Strength ⚔", "Base Duration of " + baseDuration);
         Color strengthColor = Color.fromRGB(101, 67, 33);
         recipeRegistry.add(
                 new PotionRecipe("Potion of Strength", strengthIngredients, 60 * 10, new ItemStack(Material.POTION), strengthColor, strengthLore)

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfStrength.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/brewing/custompotions/PotionOfStrength.java
@@ -2,24 +2,19 @@ package goat.minecraft.minecraftnew.subsystems.brewing.custompotions;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
-import goat.minecraft.minecraftnew.subsystems.brewing.PotionEffectPreferences;
 import goat.minecraft.minecraftnew.utils.devtools.XPManager;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.entity.Minecart;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.inventory.ItemStack;
 
 public class PotionOfStrength implements Listener {
 
     /**
-     * Listens for a player drinking a potion.
-     * If the potion’s display name (after stripping colors) equals "Potion of Strength",
-     * the custom effect is added for 15 seconds.
+     * Handles consumption of the Potion of Strength.
+     * Grants the custom effect for a base duration of 3 minutes.
      */
     @EventHandler
     public void onPotionDrink(PlayerItemConsumeEvent event) {
@@ -37,27 +32,10 @@ public class PotionOfStrength implements Listener {
                                     goat.minecraft.minecraftnew.other.skilltree.Talent.STRENGTH_MASTERY);
                     duration += bonus;
                 }
-                // Add the custom effect for 15 seconds
+                // Add the custom effect for the calculated duration
                 PotionManager.addCustomPotionEffect("Potion of Strength", player, duration);
                 player.sendMessage(ChatColor.GREEN + "Potion of Strength effect activated for " + duration + " seconds!");
                 xpManager.addXP(player, "Brewing", 100);
-            }
-        }
-    }
-
-    /**
-     * Listens for when a player deals damage.
-     * If the damager is a player with an active "Potion of Strength" effect,
-     * increases the damage by 15%.
-     */
-    @EventHandler
-    public void onPlayerDamage(EntityDamageByEntityEvent event) {
-        if (event.getDamager() instanceof Player) {
-            Player player = (Player) event.getDamager();
-            if (PotionManager.isActive("Potion of Strength", player)
-                    && PotionEffectPreferences.isEnabled(player, "Potion of Strength")) {
-                double extraDamage = event.getDamage() * 0.25;
-                event.setDamage(event.getDamage() + extraDamage);
             }
         }
     }

--- a/src/main/java/goat/minecraft/minecraftnew/utils/stats/StrengthManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/stats/StrengthManager.java
@@ -6,6 +6,8 @@ import goat.minecraft.minecraftnew.other.beacon.CatalystType;
 import goat.minecraft.minecraftnew.other.skilltree.Skill;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
 import goat.minecraft.minecraftnew.other.skilltree.Talent;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionEffectPreferences;
+import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
 import goat.minecraft.minecraftnew.subsystems.smithing.tierreforgelisteners.ReforgeManager;
 import goat.minecraft.minecraftnew.subsystems.smithing.tierreforgelisteners.ReforgeManager.ReforgeTier;
 import goat.minecraft.minecraftnew.utils.devtools.TalismanManager;
@@ -72,6 +74,12 @@ public final class StrengthManager {
                 int tier = cm.getCatalystTier(catalyst);
                 strength += 25 + (tier * 5);
             }
+        }
+
+        // Potion of Strength grants a flat Strength bonus while active
+        if (PotionManager.isActive("Potion of Strength", player)
+                && PotionEffectPreferences.isEnabled(player, "Potion of Strength")) {
+            strength += 25;
         }
 
         return strength;


### PR DESCRIPTION
## Summary
- integrate Potion of Strength with new Strength stat
- update potion lore to use Strength terminology
- remove deprecated damage listener and compute bonus through StrengthManager

## Testing
- `mvn -q -e package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*
- `mvn -q -e package -o` *(fails: Cannot access central in offline mode; artifact has not been downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68957f27dc5883328f6359987c5c6074