### PR TITLE
Refactor Defense into flat stat with typed bonuses

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatEventHandler.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/CombatEventHandler.java
@@ -133,22 +133,24 @@ public class CombatEventHandler implements Listener {
 
     private DamageTag mapTag(EntityDamageEvent.DamageCause cause) {
         switch (cause) {
-            case FIRE:
-            case FIRE_TICK:
-            case LAVA:
-            case HOT_FLOOR:
-                return DamageTag.FIRE;
-            case ENTITY_EXPLOSION:
-            case BLOCK_EXPLOSION:
-                return DamageTag.BLAST;
+            case ENTITY_ATTACK:
+            case ENTITY_SWEEP_ATTACK:
+                return DamageTag.ENTITY_ATTACK;
             case PROJECTILE:
                 return DamageTag.PROJECTILE;
             case FALL:
                 return DamageTag.FALL;
-            case MAGIC:
-            case POISON:
-            case WITHER:
-                return DamageTag.MAGIC;
+            case ENTITY_EXPLOSION:
+            case BLOCK_EXPLOSION:
+                return DamageTag.BLAST;
+            case FIRE_TICK:
+                return DamageTag.FIRE_TICK;
+            case HOT_FLOOR:
+                return DamageTag.HOT_FLOOR;
+            case LAVA:
+                return DamageTag.LAVA;
+            case FIRE:
+                return DamageTag.FIRE;
             default:
                 return DamageTag.GENERIC;
         }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/damage/strategies/DefenseDamageReductionStrategy.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/combat/damage/strategies/DefenseDamageReductionStrategy.java
@@ -60,22 +60,24 @@ public class DefenseDamageReductionStrategy implements DamageCalculationStrategy
 
     private DamageTag mapTag(EntityDamageEvent.DamageCause cause) {
         switch (cause) {
-            case FIRE:
-            case FIRE_TICK:
-            case LAVA:
-            case HOT_FLOOR:
-                return DamageTag.FIRE;
-            case ENTITY_EXPLOSION:
-            case BLOCK_EXPLOSION:
-                return DamageTag.BLAST;
+            case ENTITY_ATTACK:
+            case ENTITY_SWEEP_ATTACK:
+                return DamageTag.ENTITY_ATTACK;
             case PROJECTILE:
                 return DamageTag.PROJECTILE;
             case FALL:
                 return DamageTag.FALL;
-            case MAGIC:
-            case POISON:
-            case WITHER:
-                return DamageTag.MAGIC;
+            case ENTITY_EXPLOSION:
+            case BLOCK_EXPLOSION:
+                return DamageTag.BLAST;
+            case FIRE_TICK:
+                return DamageTag.FIRE_TICK;
+            case HOT_FLOOR:
+                return DamageTag.HOT_FLOOR;
+            case LAVA:
+                return DamageTag.LAVA;
+            case FIRE:
+                return DamageTag.FIRE;
             default:
                 return DamageTag.GENERIC;
         }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/tierreforgelisteners/ArmorReforge.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/tierreforgelisteners/ArmorReforge.java
@@ -1,102 +1,16 @@
 package goat.minecraft.minecraftnew.subsystems.smithing.tierreforgelisteners;
 
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.inventory.ItemStack;
 
 /**
- * Listener class to handle armor damage reduction based on reforge tiers.
+ * Legacy listener for armor reforges. Reforges now grant flat Defense
+ * through {@link goat.minecraft.minecraftnew.utils.stats.DefenseManager},
+ * so this listener no longer applies additional damage reduction.
  */
 public class ArmorReforge implements Listener {
-
     private final ReforgeManager reforgeManager;
-    // Define a maximum total damage reduction to prevent excessive protection
-    private static final double MAX_TOTAL_REDUCTION = 20; // 40%
 
-    /**
-     * Constructor to initialize the ReforgeManager.
-     *
-     * @param reforgeManager Instance of ReforgeManager.
-     */
     public ArmorReforge(ReforgeManager reforgeManager) {
         this.reforgeManager = reforgeManager;
-    }
-
-    /**
-     * Event handler to modify incoming damage based on the player's armor reforge tiers.
-     *
-     * @param event The EntityDamageEvent.
-     */
-    @EventHandler
-    public void onEntityDamage(EntityDamageEvent event) {
-        Entity damagedEntity = event.getEntity();
-
-        // Check if the damaged entity is a player
-        if (!(damagedEntity instanceof Player)) {
-            return;
-        }
-
-        // Check if the damage is from a monster
-        if (!isDamageFromMonster(event.getCause())) {
-            return;
-        }
-
-        Player player = (Player) damagedEntity;
-        ItemStack[] armorContents = player.getInventory().getArmorContents();
-
-        double totalReduction = 0.0;
-
-        // Iterate through each armor piece
-        for (ItemStack armorPiece : armorContents) {
-            if (reforgeManager.isArmor(armorPiece)) {
-                int reforgeTierNumber = reforgeManager.getReforgeTier(armorPiece);
-                ReforgeManager.ReforgeTier tier = reforgeManager.getReforgeTierByTier(reforgeTierNumber);
-
-                if (tier != null) {
-                    int reduction = tier.getArmorDamageReduction();
-                    totalReduction += reduction;
-                }
-            }
-        }
-
-        // Cap the total damage reduction to prevent excessive protection
-        if (totalReduction > MAX_TOTAL_REDUCTION) {
-            totalReduction = MAX_TOTAL_REDUCTION;
-        }
-
-        // Calculate the final damage after reduction
-        double originalDamage = event.getDamage();
-        double reducedDamage = originalDamage * (1 - (totalReduction / 100.0));
-
-        // Set the new damage value
-        event.setDamage(reducedDamage);
-
-        // Optional: Send feedback to the player about the damage reduction
-        // Uncomment the following lines if you want players to receive messages about damage reduction
-
-        if (totalReduction > 0) {
-            Bukkit.getLogger().info(ChatColor.GREEN + "" + player + "'s reforges reduces incoming damage by " + totalReduction + "%!");
-        }
-    }
-
-    /**
-     * Check if the damage is from a monster.
-     *
-     * @param cause The cause of the damage.
-     * @return True if the damage is from a monster, false otherwise.
-     */
-    private boolean isDamageFromMonster(EntityDamageEvent.DamageCause cause) {
-        switch (cause) {
-            case ENTITY_ATTACK: // Damage from mob attacks
-            case PROJECTILE: // Damage from projectiles (e.g., arrows, fireballs)
-                return true;
-            default:
-                return false;
-        }
     }
 }

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/tierreforgelisteners/ReforgeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/tierreforgelisteners/ReforgeManager.java
@@ -2,6 +2,7 @@ package goat.minecraft.minecraftnew.subsystems.smithing.tierreforgelisteners;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.utils.stats.StrengthManager;
+import goat.minecraft.minecraftnew.utils.stats.DefenseManager;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -27,11 +28,11 @@ public class ReforgeManager {
      */
     public enum ReforgeTier {
         TIER_0(0, ChatColor.RESET, "Sword", "Armor", "Tool", "Bow", 0, 0, 0, 0),
-        TIER_1(1, ChatColor.WHITE, "Sturdy Blade", "Sturdy Armor", "Sturdy Tool", "Oak Bow", 4, 1, 100, 10),
-        TIER_2(2, ChatColor.GREEN, "Sharpened Blade", "Reinforced Armor", "Enhanced Tool", "Birch Bow", 8, 2, 150, 20),
-        TIER_3(3, ChatColor.BLUE, "Reinforced Blade", "Fortified Armor", "Refined Tool", "Spruce Bow", 12, 3, 200, 30),
-        TIER_4(4, ChatColor.DARK_PURPLE, "Lethal Blade", "Battle Armor", "Superior Tool", "Acacia Bow", 16, 4, 250, 40),
-        TIER_5(5, ChatColor.GOLD, "Fatal Blade", "Legendary Armor", "Masterwork Tool", "Dark Oak Bow", 20, 5, 400, 50);
+        TIER_1(1, ChatColor.WHITE, "Sturdy Blade", "Sturdy Armor", "Sturdy Tool", "Oak Bow", 4, 6, 100, 10),
+        TIER_2(2, ChatColor.GREEN, "Sharpened Blade", "Reinforced Armor", "Enhanced Tool", "Birch Bow", 8, 12, 150, 20),
+        TIER_3(3, ChatColor.BLUE, "Reinforced Blade", "Fortified Armor", "Refined Tool", "Spruce Bow", 12, 18, 200, 30),
+        TIER_4(4, ChatColor.DARK_PURPLE, "Lethal Blade", "Battle Armor", "Superior Tool", "Acacia Bow", 16, 24, 250, 40),
+        TIER_5(5, ChatColor.GOLD, "Fatal Blade", "Legendary Armor", "Masterwork Tool", "Dark Oak Bow", 20, 30, 400, 50);
 
         private final int tier;
         private final ChatColor color;
@@ -40,7 +41,7 @@ public class ReforgeManager {
         private final String toolName;
         private final String bowName;
         private final int weaponDamageIncrease; // In percent
-        private final int armorDamageReduction; // In percent
+        private final int armorDefenseBonus; // Flat Defense bonus
         private final int toolDurabilityBonus; // Additional max durability
         private final int bowDamageIncrease; // In percent
 
@@ -48,7 +49,7 @@ public class ReforgeManager {
          * Constructs a ReforgeTier enum constant.
          */
         ReforgeTier(int tier, ChatColor color, String swordName, String armorName, String toolName, String bowName,
-                    int weaponDamageIncrease, int armorDamageReduction, int toolDurabilityBonus, int bowDamageIncrease) {
+                    int weaponDamageIncrease, int armorDefenseBonus, int toolDurabilityBonus, int bowDamageIncrease) {
             this.tier = tier;
             this.color = color;
             this.swordName = swordName;
@@ -56,7 +57,7 @@ public class ReforgeManager {
             this.toolName = toolName;
             this.bowName = bowName;
             this.weaponDamageIncrease = weaponDamageIncrease;
-            this.armorDamageReduction = armorDamageReduction;
+            this.armorDefenseBonus = armorDefenseBonus;
             this.toolDurabilityBonus = toolDurabilityBonus;
             this.bowDamageIncrease = bowDamageIncrease;
         }
@@ -89,8 +90,8 @@ public class ReforgeManager {
             return weaponDamageIncrease;
         }
 
-        public int getArmorDamageReduction() {
-            return armorDamageReduction;
+        public int getArmorDefenseBonus() {
+            return armorDefenseBonus;
         }
 
         public int getToolDurabilityBonus() {
@@ -153,6 +154,7 @@ public class ReforgeManager {
         // Remove existing reforge-related lore
         lore.removeIf(line -> line.contains("Damage Increase:")
                 || line.contains("Damage Reduction:")
+                || line.contains("Defense:")
                 || line.contains("Chance to repair durability:")
                 || line.contains("Max Durability: +")
                 || line.contains("Strength:"));
@@ -162,7 +164,8 @@ public class ReforgeManager {
             lore.add(ChatColor.DARK_GRAY + "Strength: " + StrengthManager.COLOR + "+" +
                     targetTier.getWeaponDamageIncrease() + " " + StrengthManager.EMOJI);
         } else if (isArmor) {
-            lore.add(ChatColor.DARK_GRAY + "Damage Reduction: " + ChatColor.AQUA + targetTier.getArmorDamageReduction() + "%");
+            lore.add(ChatColor.DARK_GRAY + "Defense: " + DefenseManager.COLOR + "+" +
+                    targetTier.getArmorDefenseBonus() + " " + DefenseManager.EMOJI);
         } else if (isTool) {
             lore.add(ChatColor.DARK_GRAY + "Max Durability: " + ChatColor.AQUA + "+" + targetTier.getToolDurabilityBonus());
         } else if (isBow) {
@@ -262,6 +265,7 @@ public class ReforgeManager {
         List<String> lore = meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
         lore.removeIf(line -> line.contains("Damage Increase:")
                 || line.contains("Damage Reduction:")
+                || line.contains("Defense:")
                 || line.contains("Chance to repair durability:")
                 || line.contains("Max Durability: ")
                 || line.contains("Max Durability: +")

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemLoreFormatter.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemLoreFormatter.java
@@ -96,6 +96,7 @@ public class ItemLoreFormatter {
             } else if (stripped.startsWith("Strength:")) {
                 reforge.add(line);
             } else if (stripped.startsWith("Damage Reduction") ||
+                       stripped.startsWith("Defense") ||
                        stripped.startsWith("Chance to repair durability") || stripped.startsWith("Max Durability")) {
                 reforge.add(line);
             } else if (stripped.startsWith("Durability:") || stripped.startsWith("Golden Durability:")) {


### PR DESCRIPTION
## Summary
- Rework `DefenseManager` to use flat Defense values and apply situational bonuses based on damage cause
- Update combat strategies to map damage causes to the new typed Defense tags
- Change armor reforges to grant +Defense and adjust lore/formatting accordingly

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897f50480fc833282f85b090a262a87