### PR TITLE
Add /getnearestarena developer command

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -383,6 +383,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getCommand("getstructureblock").setExecutor(new GetStructureBlockCommand());
         getCommand("setstructureblockpower").setExecutor(new SetStructureBlockPowerCommand());
         getCommand("getnearestcatalysttype").setExecutor(new GetNearestCatalystTypeCommand());
+        getCommand("getnearestarena").setExecutor(new GetNearestArenaCommand());
         getCommand("previewparticle").setExecutor(new PreviewParticleCommand(this));
         getCommand("previewflow").setExecutor(new PreviewFlowCommand(this));
         new RedVignetteCommand(this);

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/GetNearestArenaCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/GetNearestArenaCommand.java
@@ -1,0 +1,82 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import goat.minecraft.minecraftnew.other.arenas.ArenaManager;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.ComponentBuilder;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+
+/**
+ * Developer command that displays the coordinates of the nearest arena.
+ * Clicking the coordinates teleports the player there and sets them to spectator mode.
+ */
+public class GetNearestArenaCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command!");
+            return true;
+        }
+
+        // Handle teleport action
+        if (args.length >= 5 && args[0].equalsIgnoreCase("tp")) {
+            String worldName = args[1];
+            World world = Bukkit.getWorld(worldName);
+            if (world == null) {
+                player.sendMessage(ChatColor.RED + "World '" + worldName + "' not found!");
+                return true;
+            }
+            try {
+                double x = Double.parseDouble(args[2]);
+                double y = Double.parseDouble(args[3]);
+                double z = Double.parseDouble(args[4]);
+                Location target = new Location(world, x, y, z);
+                player.teleport(target);
+                player.setGameMode(GameMode.SPECTATOR);
+                player.sendMessage(ChatColor.GREEN + "Teleported to arena.");
+            } catch (NumberFormatException e) {
+                player.sendMessage(ChatColor.RED + "Invalid coordinates!");
+            }
+            return true;
+        }
+
+        // Default behavior: show nearest arena
+        ArenaManager arenaManager;
+        try {
+            arenaManager = ArenaManager.getInstance();
+        } catch (IllegalStateException e) {
+            player.sendMessage(ChatColor.RED + "Arena system is not initialized!");
+            return true;
+        }
+
+        Location nearest = arenaManager.getNearestArena(player.getLocation());
+        if (nearest == null) {
+            player.sendMessage(ChatColor.YELLOW + "No arena found in this world.");
+            return true;
+        }
+
+        String coords = String.format("%d %d %d", nearest.getBlockX(), nearest.getBlockY(), nearest.getBlockZ());
+        TextComponent base = new TextComponent(ChatColor.GREEN + "Nearest arena: ");
+        TextComponent coordComponent = new TextComponent(ChatColor.AQUA + coords);
+        String commandStr = String.format("/getnearestarena tp %s %d %d %d",
+                nearest.getWorld().getName(), nearest.getBlockX(), nearest.getBlockY(), nearest.getBlockZ());
+        coordComponent.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, commandStr));
+        coordComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+                new ComponentBuilder("Click to teleport").color(net.md_5.bungee.api.ChatColor.YELLOW).create()));
+        base.addExtra(coordComponent);
+        player.spigot().sendMessage(base);
+        return true;
+    }
+}
+

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -218,6 +218,10 @@ commands:
     description: Gets the nearest catalyst type in range of the player
     usage: /getnearestcatalysttype
     permission: continuity.admin
+  getnearestarena:
+    description: Gets the coordinates of the nearest arena
+    usage: /getnearestarena
+    permission: continuity.admin
   warp:
     description: Teleports the player to the specified world
     usage: /warp <worldname>


### PR DESCRIPTION
## Summary
- add `/getnearestarena` dev command to find nearest arena with clickable teleport to spectator mode
- register command and expose configuration in plugin.yml

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899bcbc00e88332ba4d0f80cefe2f71