### PR TITLE
Fix map orientation in CartographyManager

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/cartography/CartographyManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/cartography/CartographyManager.java
@@ -350,19 +350,20 @@ public final class CartographyManager implements Listener {
 
     private static BlockFace rightOf(BlockFace f) {
         return switch (f) {
-            case NORTH -> BlockFace.EAST;
-            case SOUTH -> BlockFace.WEST;
-            case EAST  -> BlockFace.SOUTH;
-            case WEST  -> BlockFace.NORTH;
-            case UP, DOWN -> BlockFace.EAST;
+            case NORTH -> BlockFace.WEST;
+            case SOUTH -> BlockFace.EAST;
+            case EAST  -> BlockFace.NORTH;
+            case WEST  -> BlockFace.SOUTH;
+            case UP   -> BlockFace.WEST;
+            case DOWN -> BlockFace.EAST;
             default -> BlockFace.EAST;
         };
     }
     private static BlockFace upOf(BlockFace f) {
         return switch (f) {
             case NORTH, SOUTH, EAST, WEST -> BlockFace.UP;
-            case UP  -> BlockFace.SOUTH;   // ceiling
-            case DOWN-> BlockFace.NORTH;   // floor
+            case UP   -> BlockFace.NORTH; // floor
+            case DOWN -> BlockFace.NORTH; // ceiling
             default -> BlockFace.UP;
         };
     }
@@ -377,7 +378,7 @@ public final class CartographyManager implements Listener {
                 case EAST  -> new Axes(new Vector(0,0,1), new Vector(0,1,0));
                 case WEST  -> new Axes(new Vector(0,0,-1), new Vector(0,1,0));
                 case UP    -> new Axes(new Vector(1,0,0), new Vector(0,0,-1));
-                case DOWN  -> new Axes(new Vector(1,0,0), new Vector(0,0,1));
+                case DOWN  -> new Axes(new Vector(-1,0,0), new Vector(0,0,-1));
                 default -> new Axes(new Vector(1,0,0), new Vector(0,1,0));
             };
         }


### PR DESCRIPTION
## Summary
- Correct horizontal axis orientation when placing world map tiles
- Properly orient maps placed on floor and ceiling faces

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897fdff2d60833290bdc32bdef7503e