### PR TITLE
Adjust Pantry of Plenty to extend saturation duration

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/ignoreme
+++ b/src/main/java/goat/minecraft/minecraftnew/ignoreme
@@ -188,7 +188,7 @@ Satiation Mastery IV: +1 Bonus Saturation, Max level 1
 Cutting Board IV: +4% Chance For Double Culinary Yield, Max level 5
 Lunch Rush IV: -4% Cook time, Max level 5
 Rabbit: +10% Veggie Gains, Max level 4
-Pantry of Plenty: +4% Chance to gain 20 Saturation when eating Culinary Delights, Max level 5
+Pantry of Plenty: +20% Saturation effect duration, Max level 5
 
 Legendary:
 Satiation Mastery V: +1 Bonus Saturation, Max level 1

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/SkillTreeManager.java
@@ -491,8 +491,8 @@ public class SkillTreeManager implements Listener {
                 double veggieBonus = level * 10;
                 return ChatColor.YELLOW + "+" + veggieBonus + "% Veggie Gains";
             case PANTRY_OF_PLENTY:
-                double satChance = level * 4;
-                return ChatColor.YELLOW + "+" + satChance + "% Chance to gain 20 Saturation when eating Culinary Delights";
+                double satDuration = level * 20;
+                return ChatColor.YELLOW + "+" + satDuration + "% Saturation effect duration";
             case CAVITY:
                 double sugarBonus = level * 10;
                 return ChatColor.YELLOW + "+" + sugarBonus + "% Sugar Gains";

--- a/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/skilltree/Talent.java
@@ -1044,7 +1044,7 @@ public enum Talent {
     PANTRY_OF_PLENTY(
             "Pantry of Plenty",
             ChatColor.GRAY + "Stocked for any feast",
-            ChatColor.YELLOW + "+4% Chance to gain 20 Saturation when eating Culinary Delights",
+            ChatColor.YELLOW + "+20% Saturation effect duration",
             5,
             60,
             Material.CHEST

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/culinary/CulinarySubsystem.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/culinary/CulinarySubsystem.java
@@ -594,6 +594,8 @@ public class CulinarySubsystem implements Listener {
             }
         }
 
+        double pantryMultiplier = 1 + pantryLevel * 0.20;
+
         if (goldenLevel > 0) {
             player.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, goldenLevel * 60, 0));
         }
@@ -628,81 +630,81 @@ public class CulinarySubsystem implements Listener {
         }
         switch (displayName) {
             case "Tidal Shot (Culinary)":
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20*2, 0));
+                addSaturationEffect(player, 20*2, pantryMultiplier);
                 player.addPotionEffect(new PotionEffect(PotionEffectType.NAUSEA, 20*10, 0));
                 player.addPotionEffect(new PotionEffect(PotionEffectType.ABSORPTION, 20*60*60, 4));
                 break;
             case "Coral Cooler (Culinary)":
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20*2, 0));
+                addSaturationEffect(player, 20*2, pantryMultiplier);
                 player.addPotionEffect(new PotionEffect(PotionEffectType.NAUSEA, 20*10, 0));
                 player.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, 20*60*60, 0));
                 break;
             case "Prismarita (Culinary)":
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20*2, 0));
+                addSaturationEffect(player, 20*2, pantryMultiplier);
                 player.addPotionEffect(new PotionEffect(PotionEffectType.NAUSEA, 20*10, 0));
                 player.addPotionEffect(new PotionEffect(PotionEffectType.STRENGTH, 20*60*60, 0));
                 break;
             case "Kelp Mojito (Culinary)":
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20*2, 0));
+                addSaturationEffect(player, 20*2, pantryMultiplier);
                 player.addPotionEffect(new PotionEffect(PotionEffectType.NAUSEA, 20*10, 0));
                 player.addPotionEffect(new PotionEffect(PotionEffectType.WATER_BREATHING, 20*60*60, 0));
                 break;
             case "Pina Colada (Culinary)":
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20*2, 0));
+                addSaturationEffect(player, 20*2, pantryMultiplier);
                 player.addPotionEffect(new PotionEffect(PotionEffectType.NAUSEA, 20*10, 0));
                 player.addPotionEffect(new PotionEffect(PotionEffectType.FIRE_RESISTANCE, 20*60*60, 0));
                 break;
             case "Banana Split (Culinary)":
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20*2, 0));
+                addSaturationEffect(player, 20*2, pantryMultiplier);
                 player.addPotionEffect(new PotionEffect(PotionEffectType.WATER_BREATHING, 20*60*10, 0));
                 player.addPotionEffect(new PotionEffect(PotionEffectType.FIRE_RESISTANCE, 20*60*60, 0));
                 break;
             case "Key Lime Pie (Culinary)":
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20*2, 0));
+                addSaturationEffect(player, 20*2, pantryMultiplier);
                 player.addPotionEffect(new PotionEffect(PotionEffectType.WATER_BREATHING, 20*60*10, 0));
                 player.addPotionEffect(new PotionEffect(PotionEffectType.FIRE_RESISTANCE, 20*60*60, 0));
                 break;
             case "Salted Steak (Culinary)":
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20*2, 0));
+                addSaturationEffect(player, 20*2, pantryMultiplier);
                 break;
             case "Chicken Tenders (Culinary)":
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20*2, 0));
+                addSaturationEffect(player, 20*2, pantryMultiplier);
                 break;
             case "Ham and Cheese Sandwich (Culinary)":
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20*3, 0));
+                addSaturationEffect(player, 20*3, pantryMultiplier);
                 break;
             case "Toast (Culinary)":
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20*1, 0));
+                addSaturationEffect(player, 20*1, pantryMultiplier);
                 break;
             case "Grilled Salmon (Culinary)":
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20*1, 0));
+                addSaturationEffect(player, 20*1, pantryMultiplier);
                 break;
             case "Mushroom Soup (Culinary)":
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20*1, 0));
+                addSaturationEffect(player, 20*1, pantryMultiplier);
                 break;
             case "Loaded Baked Potato (Culinary)":
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20*11, 0));
+                addSaturationEffect(player, 20*11, pantryMultiplier);
                 break;
 
 
             case "Sweet Feast (Culinary)":
                 player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 20*60*60*1, 0));
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20*60*3, 0));
+                addSaturationEffect(player, 20*60*3, pantryMultiplier);
                 player.setHealth(player.getMaxHealth());
                 break;
             case "Vegetarian Feast (Culinary)":
                 player.addPotionEffect(new PotionEffect(PotionEffectType.NIGHT_VISION, 20*60*60*1, 0));
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20*60*3, 0));
+                addSaturationEffect(player, 20*60*3, pantryMultiplier);
                 player.setHealth(player.getMaxHealth());
                 break;
             case "Meatlovers Feast (Culinary)":
                 player.addPotionEffect(new PotionEffect(PotionEffectType.STRENGTH, 20*60*60*1, 0));
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20*60*3, 0));
+                addSaturationEffect(player, 20*60*3, pantryMultiplier);
                 player.setHealth(player.getMaxHealth());
                 break;
             case "Seafood Feast (Culinary)":
                 player.addPotionEffect(new PotionEffect(PotionEffectType.WATER_BREATHING, 20*60*60*1, 0));
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20*60*3, 0));
+                addSaturationEffect(player, 20*60*3, pantryMultiplier);
                 player.setHealth(player.getMaxHealth());
                 break;
             default:
