### PR TITLE
Add champion spawn command with skins

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -39,6 +39,7 @@ import goat.minecraft.minecraftnew.subsystems.fishing.SeaCreatureRegistry;
 import goat.minecraft.minecraftnew.subsystems.fishing.SpawnSeaCreatureCommand;
 import goat.minecraft.minecraftnew.subsystems.fishing.SeaCreatureChanceCommand;
 import goat.minecraft.minecraftnew.subsystems.fishing.TreasureChanceCommand;
+import goat.minecraft.minecraftnew.other.arenas.champions.SpawnChampionCommand;
 import goat.minecraft.minecraftnew.subsystems.forestry.ForestSpiritManager;
 import goat.minecraft.minecraftnew.subsystems.forestry.SpiritChanceCommand;
 import goat.minecraft.minecraftnew.subsystems.mining.PlayerOxygenManager;
@@ -469,6 +470,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
             getDataFolder().mkdirs();
         }
         this.getCommand("spawnseacreature").setExecutor(new SpawnSeaCreatureCommand());
+        this.getCommand("spawnchampion").setExecutor(new SpawnChampionCommand());
         getCommand("seacreaturechance").setExecutor(new SeaCreatureChanceCommand(this, xpManager));
         getCommand("treasurechance").setExecutor(new TreasureChanceCommand(this));
         getCommand("spiritchance").setExecutor(new SpiritChanceCommand(this, xpManager));

