### PR TITLE
Refactor health stat system and fix stats GUI

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -214,7 +214,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
                 p.stopAllSounds());
         removeAllCitizenEntities();
 
-        HealthManager.getInstance(this).startup();
+        HealthManager.startup();
 
         ArmorStandCommand armorStandCommand = new ArmorStandCommand(this);
         armorStandCommand.removeInvisibleArmorStands();
@@ -784,7 +784,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
 
     @Override
     public void onDisable() {
-        HealthManager.getInstance(this).shutdown();
+        HealthManager.shutdown();
         if (shelfManager != null) {
             shelfManager.onDisable();
         }

--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/PlayerLevel.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/PlayerLevel.java
@@ -21,7 +21,7 @@ public class PlayerLevel implements Listener {
 
     // Method to apply attribute bonuses to a player
     public void applyPlayerAttributes(Player player) {
-        HealthManager.getInstance(plugin).applyAndFill(player);
+        HealthManager.applyAndFill(player);
     }
 
     // Event handlers to apply attributes when necessary

--- a/src/main/java/goat/minecraft/minecraftnew/other/armorsets/MonolithSetBonus.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/armorsets/MonolithSetBonus.java
@@ -88,7 +88,7 @@ public class MonolithSetBonus implements Listener {
             return;
         }
         player.addPotionEffect(new PotionEffect(PotionEffectType.RESISTANCE, Integer.MAX_VALUE, 0, false, false));
-        HealthManager.getInstance(plugin).updateHealth(player);
+        HealthManager.updateHealth(player);
         applied.put(id, true);
     }
 
@@ -98,7 +98,7 @@ public class MonolithSetBonus implements Listener {
             return;
         }
         player.removePotionEffect(PotionEffectType.RESISTANCE);
-        HealthManager.getInstance(plugin).updateHealth(player);
+        HealthManager.updateHealth(player);
         applied.put(id, false);
     }
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/beacon/BeaconPassiveEffects.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/beacon/BeaconPassiveEffects.java
@@ -40,7 +40,7 @@ public class BeaconPassiveEffects implements Listener {
         boolean hasBeaconPassives = BeaconPassivesGUI.hasBeaconPassives(player);
         
         // Trigger health updates for Mending passive
-        HealthManager.getInstance(plugin).updateHealth(player);
+        HealthManager.updateHealth(player);
         
         // Apply/remove Swift effect (+20% walk speed, -50% fall damage)
         if (hasBeaconPassives && BeaconPassivesGUI.hasPassiveEnabled(player, "swift")) {
@@ -107,7 +107,7 @@ public class BeaconPassiveEffects implements Listener {
         // Clean up effects when player no longer has beacon
         if (!BeaconPassivesGUI.hasBeaconPassives(player)) {
             removeSwiftEffect(player);
-            HealthManager.getInstance(plugin).updateHealth(player);
+            HealthManager.updateHealth(player);
         }
     }
 
@@ -118,7 +118,7 @@ public class BeaconPassiveEffects implements Listener {
     public void removeAllPassiveEffects() {
         for (Player player : plugin.getServer().getOnlinePlayers()) {
             removeSwiftEffect(player);
-            HealthManager.getInstance(plugin).updateHealth(player);
+            HealthManager.updateHealth(player);
         }
         swiftApplied.clear();
     }

--- a/src/main/java/goat/minecraft/minecraftnew/other/health/HealthManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/health/HealthManager.java
@@ -3,83 +3,144 @@ package goat.minecraft.minecraftnew.other.health;
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.other.additionalfunctionality.BlessingUtils;
 import goat.minecraft.minecraftnew.other.beacon.BeaconPassivesGUI;
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
 import goat.minecraft.minecraftnew.subsystems.pets.PetTrait;
-import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
-import goat.minecraft.minecraftnew.other.skilltree.Skill;
-import goat.minecraft.minecraftnew.other.skilltree.Talent;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
-public class HealthManager {
+/**
+ * Utility class for calculating and applying player health values.
+ */
+public final class HealthManager {
 
-    private static HealthManager instance;
-    private final JavaPlugin plugin;
+    /** Chat color used when displaying Health. */
+    public static final ChatColor COLOR = ChatColor.RED;
 
-    private HealthManager(JavaPlugin plugin) {
-        this.plugin = plugin;
-    }
+    /** Emoji used alongside the Health name. */
+    public static final String EMOJI = "❤️";
 
-    public static synchronized HealthManager getInstance(JavaPlugin plugin) {
-        if (instance == null) {
-            instance = new HealthManager(plugin);
-        }
-        return instance;
-    }
+    /** Preformatted display name for Health with color and emoji. */
+    public static final String DISPLAY_NAME = COLOR + "Health " + EMOJI;
 
-    public static HealthManager getInstance() {
-        return instance;
+    private HealthManager() {
+        // Utility class
     }
 
     /**
-     * Compute the maximum health for a player based on all bonuses.
+     * Computes the maximum health for a player from all current sources.
+     *
+     * @param player player to calculate Health for
+     * @return total max health value
      */
-    public double computeMaxHealth(Player player) {
+    public static double getMaxHealth(Player player) {
         double health = 20.0;
 
         int talentLevel = 0;
-        if (SkillTreeManager.getInstance() != null) {
-            talentLevel += SkillTreeManager.getInstance()
-                    .getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_I);
-            talentLevel += SkillTreeManager.getInstance()
-                    .getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_II);
-            talentLevel += SkillTreeManager.getInstance()
-                    .getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_III);
-            talentLevel += SkillTreeManager.getInstance()
-                    .getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_IV);
-            talentLevel += SkillTreeManager.getInstance()
-                    .getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_V);
+        SkillTreeManager stm = SkillTreeManager.getInstance();
+        if (stm != null) {
+            talentLevel += stm.getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_I);
+            talentLevel += stm.getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_II);
+            talentLevel += stm.getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_III);
+            talentLevel += stm.getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_IV);
+            talentLevel += stm.getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_V);
         }
         health += talentLevel;
 
