### PR TITLE
Fix champion armor using Citizens InventoryTrait

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionEquipmentUtil.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionEquipmentUtil.java
@@ -1,5 +1,7 @@
 package goat.minecraft.minecraftnew.other.arenas.champions;
 
+import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.trait.InventoryTrait;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -18,24 +20,39 @@ public class ChampionEquipmentUtil {
 
     /**
      * Loads armor contents from a YAML file bundled in the plugin resources and applies
-     * them to the player's armor slots.
+     * them to the NPC's armor slots via the Citizens {@link InventoryTrait}.
      *
-     * @param plugin      plugin instance used to access resources
-     * @param player      player to modify
+     * <p>The YAML file is expected to contain a list of {@link ItemStack} in the same
+     * order returned by Bukkit's {@code PlayerInventory#getArmorContents()} (boots,
+     * leggings, chestplate, helmet). The items will be mapped to Citizens inventory
+     * slots as helmet (0), chestplate (1), leggings (2) and boots (3).</p>
+     *
+     * @param plugin       plugin instance used to access resources
+     * @param npc          NPC whose armor should be modified
      * @param resourcePath path within the plugin JAR to the YAML file
      */
-    public static void setArmorContentsFromFile(JavaPlugin plugin, Player player, String resourcePath) {
+    public static void setArmorContentsFromFile(JavaPlugin plugin, NPC npc, String resourcePath) {
         try (InputStream in = plugin.getResource(resourcePath)) {
             if (in == null) return;
             YamlConfiguration config = YamlConfiguration.loadConfiguration(new InputStreamReader(in));
             List<?> armorList = config.getList("armor");
-            if (armorList != null && player.getEquipment() != null) {
-                ItemStack[] armor = armorList.stream()
-                        .filter(ItemStack.class::isInstance)
-                        .map(ItemStack.class::cast)
-                        .toArray(ItemStack[]::new);
-                player.getEquipment().setArmorContents(armor);
+            if (armorList == null || !npc.hasTrait(InventoryTrait.class)) {
+                return;
             }
+            InventoryTrait inventory = npc.getTrait(InventoryTrait.class);
+            if (inventory.getInventory() == null) {
+                return;
+            }
+
+            ItemStack[] armor = armorList.stream()
+                    .filter(ItemStack.class::isInstance)
+                    .map(ItemStack.class::cast)
+                    .toArray(ItemStack[]::new);
+
+            if (armor.length > 3) inventory.setItem(0, armor[3]); // helmet
+            if (armor.length > 2) inventory.setItem(1, armor[2]); // chestplate
+            if (armor.length > 1) inventory.setItem(2, armor[1]); // leggings
+            if (armor.length > 0) inventory.setItem(3, armor[0]); // boots
         } catch (Exception ignored) {
         }
     }

--- a/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionSpawner.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionSpawner.java
@@ -54,8 +54,8 @@ public final class ChampionSpawner {
             // 2: Set skin
             npc.getOrAddTrait(SkinTrait.class)
                     .setSkinPersistent("champion", type.getSkinSig(), type.getSkinValue());
-            // 3: Set armor contents
-            ChampionEquipmentUtil.setArmorContentsFromFile(plugin, player, type.getArmorFile());
+            // 3: Set armor contents via Citizens inventory trait
+            ChampionEquipmentUtil.setArmorContentsFromFile(plugin, npc, type.getArmorFile());
             // 4: set held item as the sword
             ChampionEquipmentUtil.setHeldItemFromFile(plugin, player, type.getSwordFile());
         }


### PR DESCRIPTION
## Summary
- Equip champion NPCs using Citizens InventoryTrait instead of player equipment APIs
- Map armor items from saved YAML files to the correct NPC armor slots
- Adjust champion spawning to apply armor through InventoryTrait

## Testing
- `mvn -q test` *(fails: PluginResolutionException – Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899d0418e8483328fff9f9da65010c9