### PR TITLE
Add Strength support to beacon power passive

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/beacon/BeaconPassiveEffects.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/beacon/BeaconPassiveEffects.java
@@ -4,7 +4,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -102,20 +101,6 @@ public class BeaconPassiveEffects implements Listener {
     }
 
     @EventHandler
-    public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
-        // Power passive: +15% damage when player attacks
-        if (event.getDamager() instanceof Player) {
-            Player player = (Player) event.getDamager();
-            
-            if (BeaconPassivesGUI.hasBeaconPassives(player) && 
-                BeaconPassivesGUI.hasPassiveEnabled(player, "power")) {
-                double damage = event.getDamage();
-                event.setDamage(damage * 1.15);
-            }
-        }
-    }
-
-    @EventHandler
     public void onPlayerMove(PlayerMoveEvent event) {
         Player player = event.getPlayer();
         
@@ -146,4 +131,5 @@ public class BeaconPassiveEffects implements Listener {
         for (Player player : plugin.getServer().getOnlinePlayers()) {
             updatePassiveEffects(player);
         }
-    }}
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/other/beacon/BeaconPassivesGUI.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/beacon/BeaconPassivesGUI.java
@@ -17,6 +17,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.java.JavaPlugin;
+import goat.minecraft.minecraftnew.utils.stats.StrengthManager;
 
 import java.io.File;
 import java.io.IOException;
@@ -91,8 +92,9 @@ public class BeaconPassivesGUI implements Listener {
         ItemStack swiftButton = createPassiveButton(Material.FEATHER, 
             "Swift", "+20% walk speed, -50% fall damage", passives.getOrDefault("swift", false));
         
-        ItemStack powerButton = createPassiveButton(Material.DIAMOND_SWORD, 
-            "Power", "+15% damage", passives.getOrDefault("power", false));
+        ItemStack powerButton = createPassiveButton(Material.DIAMOND_SWORD,
+            "Power", ChatColor.RED + "+15 " + StrengthManager.DISPLAY_NAME,
+            passives.getOrDefault("power", false));
         
         // Place passive buttons in the GUI
         gui.setItem(10, mendingButton);

--- a/src/main/java/goat/minecraft/minecraftnew/utils/stats/StrengthManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/stats/StrengthManager.java
@@ -1,5 +1,6 @@
 package goat.minecraft.minecraftnew.utils.stats;
 
+import goat.minecraft.minecraftnew.other.beacon.BeaconPassivesGUI;
 import goat.minecraft.minecraftnew.other.beacon.Catalyst;
 import goat.minecraft.minecraftnew.other.beacon.CatalystManager;
 import goat.minecraft.minecraftnew.other.beacon.CatalystType;
@@ -77,6 +78,13 @@ public final class StrengthManager {
                 strength += 25 + (tier * 5);
             }
         }
+
+        // Beacon Power passive grants flat Strength
+        if (BeaconPassivesGUI.hasBeaconPassives(player)
+                && BeaconPassivesGUI.hasPassiveEnabled(player, "power")) {
+            strength += 15;
+        }
+
         // Pet perks that grant bonus Strength
         PetManager pm = PetManager.getInstance(MinecraftNew.getInstance());
         if (pm != null) {
@@ -159,6 +167,15 @@ public final class StrengthManager {
         }
         total += catalystStrength;
         player.sendMessage(COLOR + "Catalyst of Power: " + ChatColor.YELLOW + catalystStrength);
+
+        // Strength from Beacon Power passive
+        int powerPassiveStrength = 0;
+        if (BeaconPassivesGUI.hasBeaconPassives(player)
+                && BeaconPassivesGUI.hasPassiveEnabled(player, "power")) {
+            powerPassiveStrength = 15;
+        }
+        total += powerPassiveStrength;
+        player.sendMessage(COLOR + "Beacon Power Passive: " + ChatColor.YELLOW + powerPassiveStrength);
 
         // Strength from pet perks
         int petEliteStrength = 0;


### PR DESCRIPTION
## Summary
- Replace beacon Power passive damage bonus with +15 Strength ⚔️
- Integrate Power passive with StrengthManager and strength breakdown
- Remove deprecated damage listener logic for Power passive

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896771c75cc8332b61aab061c295f52