### PR TITLE
Add strength breakdown to stats GUI

### DIFF
--- a/ADDING_STRENGTH_SUPPORT.md
+++ b/ADDING_STRENGTH_SUPPORT.md
@@ -2,7 +2,9 @@ Adding Strength Support is a simple enough process.
 1: Identify deprecated damage increase logic (eg, Sword Damage Talents Granting "+4% Damage". Other possible identifiers are Bonus Damage, Increase Damage, + Damage, etc)
 2: Replace deprecated displays of damage increases with Strength. 1 Strength equates to 1% Bonus damage. (for example, replacing "+4% Bonus Damage" with "+4 Strength ⚔️")
 3: Replace deprecated logic (all Strength is processed through the StrengthManager, so all you need to do is add strength, no need to change logic. however, old logic will need to be removed. Example: Sword Damage Talents used to have a dedicated damage listener, which was removed when adding the StrengthManager)
-4: Provide the user with a detailed report of: 
+4: Provide the user with a detailed report of:
 A: Identified Deprecated Logic: True/False, <Location (Example, MinecraftNew.java)>"
 B: Replaced Old Display: "<oldDisplay (example: "+4% Damage")>" with "<newDisplay (example: "+4 Strength ⚔️")>"
 C: Removed Deprecated Logic: True/False, <oldExampleOfDeprecatedDamageIncreaseListeners/strategies>
+5: When adding new components to the StrengthManager#getStrength calculation, ensure each component is also represented in the
+   Strength breakdown printout so users can see its contribution.

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/StatsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/StatsCommand.java
@@ -36,9 +36,19 @@ public class StatsCommand implements CommandExecutor, Listener {
 
     @EventHandler
     public void onInventoryClick(InventoryClickEvent event) {
-        if (!(event.getWhoClicked() instanceof Player)) return;
+        if (!(event.getWhoClicked() instanceof Player player)) return;
         if (ChatColor.stripColor(event.getView().getTitle()).equals("Player Stats")) {
             event.setCancelled(true);
+
+            ItemStack clicked = event.getCurrentItem();
+            if (clicked == null) return;
+            ItemMeta meta = clicked.getItemMeta();
+            if (meta == null || !meta.hasDisplayName()) return;
+
+            String name = ChatColor.stripColor(meta.getDisplayName());
+            if (name.equals(ChatColor.stripColor(StrengthManager.DISPLAY_NAME))) {
+                StrengthManager.sendStrengthBreakdown(player);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Show detailed strength breakdown when clicking the stat in the Player Stats GUI.
- Introduce `StrengthManager.sendStrengthBreakdown` to list contributions from talents, reforges, catalysts, pets, and potions.
- Document that new strength components must appear in the breakdown printout.

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6895831f4db48332ae8d2686a2bf114e