### PR TITLE
Fix champion armor not applying

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionEquipmentUtil.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionEquipmentUtil.java
@@ -24,14 +24,17 @@ public class ChampionEquipmentUtil {
      * @param player      player to modify
      * @param resourcePath path within the plugin JAR to the YAML file
      */
-    @SuppressWarnings("unchecked")
     public static void setArmorContentsFromFile(JavaPlugin plugin, Player player, String resourcePath) {
         try (InputStream in = plugin.getResource(resourcePath)) {
             if (in == null) return;
             YamlConfiguration config = YamlConfiguration.loadConfiguration(new InputStreamReader(in));
-            List<ItemStack> armor = (List<ItemStack>) config.get("armor");
-            if (armor != null) {
-                player.getInventory().setArmorContents(armor.toArray(new ItemStack[0]));
+            List<?> list = config.getList("armor");
+            if (list != null) {
+                ItemStack[] armor = list.stream()
+                        .filter(ItemStack.class::isInstance)
+                        .map(ItemStack.class::cast)
+                        .toArray(ItemStack[]::new);
+                player.getInventory().setArmorContents(armor);
             }
         } catch (Exception ignored) {
         }


### PR DESCRIPTION
## Summary
- correctly deserialize champion armor equipment from YAML files before applying to NPCs

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899cd8781f48332ba5ba7d6ead52032