### PR TITLE
Fix champion armor application

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionEquipmentUtil.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionEquipmentUtil.java
@@ -24,14 +24,17 @@ public class ChampionEquipmentUtil {
      * @param player      player to modify
      * @param resourcePath path within the plugin JAR to the YAML file
      */
-    @SuppressWarnings("unchecked")
     public static void setArmorContentsFromFile(JavaPlugin plugin, Player player, String resourcePath) {
         try (InputStream in = plugin.getResource(resourcePath)) {
             if (in == null) return;
             YamlConfiguration config = YamlConfiguration.loadConfiguration(new InputStreamReader(in));
-            List<ItemStack> armor = (List<ItemStack>) config.get("armor");
-            if (armor != null) {
-                player.getInventory().setArmorContents(armor.toArray(new ItemStack[0]));
+            List<?> armorList = config.getList("armor");
+            if (armorList != null && player.getEquipment() != null) {
+                ItemStack[] armor = armorList.stream()
+                        .filter(ItemStack.class::isInstance)
+                        .map(ItemStack.class::cast)
+                        .toArray(ItemStack[]::new);
+                player.getEquipment().setArmorContents(armor);
             }
         } catch (Exception ignored) {
         }
@@ -50,8 +53,8 @@ public class ChampionEquipmentUtil {
             if (in == null) return;
             YamlConfiguration config = YamlConfiguration.loadConfiguration(new InputStreamReader(in));
             ItemStack item = config.getItemStack("item");
-            if (item != null) {
-                player.getInventory().setItemInMainHand(item);
+            if (item != null && player.getEquipment() != null) {
+                player.getEquipment().setItemInMainHand(item);
             }
         } catch (Exception ignored) {
         }


### PR DESCRIPTION
## Summary
- correctly equip champions by applying armor and weapons through `Player#getEquipment`
- improve YAML equipment loading

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899cd8781f48332ba5ba7d6ead52032