### PR TITLE
Add configurable clock timing and backpack return for containers

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TrinketManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/trinkets/TrinketManager.java
@@ -6,6 +6,7 @@ import goat.minecraft.minecraftnew.other.trinkets.PotionPouchManager;
 import goat.minecraft.minecraftnew.other.trinkets.MiningPouchManager;
 import goat.minecraft.minecraftnew.other.trinkets.TransfigurationPouchManager;
 import goat.minecraft.minecraftnew.other.trinkets.EnchantedHopperManager;
+import goat.minecraft.minecraftnew.other.trinkets.EnchantedClockManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -170,6 +171,12 @@ public class TrinketManager implements Listener {
                     event.setCancelled(true);
                 } else if (event.getClick() == ClickType.SHIFT_RIGHT) {
                     EnchantedHopperManager.getInstance().cycleDelay(player, item);
+                    event.setCancelled(true);
+                }
+            }
+            case "Enchanted Clock" -> {
+                if (event.getClick() == ClickType.SHIFT_RIGHT) {
+                    EnchantedClockManager.getInstance().cycleDelay(player, item);
                     event.setCancelled(true);
                 }
             }

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -1400,8 +1400,10 @@ public class ItemRegistry {
                 Material.CLOCK,
                 ChatColor.YELLOW + "Enchanted Clock",
                 List.of(
-                        ChatColor.GRAY + "Activates the trinket above every 3 minutes",
-                        ChatColor.BLUE + "Right-click" + ChatColor.GRAY + ": Pick up"
+                        ChatColor.GRAY + "Activates the trinket above automatically",
+                        ChatColor.BLUE + "Shift-Right-click" + ChatColor.GRAY + ": Change delay",
+                        ChatColor.BLUE + "Right-click" + ChatColor.GRAY + ": Pick up",
+                        ChatColor.GRAY + "Delay: " + ChatColor.WHITE + "3m"
                 ),
                 1,
                 false,


### PR DESCRIPTION
## Summary
- Allow shift-right-clicking Enchanted Clocks to cycle their activation delay
- Reopen backpack after closing Enchanted Hoppers and Satchels

## Testing
- `mvn -q -e -DskipTests package` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ab7c8e808833280eda9413264eb68