### PR TITLE
feat: add travelers brush artifact

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -4626,6 +4626,21 @@ public class ItemRegistry {
                 true
         );
     }
+
+    /** Artifact that expands a world map from the clicked pixel. */
+    public static ItemStack getTravelersBrush() {
+        return createCustomItem(
+                Material.BRUSH,
+                ChatColor.YELLOW + "Travelers Brush",
+                Arrays.asList(
+                        ChatColor.GRAY + "Right-click a world map to explore it.",
+                        ChatColor.DARK_PURPLE + "Artifact"
+                ),
+                1,
+                false,
+                true
+        );
+    }
     public static ItemStack getComposterEnchant() {
         return createCustomItem(Material.COMPOSTER, ChatColor.YELLOW +
                 "Composter", Arrays.asList(


### PR DESCRIPTION
## Summary
- add Travelers Brush artifact item
- allow brushing world maps to explore up to 5000 pixels from clicked location
- support concurrent limited map expansion

## Testing
- `mvn -q -e -ntp test` *(fails: Could not transfer artifact maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898160aed8c833285f208cedf989ef5