### PR TITLE
feat: add defense talisman

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
@@ -1233,7 +1233,7 @@ public class AnvilRepair implements Listener {
 
 
         else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Armor Talisman")&& ARMOR.contains(repairee.getType())){
-            TalismanManager.applyReforgeLore(repairee, "Armor");
+            TalismanManager.applyReforgeLore(repairee, "Defense");
             player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
             return;
         }else if(billItem.getItemMeta().getDisplayName().equals(ChatColor.YELLOW + "Armor Toughness Talisman")&& ARMOR.contains(repairee.getType())){

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemLoreFormatter.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemLoreFormatter.java
@@ -3,6 +3,7 @@ package goat.minecraft.minecraftnew.utils.devtools;
 import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentManager;
 import goat.minecraft.minecraftnew.utils.devtools.TalismanManager;
 import goat.minecraft.minecraftnew.utils.stats.StrengthManager;
+import goat.minecraft.minecraftnew.utils.stats.DefenseManager;
 import org.bukkit.ChatColor;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
@@ -68,6 +69,12 @@ public class ItemLoreFormatter {
                     String newline = ChatColor.GOLD + "Talisman: Damage. "
                             + StrengthManager.COLOR + "+" + TalismanManager.DAMAGE_STRENGTH_BONUS
                             + " Strength" + StrengthManager.EMOJI;
+                    talismans.add(newline);
+                } else if (stripped.startsWith("Talisman: Armor") ||
+                        (stripped.startsWith("Talisman: Defense") && !stripped.contains("+"))) {
+                    String newline = ChatColor.GOLD + "Talisman: Defense. "
+                            + DefenseManager.COLOR + "+" + TalismanManager.DEFENSE_DEFENSE_BONUS
+                            + " Defense" + DefenseManager.EMOJI;
                     talismans.add(newline);
                 } else {
                     talismans.add(line);

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -4,6 +4,7 @@ package goat.minecraft.minecraftnew.utils.devtools;
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.other.structureblocks.StructureBlockManager;
 import goat.minecraft.minecraftnew.other.durability.HeirloomManager;
+import goat.minecraft.minecraftnew.utils.stats.DefenseManager;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -1778,7 +1779,8 @@ public class ItemRegistry {
                 ChatColor.YELLOW + "Armor Talisman",
                 Arrays.asList(
                         ChatColor.GRAY + "An armorsmiths expertise",
-                        ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Talisman for obtaining a higher Armor Rating.",
+                        ChatColor.BLUE + "Use: " + ChatColor.GRAY + "Talisman that grants "
+                                + DefenseManager.COLOR + "+10 Defense" + ChatColor.GRAY + ".",
                         ChatColor.DARK_PURPLE + "Smithing Item"
                 ),
                 1,

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/TalismanManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/TalismanManager.java
@@ -1,6 +1,7 @@
 package goat.minecraft.minecraftnew.utils.devtools;
 
 import goat.minecraft.minecraftnew.utils.stats.StrengthManager;
+import goat.minecraft.minecraftnew.utils.stats.DefenseManager;
 import org.bukkit.ChatColor;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -14,6 +15,11 @@ public class TalismanManager {
      * Default Strength granted by a Damage talisman.
      */
     public static final int DAMAGE_STRENGTH_BONUS = 30;
+
+    /**
+     * Default Defense granted by an Armor talisman.
+     */
+    public static final int DEFENSE_DEFENSE_BONUS = 10;
 
     /**
      * Applies or updates the reforge lore on an ItemStack.
@@ -40,6 +46,9 @@ public class TalismanManager {
         if ("Damage".equalsIgnoreCase(reforgeType)) {
             newLine = ChatColor.GOLD + "Talisman: Damage. "
                     + StrengthManager.COLOR + "+" + DAMAGE_STRENGTH_BONUS + " Strength " + StrengthManager.EMOJI;
+        } else if ("Defense".equalsIgnoreCase(reforgeType)) {
+            newLine = ChatColor.GOLD + "Talisman: Defense. "
+                    + DefenseManager.COLOR + "+" + DEFENSE_DEFENSE_BONUS + " Defense " + DefenseManager.EMOJI;
         } else {
             newLine = ChatColor.GOLD + "Talisman: " + reforgeType;
         }
@@ -120,6 +129,40 @@ public class TalismanManager {
                         }
                     }
                     return DAMAGE_STRENGTH_BONUS;
+                }
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Retrieves the Defense bonus provided by a Defense talisman on the item.
+     *
+     * @param item Item to inspect.
+     * @return Defense value granted or 0 if none.
+     */
+    public static int getDefenseBonus(ItemStack item) {
+        if (item == null || item.getItemMeta() == null) {
+            return 0;
+        }
+
+        List<String> lore = item.getItemMeta().getLore();
+        if (lore != null) {
+            for (String line : lore) {
+                String strippedLine = ChatColor.stripColor(line);
+                if (strippedLine.startsWith("Talisman: Defense")) {
+                    int plus = strippedLine.indexOf('+');
+                    if (plus >= 0) {
+                        String num = strippedLine.substring(plus + 1).replaceAll("[^0-9]", "");
+                        if (!num.isEmpty()) {
+                            try {
+                                return Integer.parseInt(num);
+                            } catch (NumberFormatException ignored) {
+                                // fall through to default
+                            }
+                        }
+                    }
+                    return DEFENSE_DEFENSE_BONUS;
                 }
             }
         }

--- a/src/main/java/goat/minecraft/minecraftnew/utils/stats/DefenseManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/stats/DefenseManager.java
@@ -5,6 +5,7 @@ import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager.Pet;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager.PetPerk;
 import goat.minecraft.minecraftnew.subsystems.smithing.tierreforgelisteners.ReforgeManager;
+import goat.minecraft.minecraftnew.utils.devtools.TalismanManager;
 import org.bukkit.ChatColor;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.enchantments.Enchantment;
@@ -84,6 +85,7 @@ public final class DefenseManager {
         int featherLevels = 0;
         int fireProtLevels = 0;
         double reforgeDefense = 0.0;
+        double talismanDefense = 0.0;
 
         ReforgeManager rm = new ReforgeManager();
         for (ItemStack piece : armor) {
@@ -97,10 +99,11 @@ public final class DefenseManager {
             int tier = rm.getReforgeTier(piece);
             ReforgeManager.ReforgeTier rt = rm.getReforgeTierByTier(tier);
             reforgeDefense += rt.getArmorDefenseBonus();
+            talismanDefense += TalismanManager.getDefenseBonus(piece);
         }
 
         double defense = protectionLevels * cfg.genericProtLevelToDefense +
-                reforgeDefense;
+                reforgeDefense + talismanDefense;
 
         if (tag == DamageTag.ENTITY_ATTACK) {
             double armorPoints = player.getAttribute(Attribute.GENERIC_ARMOR) != null
@@ -158,6 +161,7 @@ public final class DefenseManager {
         ItemStack[] armor = player.getInventory().getArmorContents();
         int protectionLevels = 0;
         double reforgeDefense = 0.0;
+        double talismanDefense = 0.0;
         ReforgeManager rm = new ReforgeManager();
         for (ItemStack piece : armor) {
             if (piece == null) continue;
@@ -165,9 +169,11 @@ public final class DefenseManager {
             int tier = rm.getReforgeTier(piece);
             ReforgeManager.ReforgeTier rt = rm.getReforgeTierByTier(tier);
             reforgeDefense += rt.getArmorDefenseBonus();
+            talismanDefense += TalismanManager.getDefenseBonus(piece);
         }
         double defense = getDefense(player, DamageTag.GENERIC);
         player.sendMessage(COLOR + "Reforges: " + ChatColor.YELLOW + reforgeDefense);
+        player.sendMessage(COLOR + "Talismans: " + ChatColor.YELLOW + talismanDefense);
         player.sendMessage(COLOR + "Protection: " + ChatColor.YELLOW + protectionLevels * CONFIG.genericProtLevelToDefense);
         player.sendMessage(COLOR + "Total: " + ChatColor.YELLOW + defense);
     }


### PR DESCRIPTION
## Summary
- support Defense talismans that grant +10 Defense
- apply Armor Talisman as Defense talisman with lore formatting
- include talisman Defense in player stat calculations and breakdowns

## Testing
- `mvn -q -e test` *(fails: Could not transfer artifact maven-resources-plugin:3.3.1 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897fafea2848332a69a5daac93f9c21