### PR TITLE
Add health support to Monolith armor set

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/BlessingArmorStandListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/additionalfunctionality/BlessingArmorStandListener.java
@@ -3,6 +3,7 @@ package goat.minecraft.minecraftnew.other.additionalfunctionality;
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.subsystems.music.MusicDiscManager;
 import goat.minecraft.minecraftnew.utils.stats.StrengthManager;
+import goat.minecraft.minecraftnew.other.health.HealthManager;
 import org.bukkit.*;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
@@ -38,7 +39,9 @@ public class BlessingArmorStandListener implements Listener {
         colorMap.put("Nature's Wrath", ChatColor.DARK_GREEN);
 
         bonusMap.put("Lost Legion", List.of(ChatColor.GRAY + "Full Set Bonus: +25% Arrow Damage"));
-        bonusMap.put("Monolith", List.of(ChatColor.GRAY + "Full Set Bonus: +20 Health, +20% Defense"));
+        bonusMap.put("Monolith", List.of(ChatColor.GRAY + "Full Set Bonus: "
+                + HealthManager.COLOR + "+20 " + HealthManager.DISPLAY_NAME
+                + ChatColor.GRAY + ", +20% Defense"));
         bonusMap.put("Scorchsteel", List.of(ChatColor.GRAY + "Full Set Bonus: +20 Fire Stacks, +40% Nether Monster Damage Reduction"));
         bonusMap.put("Nature's Wrath", List.of(ChatColor.GRAY + "Full Set Bonus: +4% Spirit Chance, +25% Spirit Defense, +25% Spirit Damage"));
         bonusMap.put("Dweller", List.of(ChatColor.GRAY + "Full Set Bonus: +25% Ore Yield, +500 Oxygen"));

--- a/src/main/java/goat/minecraft/minecraftnew/other/health/HealthManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/health/HealthManager.java
@@ -61,10 +61,10 @@ public final class HealthManager {
             health += beaconBonus;
         }
 
-        double setBonus = 0.0;
+        double monolithBonus = 0.0;
         if (BlessingUtils.hasFullSetBonus(player, "Monolith")) {
-            setBonus = 20.0;
-            health += setBonus;
+            monolithBonus = 20.0;
+            health += monolithBonus;
         }
 
         double petBonus = 0.0;
@@ -118,12 +118,12 @@ public final class HealthManager {
         total += beaconBonus;
         player.sendMessage(COLOR + "Beacon Mending Passive: " + ChatColor.YELLOW + beaconBonus);
 
-        double setBonus = 0.0;
+        double monolithBonus = 0.0;
         if (BlessingUtils.hasFullSetBonus(player, "Monolith")) {
-            setBonus = 20.0;
+            monolithBonus = 20.0;
         }
-        total += setBonus;
-        player.sendMessage(COLOR + "Monolith Set Bonus: " + ChatColor.YELLOW + setBonus);
+        total += monolithBonus;
+        player.sendMessage(COLOR + "Monolith Set Bonus: " + ChatColor.YELLOW + monolithBonus);
 
         double petBonus = 0.0;
         PetManager pm = PetManager.getInstance(MinecraftNew.getInstance());


### PR DESCRIPTION
## Summary
- Use HealthManager for Monolith set bonus display
- Clarify Monolith health bonus in HealthManager calculations

## Testing
- `mvn -q -e test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896aacb96dc8332b287d7341aa52e55