### PR TITLE
Add persistent world map refresh command

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -84,6 +84,10 @@ commands:
     description: Respawns a fresh dragon in The End.
     usage: /refreshEnd
     permission: continuity.admin
+  refreshmaps:
+    description: Force all world maps to refresh their pixels
+    usage: /refreshmaps
+    permission: continuity.admin
   end:
     description: Teleports the player to The End.
     usage: /end


### PR DESCRIPTION
## Summary
- Slow cartography BFS to 20 pixels per tick and allow full-map completion
- Persist map tiles and pixel caches so world maps survive reloads
- Expand terrain color mapping for mud, clay, nylium, and more
- Add `/refreshmaps` admin command to force-map updates

## Testing
- `mvn -q -e -DskipTests package` *(failed: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68980b93f8008332b86887177e8e59e6