### PR TITLE
feat: add defense stat to GUI

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/utils/commands/StatsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/commands/StatsCommand.java
@@ -2,6 +2,7 @@ package goat.minecraft.minecraftnew.utils.commands;
 
 import goat.minecraft.minecraftnew.utils.stats.StatsCalculator;
 import goat.minecraft.minecraftnew.utils.stats.StrengthManager;
+import goat.minecraft.minecraftnew.utils.stats.DefenseManager;
 import goat.minecraft.minecraftnew.other.health.HealthManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -48,6 +49,8 @@ public class StatsCommand implements CommandExecutor, Listener {
                 StrengthManager.sendStrengthBreakdown(player);
             } else if (name.equals(ChatColor.stripColor(HealthManager.DISPLAY_NAME))) {
                 HealthManager.sendHealthBreakdown(player);
+            } else if (name.equals(ChatColor.stripColor(DefenseManager.DISPLAY_NAME))) {
+                DefenseManager.sendDefenseBreakdown(player);
             }
         }
     }
@@ -85,6 +88,7 @@ public class StatsCommand implements CommandExecutor, Listener {
         int index = 0;
         addStatItem(inv, slots[index++], Material.REDSTONE, HealthManager.DISPLAY_NAME, String.format("%.1f", calculator.getHealth(player)));
         addStatItem(inv, slots[index++], Material.IRON_SWORD, StrengthManager.DISPLAY_NAME, String.format("%d", calculator.getStrength(player)));
+        addStatItem(inv, slots[index++], Material.DIAMOND_CHESTPLATE, DefenseManager.DISPLAY_NAME, String.format("%.1f", calculator.getDefense(player)));
         addStatItem(inv, slots[index++], Material.BOW, "Arrow Damage +%", String.format("%.1f%%", calculator.getArrowDamageIncrease(player)));
         addStatItem(inv, slots[index++], Material.SHIELD, "Resistance", String.format("%.1f%%", calculator.getResistance(player)));
         addStatItem(inv, slots[index++], Material.ELYTRA, "Flight Time", String.format("%ds", calculator.getFlightTime(player)));

--- a/src/main/java/goat/minecraft/minecraftnew/utils/stats/StatsCalculator.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/stats/StatsCalculator.java
@@ -83,7 +83,9 @@ public class StatsCalculator {
     }
 
     /**
-     * Calculates the player's Defense value.
+     * Calculates the player's Defense value using {@link DefenseManager}.
+     * This aggregates armor, toughness, protections and other bonuses into a
+     * single number representing how much incoming damage is mitigated.
      *
      * @param player player to calculate Defense for
      * @return total Defense amount


### PR DESCRIPTION
## Summary
- document defense stat aggregation in StatsCalculator
- show defense in player stats GUI with diamond chestplate icon
- allow players to view a defense breakdown when clicked

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896de85a888833295c79374c0ccc37b