-        if (BeaconPassivesGUI.hasBeaconPassives(player) &&
-                BeaconPassivesGUI.hasPassiveEnabled(player, "mending")) {
-            health += 20.0;
+        double beaconBonus = 0.0;
+        if (BeaconPassivesGUI.hasBeaconPassives(player)
+                && BeaconPassivesGUI.hasPassiveEnabled(player, "mending")) {
+            beaconBonus = 20.0;
+            health += beaconBonus;
         }
 
+        double setBonus = 0.0;
         if (BlessingUtils.hasFullSetBonus(player, "Monolith")) {
-            health += 20.0;
+            setBonus = 20.0;
+            health += setBonus;
         }
 
-        PetManager.Pet active = PetManager.getInstance(plugin).getActivePet(player);
-        if (active != null && active.getTrait() == PetTrait.HEALTHY) {
-            double percent = active.getTrait().getValueForRarity(active.getTraitRarity());
-            double bonus = Math.floor((health * percent / 100.0) / 2) * 2; // round down to full hearts
-            health += bonus;
+        double petBonus = 0.0;
+        PetManager pm = PetManager.getInstance(MinecraftNew.getInstance());
+        if (pm != null) {
+            PetManager.Pet active = pm.getActivePet(player);
+            if (active != null && active.getTrait() == PetTrait.HEALTHY) {
+                double percent = active.getTrait().getValueForRarity(active.getTraitRarity());
+                petBonus = Math.floor((health * percent / 100.0) / 2) * 2; // round down to full hearts
+                health += petBonus;
+            }
         }
 
         return health;
     }
 
     /**
+     * Sends a detailed breakdown of the player's Health calculation.
+     *
+     * @param player the player to report Health for
+     */
+    public static void sendHealthBreakdown(Player player) {
+        player.sendMessage(COLOR + "Health Breakdown:");
+
+        double base = 20.0;
+        player.sendMessage(COLOR + "Base: " + ChatColor.YELLOW + base);
+
+        double total = base;
+
+        double talentBonus = 0.0;
+        SkillTreeManager stm = SkillTreeManager.getInstance();
+        if (stm != null) {
+            talentBonus += stm.getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_I);
+            talentBonus += stm.getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_II);
+            talentBonus += stm.getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_III);
+            talentBonus += stm.getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_IV);
+            talentBonus += stm.getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_V);
+        }
+        total += talentBonus;
+        player.sendMessage(COLOR + "Health Talents: " + ChatColor.YELLOW + talentBonus);
+
+        double beaconBonus = 0.0;
+        if (BeaconPassivesGUI.hasBeaconPassives(player)
+                && BeaconPassivesGUI.hasPassiveEnabled(player, "mending")) {
+            beaconBonus = 20.0;
+        }
+        total += beaconBonus;
+        player.sendMessage(COLOR + "Beacon Mending Passive: " + ChatColor.YELLOW + beaconBonus);
+
+        double setBonus = 0.0;
+        if (BlessingUtils.hasFullSetBonus(player, "Monolith")) {
+            setBonus = 20.0;
+        }
+        total += setBonus;
+        player.sendMessage(COLOR + "Monolith Set Bonus: " + ChatColor.YELLOW + setBonus);
+
+        double petBonus = 0.0;
+        PetManager pm = PetManager.getInstance(MinecraftNew.getInstance());
+        if (pm != null) {
+            PetManager.Pet active = pm.getActivePet(player);
+            if (active != null && active.getTrait() == PetTrait.HEALTHY) {
+                double percent = active.getTrait().getValueForRarity(active.getTraitRarity());
+                petBonus = Math.floor((total * percent / 100.0) / 2) * 2; // round down to full hearts
+            }
+        }
+        total += petBonus;
+        player.sendMessage(COLOR + "Healthy Pet Trait: " + ChatColor.YELLOW + petBonus);
+
+        player.sendMessage(COLOR + "Total Health: " + ChatColor.YELLOW + total);
+    }
+
+    /**
      * Apply computed max health to the player, keeping current health within bounds.
      */
