### PR TITLE
Add Trail Ruin drop manager and registry

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -5,6 +5,7 @@ import goat.minecraft.minecraftnew.other.additionalfunctionality.*;
 import goat.minecraft.minecraftnew.other.resourcepack.ResourcePackListener;
 import goat.minecraft.minecraftnew.subsystems.cartography.CartographyManager;
 import goat.minecraft.minecraftnew.subsystems.gravedigging.Gravedigging;
+import goat.minecraft.minecraftnew.subsystems.archaeology.TrailRuinManager;
 import goat.minecraft.minecraftnew.subsystems.villagers.professions.bartender.BartenderVillagerManager;
 import goat.minecraft.minecraftnew.subsystems.villagers.professions.engineer.EngineerVillagerManager;
 import goat.minecraft.minecraftnew.subsystems.villagers.professions.engineer.EngineeringProfessionListener;
@@ -607,6 +608,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new Mining(), MinecraftNew.getInstance());
         getServer().getPluginManager().registerEvents(new goat.minecraft.minecraftnew.subsystems.gravedigging.terraforming.Terraforming(), MinecraftNew.getInstance());
 
+        getServer().getPluginManager().registerEvents(new TrailRuinManager(), this);
         getServer().getPluginManager().registerEvents(new Gravedigging(this), this);
         Gravedigging gravedigging = new Gravedigging(this);
         gravedigging.startup();

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/archaeology/TrailRuinManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/archaeology/TrailRuinManager.java
@@ -1,0 +1,56 @@
+package goat.minecraft.minecraftnew.subsystems.archaeology;
+
+import goat.minecraft.minecraftnew.subsystems.fishing.Rarity;
+import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Handles brushing of suspicious sand and gravel in trail ruins.
+ * Drops items from the {@link TrailRuinRegistry} instead of the
+ * vanilla loot table.
+ */
+public class TrailRuinManager implements Listener {
+
+    public TrailRuinManager() {
+        // Register default drops such as verdant relic seeds
+        TrailRuinRegistry.addItem(ItemRegistry.getVerdantRelicEntionPlastSeed(), Rarity.UNCOMMON);
+        TrailRuinRegistry.addItem(ItemRegistry.getVerdantRelicEntropySeed(), Rarity.UNCOMMON);
+        TrailRuinRegistry.addItem(ItemRegistry.getVerdantRelicSunflareSeed(), Rarity.UNCOMMON);
+        TrailRuinRegistry.addItem(ItemRegistry.getVerdantRelicStarlightSeed(), Rarity.UNCOMMON);
+        TrailRuinRegistry.addItem(ItemRegistry.getVerdantRelicTideSeed(), Rarity.UNCOMMON);
+        TrailRuinRegistry.addItem(ItemRegistry.getVerdantRelicShinyEmeraldSeed(), Rarity.UNCOMMON);
+        TrailRuinRegistry.addItem(ItemRegistry.getVerdantRelicTreasury(), Rarity.RARE);
+        TrailRuinRegistry.addItem(ItemRegistry.getVerdantRelicMarrow(), Rarity.RARE);
+    }
+
+    @EventHandler
+    public void onBrush(PlayerInteractEvent event) {
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
+        if (event.getHand() != EquipmentSlot.HAND) return;
+
+        Block block = event.getClickedBlock();
+        if (block == null) return;
+        Material type = block.getType();
+        if (type != Material.SUSPICIOUS_SAND && type != Material.SUSPICIOUS_GRAVEL) return;
+
+        Player player = event.getPlayer();
+        if (player.getInventory().getItemInMainHand().getType() != Material.BRUSH) return;
+
+        // Cancel default brushing behaviour
+        event.setCancelled(true);
+        block.setType(Material.AIR);
+
+        ItemStack drop = TrailRuinRegistry.getRandomItem();
+        if (drop != null) {
+            block.getWorld().dropItemNaturally(block.getLocation().add(0.5, 0.5, 0.5), drop);
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/archaeology/TrailRuinRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/archaeology/TrailRuinRegistry.java
@@ -1,0 +1,73 @@
+package goat.minecraft.minecraftnew.subsystems.archaeology;
+
+import goat.minecraft.minecraftnew.subsystems.fishing.Rarity;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Registry of items that can be obtained from brushing
+ * suspicious sand or gravel within trail ruins.
+ * Only items registered here are eligible to drop.
+ */
+public final class TrailRuinRegistry {
+
+    private static final Map<Rarity, List<ItemStack>> ITEMS = new EnumMap<>(Rarity.class);
+    private static final Map<Rarity, Double> RARITY_WEIGHTS = new EnumMap<>(Rarity.class);
+
+    static {
+        for (Rarity r : Rarity.values()) {
+            ITEMS.put(r, new ArrayList<>());
+        }
+        // Rough weights matching the corpse rarity distribution
+        RARITY_WEIGHTS.put(Rarity.COMMON, 0.50);
+        RARITY_WEIGHTS.put(Rarity.UNCOMMON, 0.30);
+        RARITY_WEIGHTS.put(Rarity.RARE, 0.12);
+        RARITY_WEIGHTS.put(Rarity.EPIC, 0.06);
+        RARITY_WEIGHTS.put(Rarity.LEGENDARY, 0.02);
+        RARITY_WEIGHTS.put(Rarity.MYTHIC, 0.0);
+    }
+
+    private TrailRuinRegistry() {}
+
+    /**
+     * Adds an item to the registry under the given rarity.
+     */
+    public static void addItem(ItemStack stack, Rarity rarity) {
+        if (stack == null || rarity == null) return;
+        ITEMS.get(rarity).add(stack);
+    }
+
+    /**
+     * Returns a random item from the registry using the rarity weights.
+     * Returns null if no items are registered.
+     */
+    public static ItemStack getRandomItem() {
+        if (ITEMS.values().stream().allMatch(List::isEmpty)) {
+            return null;
+        }
+        Rarity rarity = pickWeightedRarity();
+        List<ItemStack> list = ITEMS.get(rarity);
+        if (list.isEmpty()) {
+            // Fallback to any available item
+            List<ItemStack> flat = new ArrayList<>();
+            ITEMS.values().forEach(flat::addAll);
+            if (flat.isEmpty()) return null;
+            return flat.get(ThreadLocalRandom.current().nextInt(flat.size())).clone();
+        }
+        return list.get(ThreadLocalRandom.current().nextInt(list.size())).clone();
+    }
+
+    private static Rarity pickWeightedRarity() {
+        double rand = ThreadLocalRandom.current().nextDouble();
+        double cumulative = 0.0;
+        for (Map.Entry<Rarity, Double> entry : RARITY_WEIGHTS.entrySet()) {
+            cumulative += entry.getValue();
+            if (rand <= cumulative) {
+                return entry.getKey();
+            }
+        }
+        return Rarity.COMMON;
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/gravedigging/Gravedigging.java
@@ -13,7 +13,6 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.EquipmentSlot;
-import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
 import goat.minecraft.minecraftnew.utils.stats.StatsCalculator;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitTask;
@@ -216,17 +215,8 @@ public class Gravedigging implements Listener {
         if (world == null) return;
         Location center = loc.clone().add(0.5, 2, 0.5);
 
-        ItemStack relic = ItemRegistry.getRandomVerdantRelic();
-        world.dropItemNaturally(center, relic);
-        world.playSound(center, Sound.ENTITY_ITEM_PICKUP, 1.0f, 0.8f);
-        String name = relic.getItemMeta() != null
-                ? relic.getItemMeta().getDisplayName()
-                : "Relic";
-        player.sendMessage(ChatColor.AQUA
-                + "You uncover a treasure! ("
-                + name
-                + ChatColor.AQUA
-                + ")");
+        world.playSound(center, Sound.BLOCK_GRAVEL_BREAK, 1.0f, 1.0f);
+        player.sendMessage(ChatColor.GRAY + "You uncover nothing of value.");
 
         world.spawnParticle(
                 Particle.BLOCK,


### PR DESCRIPTION
## Summary
- add TrailRuinRegistry and TrailRuinManager to control suspicious sand and gravel drops
- move verdant relic seeds from graves to trail ruin brushing
- register TrailRuinManager and clean up grave loot

## Testing
- `mvn -q -e -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_689a9b174df08332b70c28e3bc2f254d