--- a/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionRegistry.java
@@ -15,7 +15,9 @@ public class ChampionRegistry {
                 "legionnaire.yml",
                 "legendary_sword.yml",
                 "dark_oak_bow.yml",
-                Arrays.asList("Hello.", "Greetings", "Beware")
+                Arrays.asList("Hello.", "Greetings", "Beware"),
+                "ewogICJ0aW1lc3RhbXAiIDogMTc1MjU5NjE3MTQ4NSwKICAicHJvZmlsZUlkIiA6ICI3ZGEyYWIzYTkzY2E0OGVlODMwNDhhZmMzYjgwZTY4ZSIsCiAgInByb2ZpbGVOYW1lIiA6ICJHb2xkYXBmZWwiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjFlYWE1M2VhNzVlZTZjNzQyNGUzZDYxMDRlOWNmMDA0Y2M5MjFkMTMwMDkyZGE4MmRlMmZiZjAxY2I0MjYiCiAgICB9CiAgfQp9",
+                "u/+jaHspIYPPxSwVlHXjebtMMDQmq3tCQfknwLHhzLVTK3aLGV4TxDAo3BMjL8yorhLn+akbbJ3WMmlyOD8/skymOUEIGqOj5Rx0nyJBdAhRObCY1d0Pc6Cz9iFci6P/K7f02W70cbvU1Gm59X+9s7SM9/kQOTCQJfCbbHzAvmUx/HhoXkWdZVbRyRc67Tadl5C2LL/QznVpTBSeG9re5czoZ0+FSNYtXlfNBIvi+Jsd99m8CNpLc0CuaoJ9J4iSGHnI3kmXx1TrxMtwbVwZqeMk08mM6AyI9SHoE6hi35d9NRhY4VlH2Rk4w+HJkH+0npi6hohS+lu9NhDzQx23ejh6MakQSks6jXiXVgBaNI5qG+hmLWbCEK+PxhIuDDWFKjhbw56knE5+PuGVAC6hAiLW0PsVHhz29Z0qPN8pE5agw9b2pH+JnPwc/HQjHBr5Oki6roN0w0sgKFwDbq+X9+txHq/1fVu/iCN1iYpdQbWw5kQhUuN7m/Jvxp3cx0rpa4DQ1QgRITeMbaCvtV8sjgjeVXbJ9i5BCwNK2fFHEFDs8uxp5K786FLxJit0mp5U7703pDP1seoDZVgSmKA72p/E3f9y3oGAbwZgBJ1A/FteEK0sH+p/hvbvDthCJlGqLbufYYf72Ktz25fu9ctVRx3A2sRJk6N3C28Co71MSWI="
         ));
 
         CHAMPIONS.put("Monolithian", new ChampionType(
@@ -24,7 +26,9 @@ public class ChampionRegistry {
                 "monolithian.yml",
                 "legendary_sword.yml",
                 "dark_oak_bow.yml",
-                Arrays.asList("Hello.", "Greetings", "Beware")
+                Arrays.asList("Hello.", "Greetings", "Beware"),
+                "ewogICJ0aW1lc3RhbXAiIDogMTc1MDY1Nzg0NjM5MSwKICAicHJvZmlsZUlkIiA6ICI2NDU4Mjc0MjEyNDg0MDY0YTRkMDBlNDdjZWM4ZjcyZSIsCiAgInByb2ZpbGVOYW1lIiA6ICJUaDNtMXMiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMWEzZTFhMDUwZmZkYWUyY2YzNDJmZTM4YzYxZWJhYzdlMDZhYzU4Y2UxYTYwMDNmZTIzZWE4YWU0YjU4YzYwOCIKICAgIH0KICB9Cn0=",
+                "sfsTWZwTrvApbtUZBgLzAS1HSRo6gyKh//e9tOrkLqryLnF/t+gJgF4PS+pGjJXVKXjYaAak/9n+02exmP1E0JIzOPSlqqpeDgD746nXzwavsBwlCStOSCzVEjImWI4xw1F4upjwEeZHFNqUXLEgbRnA+z2xZfXV7V44m2T9bHuFaxl72hPO7xaNwRwACCVNTG0DMUXcmsuylVOhNh06IHTSdYNEZmR8i2NIp90vF9nsuqEVcSSY+aNz6oB9FfUUlHWpI/6NbqSb18cZALe6Ins79kYSMI2atX/CD1KcPfParrht9rsU1EOx8nx+lMfcmsgpYutkrWZz1PXVd48Pck0EOPCGoElJ6gjxwZPVfa2EyWk5Y/12ix4LWcJl91dpu4BOgbCQDY0B6E4F+bWFwuIl3+nEZlhRqy2AvHcWBW9T7Rnr5pRMVxA58RkQ6T7+h8Ban6brcMaaSACWSE+PIULsCNCWaFEi8w78s1VFu/QETXTaVZC9kGgHSLkx4gQxBuvhDbBrwWhw9Ws08dwmt7A4mtgKZNF+d6FdXIjBDuMVm7bqRjDVn6Q5XYPtbAnSEd3rbgGeBIijVpfE8iDKGSZR/TKzBLgm6JQ6fZG8JfYcbMiUuopcJcyCaZ9yJf7w7pFsW3b8WgPXavwFra45PmY4Rgg9UhyIeguqVF4qmOo="
         ));
     }
 