-    public void updateHealth(Player player) {
-        double max = computeMaxHealth(player);
+    public static void updateHealth(Player player) {
+        double max = getMaxHealth(player);
         AttributeInstance attr = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
         if (attr != null) {
             attr.setBaseValue(max);
@@ -92,8 +153,8 @@ public class HealthManager {
     /**
      * Apply computed max health and fully heal the player.
      */
-    public void applyAndFill(Player player) {
-        double max = computeMaxHealth(player);
+    public static void applyAndFill(Player player) {
+        double max = getMaxHealth(player);
         AttributeInstance attr = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
         player.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, 100, 255, true));
         if (attr != null) {
@@ -105,8 +166,8 @@ public class HealthManager {
     /**
      * Recalculate and fill health for all online players on startup.
      */
-    public void startup() {
-        for (Player player : plugin.getServer().getOnlinePlayers()) {
+    public static void startup() {
+        for (Player player : Bukkit.getOnlinePlayers()) {
             applyAndFill(player);
         }
     }
@@ -114,8 +175,8 @@ public class HealthManager {
     /**
      * Reset all player health to the default 20 before shutdown to avoid stacking.
      */
-    public void shutdown() {
-        for (Player player : plugin.getServer().getOnlinePlayers()) {
+    public static void shutdown() {
+        for (Player player : Bukkit.getOnlinePlayers()) {
             AttributeInstance attr = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
             if (attr != null) {
                 attr.setBaseValue(20.0);
@@ -126,3 +187,4 @@ public class HealthManager {
         }
     }
 }
+

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -939,7 +939,7 @@ public class SkillTreeManager implements Listener {
             if (talent == Talent.HEALTH_I || talent == Talent.HEALTH_II ||
                     talent == Talent.HEALTH_III || talent == Talent.HEALTH_IV ||
                     talent == Talent.HEALTH_V) {
-                HealthManager.getInstance(plugin).applyAndFill(player);
+                HealthManager.applyAndFill(player);
             }
             if (talent == Talent.STUDY_BREWING) {
                 addExtraTalentPoints(player.getUniqueId(), Skill.BREWING, 1);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/traits/PetTraitEffects.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/traits/PetTraitEffects.java
@@ -40,11 +40,11 @@ public class PetTraitEffects implements Listener {
 
     // ===== Attribute Helpers =====
     private void applyHealthTrait(Player player) {
-        HealthManager.getInstance(petManager.getPlugin()).updateHealth(player);
+        HealthManager.updateHealth(player);
     }
 
     private void removeHealthTrait(Player player) {
-        HealthManager.getInstance(petManager.getPlugin()).updateHealth(player);
+        HealthManager.updateHealth(player);
     }
 
     private void applySpeedTrait(Player player) {
@@ -76,13 +76,13 @@ public class PetTraitEffects implements Listener {
     public void applyTraits(Player player) {
         applyHealthTrait(player);
         applySpeedTrait(player);
-        HealthManager.getInstance(petManager.getPlugin()).updateHealth(player);
+        HealthManager.updateHealth(player);
     }
 
     public void removeTraits(Player player) {
         removeHealthTrait(player);
         removeSpeedTrait(player);
-        HealthManager.getInstance(petManager.getPlugin()).updateHealth(player);
+        HealthManager.updateHealth(player);
     }
 
     // ===== Event Hooks =====

--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/StatsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/StatsCommand.java
@@ -2,6 +2,7 @@ package goat.minecraft.minecraftnew.utils.commands;
 
 import goat.minecraft.minecraftnew.utils.stats.StatsCalculator;
 import goat.minecraft.minecraftnew.utils.stats.StrengthManager;
+import goat.minecraft.minecraftnew.other.health.HealthManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -25,13 +26,10 @@ import java.util.List;
  */
 public class StatsCommand implements CommandExecutor, Listener {
 
-    private final JavaPlugin plugin;
     private final StatsCalculator calculator;
 
     public StatsCommand(JavaPlugin plugin) {
-        this.plugin = plugin;
         this.calculator = StatsCalculator.getInstance(plugin);
-        Bukkit.getPluginManager().registerEvents(this, plugin);
     }
 
     @EventHandler
@@ -48,6 +46,8 @@ public class StatsCommand implements CommandExecutor, Listener {
             String name = ChatColor.stripColor(meta.getDisplayName());
             if (name.equals(ChatColor.stripColor(StrengthManager.DISPLAY_NAME))) {
                 StrengthManager.sendStrengthBreakdown(player);
+            } else if (name.equals(ChatColor.stripColor(HealthManager.DISPLAY_NAME))) {
+                HealthManager.sendHealthBreakdown(player);
             }
         }
     }
@@ -83,7 +83,7 @@ public class StatsCommand implements CommandExecutor, Listener {
 
         int[] slots = {10,11,12,13,14,15,16,19,20,21,22,23,24,25,28,29,30,31,32,33,34};
         int index = 0;
-        addStatItem(inv, slots[index++], Material.REDSTONE, "Health", String.format("%.1f", calculator.getHealth(player)));
+        addStatItem(inv, slots[index++], Material.REDSTONE, HealthManager.DISPLAY_NAME, String.format("%.1f", calculator.getHealth(player)));
         addStatItem(inv, slots[index++], Material.IRON_SWORD, StrengthManager.DISPLAY_NAME, String.format("%d", calculator.getStrength(player)));
         addStatItem(inv, slots[index++], Material.BOW, "Arrow Damage +%", String.format("%.1f%%", calculator.getArrowDamageIncrease(player)));
         addStatItem(inv, slots[index++], Material.SHIELD, "Resistance", String.format("%.1f%%", calculator.getResistance(player)));

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/XPManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/XPManager.java
@@ -535,7 +535,7 @@ public class XPManager implements CommandExecutor {
             player.addPotionEffect(new PotionEffect(PotionEffectType.ABSORPTION, 1200, 0));
             player.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, 600, 0));
 
-            HealthManager.getInstance(plugin).applyAndFill(player);
+            HealthManager.applyAndFill(player);
         }
 
         String borderTop    = ChatColor.DARK_AQUA + "╔═════════════════════╗";

--- a/src/main/java/goat/minecraft/minecraftnew/utils/stats/StatsCalculator.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/stats/StatsCalculator.java
@@ -60,7 +60,7 @@ public class StatsCalculator {
 
     /** Calculate max health using HealthManager. */
     public double getHealth(Player player) {
-        return HealthManager.getInstance(plugin).computeMaxHealth(player);
+        return HealthManager.getMaxHealth(player);
     }
 
     /** Approximate melee damage increase percent from reforges and talents. */


### PR DESCRIPTION
## Summary
- Convert `HealthManager` into a static utility with a heart-themed display name and health breakdown reporting
- Wire `/stats` GUI to use the new health stat and avoid duplicate event registration
- Update plugin startup/shutdown and other systems to call the static health helpers

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689695f4cf3083328a3ce44e25eabf1b