### PR TITLE
Add strength support for Slayer armor blessing

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/BlessingArmorStandListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/BlessingArmorStandListener.java
@@ -2,6 +2,7 @@ package goat.minecraft.minecraftnew.other.additionalfunctionality;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.music.MusicDiscManager;
+import goat.minecraft.minecraftnew.utils.stats.StrengthManager;
 import org.bukkit.*;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
@@ -44,7 +45,8 @@ public class BlessingArmorStandListener implements Listener {
         bonusMap.put("Pastureshade", List.of(ChatColor.GRAY + "Full Set Bonus: +100% Crop Yield, +1 Relic Yield"));
         bonusMap.put("Countershot", List.of(ChatColor.GRAY + "Full Set Bonus: Arrow Deflection"));
         bonusMap.put("Shadowstep", List.of(ChatColor.GRAY + "Full Set Bonus: +40% Dodge Chance"));
-        bonusMap.put("Slayer", List.of(ChatColor.GRAY + "Full Set Bonus: +20% Damage"));
+        bonusMap.put("Slayer", List.of(ChatColor.GRAY + "Full Set Bonus: "
+                + StrengthManager.COLOR + "+20 " + StrengthManager.DISPLAY_NAME));
         bonusMap.put("Duskblood", List.of(ChatColor.GRAY + "Full Set Bonus: +60 Warp Stacks"));
         bonusMap.put("Thunderforge", List.of(ChatColor.GRAY + "Full Set Bonus: +15% Fury Chance"));
         bonusMap.put("Fathmic Iron", List.of(ChatColor.GRAY + "Full Set Bonus: Removes Common/Uncommon Sea Creatures, -20% Sea Creature Chance."));

--- a/src/main/java/goat/minecraft/minecraftnew/other/armorsets/SlayerSetBonus.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/armorsets/SlayerSetBonus.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 
 /**
  * Applies the Slayer full set bonus while the player is wearing the full set.
- * Grants +20% damage to all outgoing attacks.
+ * Grants +20 Strength and activates Flow on melee strikes.
  */
 public class SlayerSetBonus implements Listener {
 
@@ -65,9 +65,6 @@ public class SlayerSetBonus implements Listener {
             return;
         }
 
-        // Increase damage by 20%
-        event.setDamage(event.getDamage() * 1.2);
-        
         // Activate Flow on melee strikes
         FlowManager flowManager = FlowManager.getInstance(plugin);
         flowManager.addFlowStacks(player, 1);

--- a/src/main/java/goat/minecraft/minecraftnew/utils/stats/StrengthManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/stats/StrengthManager.java
@@ -7,6 +7,7 @@ import goat.minecraft.minecraftnew.other.beacon.CatalystType;
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
 import goat.minecraft.minecraftnew.subsystems.pets.PetTrait;
+import goat.minecraft.minecraftnew.other.additionalfunctionality.BlessingUtils;
 import goat.minecraft.minecraftnew.other.skilltree.Skill;
 import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
 import goat.minecraft.minecraftnew.other.skilltree.Talent;
@@ -84,6 +85,11 @@ public final class StrengthManager {
         if (BeaconPassivesGUI.hasBeaconPassives(player)
                 && BeaconPassivesGUI.hasPassiveEnabled(player, "power")) {
             strength += 15;
+        }
+
+        // Slayer armor blessing grants flat Strength
+        if (BlessingUtils.hasFullSetBonus(player, "Slayer")) {
+            strength += 20;
         }
 
         // Pet traits and perks that grant bonus Strength
@@ -186,6 +192,14 @@ public final class StrengthManager {
         }
         total += powerPassiveStrength;
         player.sendMessage(COLOR + "Beacon Power Passive: " + ChatColor.YELLOW + powerPassiveStrength);
+
+        // Strength from Slayer full set bonus
+        int slayerStrength = 0;
+        if (BlessingUtils.hasFullSetBonus(player, "Slayer")) {
+            slayerStrength = 20;
+        }
+        total += slayerStrength;
+        player.sendMessage(COLOR + "Slayer Set Bonus: " + ChatColor.YELLOW + slayerStrength);
 
         // Strength from pet traits and perks
         int petEliteStrength = 0;


### PR DESCRIPTION
## Summary
- replace Slayer blessing lore with Strength-based wording
- remove deprecated Slayer damage handler while keeping Flow tracking
- include Slayer set bonus in StrengthManager totals and breakdown

## Testing
- `mvn -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896a09cf6608332819b72176ae1a80e