### PR TITLE
Add arena location generation and lookup

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -117,6 +117,7 @@ import goat.minecraft.minecraftnew.subsystems.dragons.RefreshEndCommand;
 import goat.minecraft.minecraftnew.subsystems.music.PigStepArena;
 import goat.minecraft.minecraftnew.other.realms.Tropic;
 import goat.minecraft.minecraftnew.other.realms.Frozen;
+import goat.minecraft.minecraftnew.subsystems.arenas.ArenaManager;
 import net.citizensnpcs.api.CitizensAPI;
 import org.bukkit.*;
 import org.bukkit.entity.EnderDragon;
@@ -206,6 +207,8 @@ public class MinecraftNew extends JavaPlugin implements Listener {
     @Override
     public void onEnable() {
         instance = this;
+
+        ArenaManager.activateArenas(this);
 
         // Initialize stats calculator singleton
         StatsCalculator.getInstance(this);

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/arenas/ArenaManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/arenas/ArenaManager.java
@@ -1,0 +1,105 @@
+package goat.minecraft.minecraftnew.subsystems.arenas;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Manages arena locations arranged in rings around spawn.
+ */
+public class ArenaManager {
+
+    private static final List<Location> ARENAS = new ArrayList<>();
+
+    private ArenaManager() {
+        // utility class
+    }
+
+    /**
+     * Calculates arena locations and saves them to arenaLocations.yml.
+     * Runs on plugin startup.
+     *
+     * @param plugin the plugin instance
+     */
+    public static void activateArenas(JavaPlugin plugin) {
+        ARENAS.clear();
+        if (!plugin.getDataFolder().exists()) {
+            plugin.getDataFolder().mkdirs();
+        }
+        File file = new File(plugin.getDataFolder(), "arenaLocations.yml");
+        YamlConfiguration config = new YamlConfiguration();
+
+        Random random = new Random();
+        World world = Bukkit.getWorlds().get(0);
+
+        int[] radii = {250, 500, 750, 1000};
+        for (int ring = 1; ring <= radii.length; ring++) {
+            int radius = radii[ring - 1];
+            int arenasInRing = ring * 3; // ringNumber*3 arenas
+            for (int i = 0; i < arenasInRing; i++) {
+                Location loc;
+                int attempts = 0;
+                do {
+                    double angle = random.nextDouble() * 2 * Math.PI;
+                    double x = radius * Math.cos(angle);
+                    double z = radius * Math.sin(angle);
+                    loc = new Location(world, x, -100, z);
+                    attempts++;
+                } while (!isFarEnough(loc) && attempts < 1000);
+                ARENAS.add(loc);
+            }
+        }
+
+        // save arenas to file
+        for (int i = 0; i < ARENAS.size(); i++) {
+            Location loc = ARENAS.get(i);
+            String path = "arenas." + i;
+            config.set(path + ".world", loc.getWorld().getName());
+            config.set(path + ".x", loc.getX());
+            config.set(path + ".y", loc.getY());
+            config.set(path + ".z", loc.getZ());
+        }
+        try {
+            config.save(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static boolean isFarEnough(Location location) {
+        for (Location existing : ARENAS) {
+            if (existing.distanceSquared(location) < 200 * 200) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns the arena location nearest to the provided location.
+     *
+     * @param location input location
+     * @return closest arena location, or null if none exist
+     */
+    public static Location getNearestArena(Location location) {
+        Location nearest = null;
+        double nearestDist = Double.MAX_VALUE;
+        for (Location arena : ARENAS) {
+            double dist = arena.distanceSquared(location);
+            if (dist < nearestDist) {
+                nearestDist = dist;
+                nearest = arena;
+            }
+        }
+        return nearest;
+    }
+}
+


### PR DESCRIPTION
## Summary
- compute arena locations in four concentric rings and write them to `arenaLocations.yml`
- provide `getNearestArena` utility to find closest arena
- initialize arena system during plugin startup

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6899b9b2f3908332a4a8176c3643d00e