### PR TITLE
Add champion registry and equipment saving dev commands

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -545,7 +545,8 @@ public class MinecraftNew extends JavaPlugin implements Listener {
 
         this.getCommand("givecustomitem").setExecutor(new GiveCustomItem());
         this.getCommand("i").setExecutor(new ItemCommand());
-
+        this.getCommand("savearmorcontents").setExecutor(new SaveArmorContentsCommand(this));
+        this.getCommand("saveitem").setExecutor(new SaveItemCommand(this));
 
         getCommand("testskill").setExecutor(new TestSkillMessageCommand(xpManager));
         // Register events

--- a/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionEquipmentUtil.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionEquipmentUtil.java
@@ -1,0 +1,59 @@
+package goat.minecraft.minecraftnew.other.arenas.champions;
+
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.List;
+
+/**
+ * Utility methods for loading champion equipment from YAML files in the plugin resources.
+ */
+public class ChampionEquipmentUtil {
+
+    private ChampionEquipmentUtil() { }
+
+    /**
+     * Loads armor contents from a YAML file bundled in the plugin resources and applies
+     * them to the player's armor slots.
+     *
+     * @param plugin      plugin instance used to access resources
+     * @param player      player to modify
+     * @param resourcePath path within the plugin JAR to the YAML file
+     */
+    @SuppressWarnings("unchecked")
+    public static void setArmorContentsFromFile(JavaPlugin plugin, Player player, String resourcePath) {
+        try (InputStream in = plugin.getResource(resourcePath)) {
+            if (in == null) return;
+            YamlConfiguration config = YamlConfiguration.loadConfiguration(new InputStreamReader(in));
+            List<ItemStack> armor = (List<ItemStack>) config.get("armor");
+            if (armor != null) {
+                player.getInventory().setArmorContents(armor.toArray(new ItemStack[0]));
+            }
+        } catch (Exception ignored) {
+        }
+    }
+
+    /**
+     * Loads a held item from a YAML file bundled in the plugin resources and places
+     * it in the player's main hand.
+     *
+     * @param plugin       plugin instance used to access resources
+     * @param player       player to modify
+     * @param resourcePath path within the plugin JAR to the YAML file
+     */
+    public static void setHeldItemFromFile(JavaPlugin plugin, Player player, String resourcePath) {
+        try (InputStream in = plugin.getResource(resourcePath)) {
+            if (in == null) return;
+            YamlConfiguration config = YamlConfiguration.loadConfiguration(new InputStreamReader(in));
+            ItemStack item = config.getItemStack("item");
+            if (item != null) {
+                player.getInventory().setItemInMainHand(item);
+            }
+        } catch (Exception ignored) {
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionRegistry.java
@@ -1,0 +1,40 @@
+package goat.minecraft.minecraftnew.other.arenas.champions;
+
+import java.util.*;
+
+/**
+ * Registry holding all predefined champion types for arenas.
+ */
+public class ChampionRegistry {
+    private static final Map<String, ChampionType> CHAMPIONS = new LinkedHashMap<>();
+
+    static {
+        CHAMPIONS.put("Legionnaire", new ChampionType(
+                "Legionnaire",
+                100,
+                "legionnaire.yml",
+                "legendary_sword.yml",
+                "dark_oak_bow.yml",
+                Arrays.asList("Hello.", "Greetings", "Beware")
+        ));
+
+        CHAMPIONS.put("Monolithian", new ChampionType(
+                "Monolithian",
+                200,
+                "monolithian.yml",
+                "legendary_sword.yml",
+                "dark_oak_bow.yml",
+                Arrays.asList("Hello.", "Greetings", "Beware")
+        ));
+    }
+
+    private ChampionRegistry() { }
+
+    public static ChampionType getChampion(String name) {
+        return CHAMPIONS.get(name);
+    }
+
+    public static Collection<ChampionType> getChampions() {
+        return Collections.unmodifiableCollection(CHAMPIONS.values());
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionType.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionType.java
@@ -1,0 +1,51 @@
+package goat.minecraft.minecraftnew.other.arenas.champions;
+
+import java.util.List;
+
+/**
+ * Defines a single Champion type that can appear in arenas.
+ * For now champions behave similarly to Corpses and use the same trait.
+ */
+public class ChampionType {
+    private final String name;
+    private final int health;
+    private final String armorFile;
+    private final String swordFile;
+    private final String bowFile;
+    private final List<String> greetingMessages;
+
+    public ChampionType(String name, int health, String armorFile,
+                        String swordFile, String bowFile,
+                        List<String> greetingMessages) {
+        this.name = name;
+        this.health = health;
+        this.armorFile = armorFile;
+        this.swordFile = swordFile;
+        this.bowFile = bowFile;
+        this.greetingMessages = greetingMessages;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getHealth() {
+        return health;
+    }
+
+    public String getArmorFile() {
+        return armorFile;
+    }
+
+    public String getSwordFile() {
+        return swordFile;
+    }
+
+    public String getBowFile() {
+        return bowFile;
+    }
+
+    public List<String> getGreetingMessages() {
+        return greetingMessages;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/SaveArmorContentsCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/SaveArmorContentsCommand.java
@@ -1,0 +1,58 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.inventory.ItemStack;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * Saves the executing player's armor contents to a YAML file in the plugin's
+ * champions directory. Usage: /savearmorcontents <filename>
+ */
+public class SaveArmorContentsCommand implements CommandExecutor {
+
+    private final JavaPlugin plugin;
+
+    public SaveArmorContentsCommand(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command!");
+            return true;
+        }
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You do not have permission to use this command!");
+            return true;
+        }
+        if (args.length != 1) {
+            player.sendMessage(ChatColor.RED + "Usage: /" + label + " <filename>");
+            return true;
+        }
+
+        File dir = new File(plugin.getDataFolder(), "champions");
+        dir.mkdirs();
+        File file = new File(dir, args[0] + ".yml");
+
+        YamlConfiguration config = new YamlConfiguration();
+        ItemStack[] armor = player.getInventory().getArmorContents();
+        config.set("armor", Arrays.asList(armor));
+        try {
+            config.save(file);
+            player.sendMessage(ChatColor.GREEN + "Armor saved to " + file.getName());
+        } catch (IOException e) {
+            player.sendMessage(ChatColor.RED + "Failed to save armor: " + e.getMessage());
+        }
+        return true;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/SaveItemCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/SaveItemCommand.java
@@ -1,0 +1,62 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.inventory.ItemStack;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Saves the item held in the player's main hand to a YAML file in the
+ * plugin's champions directory. Usage: /saveitem <filename>
+ */
+public class SaveItemCommand implements CommandExecutor {
+
+    private final JavaPlugin plugin;
+
+    public SaveItemCommand(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command!");
+            return true;
+        }
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You do not have permission to use this command!");
+            return true;
+        }
+        if (args.length != 1) {
+            player.sendMessage(ChatColor.RED + "Usage: /" + label + " <filename>");
+            return true;
+        }
+
+        ItemStack item = player.getInventory().getItemInMainHand();
+        if (item == null || item.getType().isAir()) {
+            player.sendMessage(ChatColor.RED + "You must hold an item in your main hand.");
+            return true;
+        }
+
+        File dir = new File(plugin.getDataFolder(), "champions");
+        dir.mkdirs();
+        File file = new File(dir, args[0] + ".yml");
+
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("item", item);
+        try {
+            config.save(file);
+            player.sendMessage(ChatColor.GREEN + "Item saved to " + file.getName());
+        } catch (IOException e) {
+            player.sendMessage(ChatColor.RED + "Failed to save item: " + e.getMessage());
+        }
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -312,3 +312,11 @@ commands:
     description: Sets all Verdant relics to a growth percentage
     usage: /setverdantrelicgrowthpercentage <1-100>
     permission: continuity.admin
+  savearmorcontents:
+    description: Saves your armor contents to a champions YAML file
+    usage: /savearmorcontents <filename>
+    permission: continuity.admin
+  saveitem:
+    description: Saves the item in your hand to a champions YAML file
+    usage: /saveitem <filename>
+    permission: continuity.admin


### PR DESCRIPTION
## Summary
- introduce `ChampionRegistry` with Legionnaire and Monolithian champion types
- add utility to load champion armor and held item from YAML resource files
- add `/savearmorcontents` and `/saveitem` developer commands for saving player gear snapshots

## Testing
- `mvn -q -e -DskipTests package` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899c47d35d08332ad960efa87146743