--- a/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionSpawner.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionSpawner.java
@@ -1,0 +1,66 @@
+package goat.minecraft.minecraftnew.other.arenas.champions;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.fishing.Rarity;
+import goat.minecraft.minecraftnew.subsystems.gravedigging.corpses.CorpseTrait;
+import net.citizensnpcs.api.CitizensAPI;
+import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.api.npc.NPCRegistry;
+import net.citizensnpcs.api.saving.MemoryNPCDataStore;
+import net.citizensnpcs.api.trait.trait.SkinTrait;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Utility for spawning champions at a given location.
+ */
+public final class ChampionSpawner {
+
+    private ChampionSpawner() {
+    }
+
+    /**
+     * Spawns the given champion type at the supplied location.
+     *
+     * @param type the champion definition
+     * @param loc  where to spawn the champion
+     */
+    public static void spawnChampion(ChampionType type, Location loc) {
+        JavaPlugin plugin = MinecraftNew.getInstance();
+        World world = loc.getWorld();
+        if (world == null) {
+            return;
+        }
+
+        // a: particle explosion
+        world.spawnParticle(Particle.EXPLOSION_LARGE, loc, 1);
+        // b: dragon roar sound
+        world.playSound(loc, Sound.ENTITY_ENDER_DRAGON_GROWL, 1f, 1f);
+
+        NPCRegistry registry = CitizensAPI.createAnonymousNPCRegistry(new MemoryNPCDataStore());
+        NPC npc = registry.createNPC(EntityType.PLAYER, type.getName());
+
+        // 1: Set name
+        npc.setName(type.getName());
+        npc.spawn(loc);
+        if (npc.getEntity() instanceof Player player) {
+            player.setCustomName(type.getName());
+            player.setCustomNameVisible(true);
+            // 2: Set skin
+            npc.getOrAddTrait(SkinTrait.class)
+                    .setSkinPersistent("champion", type.getSkinSig(), type.getSkinValue());
+            // 3: Set armor contents
+            ChampionEquipmentUtil.setArmorContentsFromFile(plugin, player, type.getArmorFile());
+            // 4: set held item as the sword
+            ChampionEquipmentUtil.setHeldItemFromFile(plugin, player, type.getSwordFile());
+        }
+
+        // 5: set corpse trait (placeholder)
+        npc.addTrait(new CorpseTrait(plugin, Rarity.COMMON, false, 0));
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionType.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionType.java
@@ -13,16 +13,21 @@ public class ChampionType {
     private final String swordFile;
     private final String bowFile;
     private final List<String> greetingMessages;
+    private final String skinValue;
+    private final String skinSig;
 
     public ChampionType(String name, int health, String armorFile,
                         String swordFile, String bowFile,
-                        List<String> greetingMessages) {
+                        List<String> greetingMessages,
+                        String skinValue, String skinSig) {
         this.name = name;
         this.health = health;
         this.armorFile = armorFile;
         this.swordFile = swordFile;
         this.bowFile = bowFile;
         this.greetingMessages = greetingMessages;
+        this.skinValue = skinValue;
+        this.skinSig = skinSig;
     }
 
     public String getName() {
@@ -47,5 +52,13 @@ public class ChampionType {
 
     public List<String> getGreetingMessages() {
         return greetingMessages;
+    }
+
+    public String getSkinValue() {
+        return skinValue;
+    }
+
+    public String getSkinSig() {
+        return skinSig;
     }
 }

--- a/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/SpawnChampionCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/SpawnChampionCommand.java
@@ -1,0 +1,38 @@
+package goat.minecraft.minecraftnew.other.arenas.champions;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Dev command to spawn a champion by name.
+ */
+public class SpawnChampionCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command!");
+            return true;
+        }
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You do not have permission to use this command!");
+            return true;
+        }
+        if (args.length != 1) {
+            player.sendMessage(ChatColor.RED + "Usage: /spawnchampion <name>");
+            return true;
+        }
+        String name = args[0].replace("_", " ");
+        ChampionType type = ChampionRegistry.getChampion(name);
+        if (type == null) {
+            player.sendMessage(ChatColor.RED + "Champion with name '" + name + "' not found!");
+            return true;
+        }
+        ChampionSpawner.spawnChampion(type, player.getLocation());
+        player.sendMessage(ChatColor.GREEN + "Spawned champion " + type.getName() + ".");
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -112,6 +112,9 @@ commands:
   spawncorpse:
     description: Spawns a corpse by name.
     permission: continuity.admin
+  spawnchampion:
+    description: Spawns a champion by name.
+    permission: continuity.admin
   givecustomitem:
     description: Gives a predefined custom item to the player.
     usage: /givecustomitem <customitem>


### PR DESCRIPTION
## Summary
- add skinSig and skinValue to ChampionType and registry entries
- implement ChampionSpawner and /spawnchampion dev command to summon champions by name
- register spawnchampion command in plugin.yml and main plugin

## Testing
- `mvn -q -e -DskipTests package` *(failed: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899cac228248332954ee7085a1ae291