### PR TITLE
Add developer command to equip armor from saved YAML files

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -548,6 +548,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         this.getCommand("givecustomitem").setExecutor(new GiveCustomItem());
         this.getCommand("i").setExecutor(new ItemCommand());
         this.getCommand("savearmorcontents").setExecutor(new SaveArmorContentsCommand(this));
+        this.getCommand("equiparmorfromfile").setExecutor(new EquipArmorFromFileCommand(this));
         this.getCommand("saveitem").setExecutor(new SaveItemCommand(this));
 
         getCommand("testskill").setExecutor(new TestSkillMessageCommand(xpManager));

--- a/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionEquipmentUtil.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/arenas/champions/ChampionEquipmentUtil.java
@@ -7,6 +7,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.configuration.file.YamlConfiguration;
 
+import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
@@ -52,6 +53,39 @@ public class ChampionEquipmentUtil {
             if (armor.length > 2) equipmentTrait.set(Equipment.EquipmentSlot.CHESTPLATE, armor[2]); // chestplate
             if (armor.length > 1) equipmentTrait.set(Equipment.EquipmentSlot.LEGGINGS, armor[1]); // leggings
             if (armor.length > 0) equipmentTrait.set(Equipment.EquipmentSlot.BOOTS, armor[0]); // boots
+        } catch (Exception ignored) {
+        }
+    }
+
+    /**
+     * Loads armor contents from a YAML file in the plugin's data folder and applies
+     * them to the provided player.
+     *
+     * <p>The YAML file must have the same structure produced by
+     * {@link goat.minecraft.minecraftnew.utils.developercommands.SaveArmorContentsCommand}
+     * so that the saved armor can be re-equipped.</p>
+     *
+     * @param plugin   plugin instance used to access the data folder
+     * @param player   player whose armor should be modified
+     * @param file     YAML file containing the armor contents
+     */
+    public static void setArmorContentsFromFile(JavaPlugin plugin, Player player, File file) {
+        try {
+            if (!file.exists() || player.getInventory() == null) {
+                return;
+            }
+            YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
+            List<?> armorList = config.getList("armor");
+            if (armorList == null) {
+                return;
+            }
+
+            ItemStack[] armor = armorList.stream()
+                    .filter(ItemStack.class::isInstance)
+                    .map(ItemStack.class::cast)
+                    .toArray(ItemStack[]::new);
+
+            player.getInventory().setArmorContents(armor);
         } catch (Exception ignored) {
         }
     }

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/EquipArmorFromFileCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/EquipArmorFromFileCommand.java
@@ -1,0 +1,51 @@
+package goat.minecraft.minecraftnew.utils.developercommands;
+
+import goat.minecraft.minecraftnew.other.arenas.champions.ChampionEquipmentUtil;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+
+/**
+ * Loads armor contents from a YAML file in the plugin's champions directory and
+ * equips them on the executing player. Usage: /equiparmorfromfile <filename>
+ */
+public class EquipArmorFromFileCommand implements CommandExecutor {
+
+    private final JavaPlugin plugin;
+
+    public EquipArmorFromFileCommand(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command!");
+            return true;
+        }
+        if (!player.hasPermission("continuity.admin")) {
+            player.sendMessage(ChatColor.RED + "You do not have permission to use this command!");
+            return true;
+        }
+        if (args.length != 1) {
+            player.sendMessage(ChatColor.RED + "Usage: /" + label + " <filename>");
+            return true;
+        }
+
+        File dir = new File(plugin.getDataFolder(), "champions");
+        File file = new File(dir, args[0] + ".yml");
+        if (!file.exists()) {
+            player.sendMessage(ChatColor.RED + "File not found: " + file.getName());
+            return true;
+        }
+
+        ChampionEquipmentUtil.setArmorContentsFromFile(plugin, player, file);
+        player.sendMessage(ChatColor.GREEN + "Equipped armor from " + file.getName());
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -319,6 +319,10 @@ commands:
     description: Saves your armor contents to a champions YAML file
     usage: /savearmorcontents <filename>
     permission: continuity.admin
+  equiparmorfromfile:
+    description: Loads armor contents from a champions YAML file
+    usage: /equiparmorfromfile <filename>
+    permission: continuity.admin
   saveitem:
     description: Saves the item in your hand to a champions YAML file
     usage: /saveitem <filename>


### PR DESCRIPTION
## Summary
- allow developers to equip armor from saved champions YAML files via `/equiparmorfromfile`
- expose ChampionEquipmentUtil API to load player armor from data files
- register new command and document it in plugin.yml

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_6899d470f84c8332a4b16d5a9384d031