@@ -741,14 +743,6 @@ public class CulinarySubsystem implements Listener {
             player.setSaturation(20f);
         }
 
-        if (pantryLevel > 0 && isCulinaryDelight) {
-            double chance = pantryLevel * 0.04;
-            if (Math.random() < chance) {
-                player.setSaturation(Math.min(player.getSaturation() + 20, 20f));
-                player.sendMessage(ChatColor.GREEN + "Your meal left you completely satisfied!");
-            }
-        }
-
         if (refundLevel > 0) {
             double chance = refundLevel * 0.05;
             if (Math.random() < chance) {
@@ -765,6 +759,11 @@ public class CulinarySubsystem implements Listener {
         }
 
         clampPlayerStats(player);
+    }
+
+    private void addSaturationEffect(Player player, int baseDuration, double pantryMultiplier) {
+        int duration = (int) Math.round(baseDuration * pantryMultiplier);
+        player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, duration, 0));
     }
 
     private void clampPlayerStats(Player player) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/culinary/CustomNutritionManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/culinary/CustomNutritionManager.java
@@ -4,6 +4,9 @@ import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.utils.devtools.AFKDetector;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionManager;
 import goat.minecraft.minecraftnew.subsystems.brewing.PotionEffectPreferences;
+import goat.minecraft.minecraftnew.other.skilltree.Skill;
+import goat.minecraft.minecraftnew.other.skilltree.SkillTreeManager;
+import goat.minecraft.minecraftnew.other.skilltree.Talent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -146,8 +149,16 @@ public class CustomNutritionManager implements Listener {
         if (map.getOrDefault(FoodGroup.FRUITS,0) >= 50 && player.getSaturation() >= 17) {
             player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.REGENERATION, 40, 0, true, false, false));
         }
+        int pantryLevel = 0;
+        SkillTreeManager manager = SkillTreeManager.getInstance();
+        if (manager != null) {
+            pantryLevel = manager.getTalentLevel(player.getUniqueId(), Skill.CULINARY, Talent.PANTRY_OF_PLENTY);
+        }
+        double pantryMultiplier = 1 + pantryLevel * 0.20;
+
         if (map.getOrDefault(FoodGroup.GRAINS,0) >= 50) {
-            player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.SATURATION, 40, 0, true, false, false));
+            int duration = (int) Math.round(40 * pantryMultiplier);
+            player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.SATURATION, duration, 0, true, false, false));
         }
         if (map.getOrDefault(FoodGroup.PROTEINS,0) >= 50) {
             player.addPotionEffect(new org.bukkit.potion.PotionEffect(PotionEffectType.STRENGTH, 40, 0, true, false, false));


### PR DESCRIPTION
## Summary
- Make Pantry of Plenty lengthen saturation effects by 20% per level (up to 2x)
- Apply multiplier to all culinary and nutrition-based saturation potion effects
- Update talent descriptions and documentation for new behavior

## Testing
- `mvn -q -e -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689bd9d59120833284cfc3158624183a