### PR TITLE
Prevent world maps from being placed on ceilings

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/cartography/CartographyManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/cartography/CartographyManager.java
@@ -76,6 +76,11 @@ public final class CartographyManager implements Listener {
         Block centerBlock = e.getClickedBlock();
         Player p = e.getPlayer();
 
+        if (face == BlockFace.DOWN) {
+            p.sendMessage(ChatColor.RED + "Cannot place a world map on a ceiling.");
+            return;
+        }
+
         BlockFace uFace = rightOf(face);
         BlockFace vFace = upOf(face);
         Rect rect = computeSurfaceRect(centerBlock, face, uFace, vFace);


### PR DESCRIPTION
## Summary
- Block placement of world maps on ceilings in `CartographyManager`

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898079ce5e08332ae45a496e36bbc61