### PR TITLE
Fix horizontal map alignment in CartographyManager

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/cartography/CartographyManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/cartography/CartographyManager.java
@@ -350,10 +350,10 @@ public final class CartographyManager implements Listener {
 
     private static BlockFace rightOf(BlockFace f) {
         return switch (f) {
-            case NORTH -> BlockFace.EAST;
-            case SOUTH -> BlockFace.WEST;
-            case EAST  -> BlockFace.SOUTH;
-            case WEST  -> BlockFace.NORTH;
+            case NORTH -> BlockFace.WEST;
+            case SOUTH -> BlockFace.EAST;
+            case EAST  -> BlockFace.NORTH;
+            case WEST  -> BlockFace.SOUTH;
             case UP, DOWN -> BlockFace.EAST;
             default -> BlockFace.EAST;
         };


### PR DESCRIPTION
## Summary
- Correct horizontal axis orientation when placing world map tiles

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897fdff2d60833290bdc32bdef7503e