### PR TITLE
Add health trait display and mending passive info

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/beacon/BeaconPassivesGUI.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/beacon/BeaconPassivesGUI.java
@@ -18,6 +18,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.java.JavaPlugin;
 import goat.minecraft.minecraftnew.utils.stats.StrengthManager;
+import goat.minecraft.minecraftnew.other.health.HealthManager;
 
 import goat.minecraft.minecraftnew.other.additionalfunctionality.CustomBundleGUI;
 
@@ -84,8 +85,9 @@ public class BeaconPassivesGUI implements Listener {
         Map<String, Boolean> passives = getPlayerPassives(player);
         
         // Create passive buttons
-        ItemStack mendingButton = createPassiveButton(Material.GOLDEN_APPLE, 
-            "Mending", "+1 row of hearts", passives.getOrDefault("mending", false));
+        ItemStack mendingButton = createPassiveButton(Material.GOLDEN_APPLE,
+            "Mending", HealthManager.COLOR + "+20 " + HealthManager.DISPLAY_NAME,
+            passives.getOrDefault("mending", false));
         
         ItemStack sturdyButton = createPassiveButton(Material.SHIELD,
             "Sturdy", "+15% damage reduction, knockback resistance",

--- a/src/main/java/goat/minecraft/minecraftnew/other/health/HealthManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/health/HealthManager.java
@@ -73,6 +73,10 @@ public final class HealthManager {
             PetManager.Pet active = pm.getActivePet(player);
             if (active != null && active.getTrait() == PetTrait.HEALTHY) {
                 double percent = active.getTrait().getValueForRarity(active.getTraitRarity());
+                if (stm != null) {
+                    int q = stm.getTalentLevel(player.getUniqueId(), Skill.TAMING, Talent.QUIRKY);
+                    percent *= (1 + q * 0.20);
+                }
                 petBonus = Math.floor((health * percent / 100.0) / 2) * 2; // round down to full hearts
                 health += petBonus;
             }
@@ -127,6 +131,10 @@ public final class HealthManager {
             PetManager.Pet active = pm.getActivePet(player);
             if (active != null && active.getTrait() == PetTrait.HEALTHY) {
                 double percent = active.getTrait().getValueForRarity(active.getTraitRarity());
+                if (stm != null) {
+                    int q = stm.getTalentLevel(player.getUniqueId(), Skill.TAMING, Talent.QUIRKY);
+                    percent *= (1 + q * 0.20);
+                }
                 petBonus = Math.floor((total * percent / 100.0) / 2) * 2; // round down to full hearts
             }
         }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetManager.java
@@ -25,6 +25,9 @@ import goat.minecraft.minecraftnew.utils.stats.StrengthManager;
 import goat.minecraft.minecraftnew.other.skilltree.Skill;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
 import goat.minecraft.minecraftnew.other.skilltree.Talent;
+import goat.minecraft.minecraftnew.other.health.HealthManager;
+import goat.minecraft.minecraftnew.other.beacon.BeaconPassivesGUI;
+import goat.minecraft.minecraftnew.other.additionalfunctionality.BlessingUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -698,6 +701,32 @@ public class PetManager implements Listener {
                         }
                         int strengthBonus = (int) Math.round(traitValue);
                         lore.add(ChatColor.GRAY + "Grants " + StrengthManager.COLOR + "+" + strengthBonus + " " + StrengthManager.DISPLAY_NAME);
+                    } else if (pet.getTrait() == PetTrait.HEALTHY) {
+                        SkillTreeManager stm = SkillTreeManager.getInstance();
+                        if (stm != null) {
+                            int q = stm.getTalentLevel(player.getUniqueId(), Skill.TAMING, Talent.QUIRKY);
+                            traitValue *= (1 + q * 0.20);
+                        }
+                        double base = 20.0;
+                        double talent = 0.0;
+                        SkillTreeManager mgr = SkillTreeManager.getInstance();
+                        if (mgr != null) {
+                            talent += mgr.getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_I);
+                            talent += mgr.getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_II);
+                            talent += mgr.getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_III);
+                            talent += mgr.getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_IV);
+                            talent += mgr.getTalentLevel(player.getUniqueId(), Skill.PLAYER, Talent.HEALTH_V);
+                        }
+                        base += talent;
+                        if (BeaconPassivesGUI.hasBeaconPassives(player)
+                                && BeaconPassivesGUI.hasPassiveEnabled(player, "mending")) {
+                            base += 20.0;
+                        }
+                        if (BlessingUtils.hasFullSetBonus(player, "Monolith")) {
+                            base += 20.0;
+                        }
+                        double petBonus = Math.floor((base * traitValue / 100.0) / 2) * 2;
+                        lore.add(ChatColor.GRAY + "Grants " + HealthManager.COLOR + "+" + (int) petBonus + " " + HealthManager.DISPLAY_NAME);
                     } else {
                         lore.add(pet.getTrait().getColor() + pet.getTrait().getDescription() + ": "
                                 + pet.getTrait().getColor() + "+" + traitValue + "%");

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetTrait.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/PetTrait.java
@@ -1,6 +1,7 @@
 package goat.minecraft.minecraftnew.subsystems.pets;
 
 import org.bukkit.ChatColor;
+import goat.minecraft.minecraftnew.other.health.HealthManager;
 import goat.minecraft.minecraftnew.utils.stats.StrengthManager;
 
 /**
@@ -10,7 +11,7 @@ import goat.minecraft.minecraftnew.utils.stats.StrengthManager;
  */
 
 public enum PetTrait {
-    HEALTHY(ChatColor.RED, "Health Increase", new double[]{1,2, 4,6,10,20}),
+    HEALTHY(ChatColor.RED, HealthManager.DISPLAY_NAME, new double[]{1,2, 4,6,10,20}),
     FAST(ChatColor.YELLOW, "Speed Increase", new double[]{1,3,5,8,10,20}),
     STRONG(ChatColor.RED, StrengthManager.DISPLAY_NAME, new double[]{3,5,8,10,15,20}),
     RESILIENT(ChatColor.WHITE, "Damage Reduction", new double[]{3,5,8,10,15,20}),


### PR DESCRIPTION
## Summary
- show Healthy pet trait bonus as concrete health using standard stat formatting
- account for Quirky talent when applying Healthy trait
- show Mending beacon passive as +20 Health

## Testing
- `mvn -q -e -DskipTests package` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68969a07f3788332813ce9da0520b8c6