### PR TITLE
Add Strength support for Strong pet trait

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
@@ -690,8 +690,18 @@ public class PetManager implements Listener {
                             + "[" + pet.getTraitRarity().getDisplayName() + "] "
                             + pet.getTraitRarity().getColor() + pet.getTrait().getDisplayName());
                     double traitValue = pet.getTrait().getValueForRarity(pet.getTraitRarity());
-                    lore.add(pet.getTrait().getColor() + pet.getTrait().getDescription() + ": "
-                            + pet.getTrait().getColor() + "+" + traitValue + "%");
+                    if (pet.getTrait() == PetTrait.STRONG) {
+                        SkillTreeManager stm = SkillTreeManager.getInstance();
+                        if (stm != null) {
+                            int q = stm.getTalentLevel(player.getUniqueId(), Skill.TAMING, Talent.QUIRKY);
+                            traitValue *= (1 + q * 0.20);
+                        }
+                        int strengthBonus = (int) Math.round(traitValue);
+                        lore.add(ChatColor.GRAY + "Grants " + StrengthManager.COLOR + "+" + strengthBonus + " " + StrengthManager.DISPLAY_NAME);
+                    } else {
+                        lore.add(pet.getTrait().getColor() + pet.getTrait().getDescription() + ": "
+                                + pet.getTrait().getColor() + "+" + traitValue + "%");
+                    }
                 }
                 if (pet.equals(active)) {
                     lore.add(ChatColor.GREEN + "Currently Active");

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetTrait.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetTrait.java
@@ -1,6 +1,7 @@
 package goat.minecraft.minecraftnew.subsystems.pets;
 
 import org.bukkit.ChatColor;
+import goat.minecraft.minecraftnew.utils.stats.StrengthManager;
 
 /**
  * Standard pet traits. Each trait defines a description of its
@@ -11,7 +12,7 @@ import org.bukkit.ChatColor;
 public enum PetTrait {
     HEALTHY(ChatColor.RED, "Health Increase", new double[]{1,2, 4,6,10,20}),
     FAST(ChatColor.YELLOW, "Speed Increase", new double[]{1,3,5,8,10,20}),
-    STRONG(ChatColor.RED, "Damage Increase", new double[]{3,5,8,10,15,20}),
+    STRONG(ChatColor.RED, StrengthManager.DISPLAY_NAME, new double[]{3,5,8,10,15,20}),
     RESILIENT(ChatColor.WHITE, "Damage Reduction", new double[]{3,5,8,10,15,20}),
     NAUTICAL(ChatColor.AQUA, "Sea Creature Chance", new double[]{1,2,3,4,5,6}),
     HAUNTED(ChatColor.AQUA, "Spirit Chance", new double[]{1,2,3,4,5,6}),

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/traits/PetTraitEffects.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/traits/PetTraitEffects.java
@@ -88,16 +88,6 @@ public class PetTraitEffects implements Listener {
     // ===== Event Hooks =====
 
     @EventHandler
-    public void onMeleeDamage(EntityDamageByEntityEvent event) {
-        if (!(event.getDamager() instanceof Player player)) return;
-        PetManager.Pet active = petManager.getActivePet(player);
-        if (active != null && active.getTrait() == PetTrait.STRONG) {
-            double bonus = active.getTrait().getValueForRarity(active.getTraitRarity());
-            event.setDamage(event.getDamage() * (1.0 + bonus / 100.0));
-        }
-    }
-
-    @EventHandler
     public void onArrowDamage(EntityDamageByEntityEvent event) {
         if (event.getDamager() instanceof Arrow arrow && arrow.getShooter() instanceof Player player) {
             PetManager.Pet active = petManager.getActivePet(player);

--- a/src/main/java/goat/minecraft/minecraftnew/utils/stats/StrengthManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/stats/StrengthManager.java
@@ -6,6 +6,7 @@ import goat.minecraft.minecraftnew.other.beacon.CatalystManager;
 import goat.minecraft.minecraftnew.other.beacon.CatalystType;
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
+import goat.minecraft.minecraftnew.subsystems.pets.PetTrait;
 import goat.minecraft.minecraftnew.other.skilltree.Skill;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
 import goat.minecraft.minecraftnew.other.skilltree.Talent;
@@ -85,11 +86,20 @@ public final class StrengthManager {
             strength += 15;
         }
 
-        // Pet perks that grant bonus Strength
+        // Pet traits and perks that grant bonus Strength
         PetManager pm = PetManager.getInstance(MinecraftNew.getInstance());
         if (pm != null) {
             PetManager.Pet pet = pm.getActivePet(player);
             if (pet != null) {
+                if (pet.getTrait() == PetTrait.STRONG) {
+                    double petStrength = pet.getTrait().getValueForRarity(pet.getTraitRarity());
+                    SkillTreeManager stm = SkillTreeManager.getInstance();
+                    if (stm != null) {
+                        int q = stm.getTalentLevel(player.getUniqueId(), Skill.TAMING, Talent.QUIRKY);
+                        petStrength *= (1 + q * 0.20);
+                    }
+                    strength += (int) Math.round(petStrength);
+                }
                 if (pet.hasPerk(PetManager.PetPerk.ELITE)) {
                     // 0.5 Strength per pet level, capped at +25
                     int petStrength = Math.min((int) (pet.getLevel() * 0.5), 25);
@@ -177,14 +187,24 @@ public final class StrengthManager {
         total += powerPassiveStrength;
         player.sendMessage(COLOR + "Beacon Power Passive: " + ChatColor.YELLOW + powerPassiveStrength);
 
-        // Strength from pet perks
+        // Strength from pet traits and perks
         int petEliteStrength = 0;
         int eliteTalentStrength = 0;
         int petClawStrength = 0;
+        int petStrongTraitStrength = 0;
         PetManager pm = PetManager.getInstance(MinecraftNew.getInstance());
         if (pm != null) {
             PetManager.Pet pet = pm.getActivePet(player);
             if (pet != null) {
+                if (pet.getTrait() == PetTrait.STRONG) {
+                    double val = pet.getTrait().getValueForRarity(pet.getTraitRarity());
+                    SkillTreeManager stm = SkillTreeManager.getInstance();
+                    if (stm != null) {
+                        int q = stm.getTalentLevel(player.getUniqueId(), Skill.TAMING, Talent.QUIRKY);
+                        val *= (1 + q * 0.20);
+                    }
+                    petStrongTraitStrength = (int) Math.round(val);
+                }
                 if (pet.hasPerk(PetManager.PetPerk.ELITE)) {
                     petEliteStrength = Math.min((int) (pet.getLevel() * 0.5), 25);
                     SkillTreeManager stm = SkillTreeManager.getInstance();
@@ -198,7 +218,8 @@ public final class StrengthManager {
                 }
             }
         }
-        total += petEliteStrength + eliteTalentStrength + petClawStrength;
+        total += petEliteStrength + eliteTalentStrength + petClawStrength + petStrongTraitStrength;
+        player.sendMessage(COLOR + "Pet Strong Trait: " + ChatColor.YELLOW + petStrongTraitStrength);
         player.sendMessage(COLOR + "Pet Elite Perk: " + ChatColor.YELLOW + petEliteStrength);
         player.sendMessage(COLOR + "Elite Talent Bonus: " + ChatColor.YELLOW + eliteTalentStrength);
         player.sendMessage(COLOR + "Pet Claw Perk: " + ChatColor.YELLOW + petClawStrength);


### PR DESCRIPTION
## Summary
- Convert Strong pet trait to grant Strength instead of percentage damage
- Show Strength bonus in pet trait lore
- Account for Strong trait in Strength calculations and breakdown

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896964dc47483329c8d4e62f3d8155e