### PR TITLE
fix: remove tab updater leak

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerTradeManager.java
@@ -2,7 +2,6 @@ package goat.minecraft.minecraftnew.subsystems.villagers;
 
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.other.additionalfunctionality.CustomBundleGUI;
-import goat.minecraft.minecraftnew.other.additionalfunctionality.PlayerTabListUpdater;
 import goat.minecraft.minecraftnew.subsystems.culinary.CulinarySubsystem;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
 import goat.minecraft.minecraftnew.subsystems.pets.PetRegistry;
@@ -1212,8 +1211,7 @@ public class VillagerTradeManager implements Listener {
 
         // Get villager profession and player's days played
         Villager.Profession profession = villager.getProfession();
-        PlayerTabListUpdater playerTabListUpdater = new PlayerTabListUpdater(MinecraftNew.getInstance(), new XPManager(MinecraftNew.getInstance()));
-        int daysPlayed = playerTabListUpdater.getDaysPlayed(player);
+        int daysPlayed = player.getStatistic(Statistic.PLAY_ONE_MINUTE) / 24000;
         SkillTreeManager mgr = SkillTreeManager.getInstance();
         int offset = 0;
         if (mgr != null) {

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/professions/bartender/BartenderVillagerManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/professions/bartender/BartenderVillagerManager.java
@@ -5,9 +5,7 @@ import goat.minecraft.minecraftnew.subsystems.culinary.CulinarySubsystem;
 import goat.minecraft.minecraftnew.subsystems.villagers.VillagerTradeManager;
 import goat.minecraft.minecraftnew.subsystems.villagers.VillagerTradeManager.TradeItem;
 import goat.minecraft.minecraftnew.utils.devtools.ItemRegistry;
-import goat.minecraft.minecraftnew.utils.devtools.XPManager;
 import goat.minecraft.minecraftnew.subsystems.pets.PetManager;
-import goat.minecraft.minecraftnew.other.additionalfunctionality.PlayerTabListUpdater;
 import org.bukkit.*;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
@@ -77,9 +75,7 @@ public class BartenderVillagerManager implements Listener {
         Villager villager = interactionMap.get(player);
 
         // 1) Compute villager level from days played exactly as your other GUI:
-        int days = new PlayerTabListUpdater(MinecraftNew.getInstance(),
-                new XPManager(plugin))
-                .getDaysPlayed(player);
+        int days = player.getStatistic(Statistic.PLAY_ONE_MINUTE) / 24000;
         int lvl = days >=200?5:
                 days >=150?4:
                         days >=100?3:


### PR DESCRIPTION
## Summary
- use built-in player statistic to check days played rather than creating new PlayerTabListUpdater each time
- stop spawning uncancelled repeating tasks that caused memory leak and lag

## Testing
- `mvn -q -e -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_689d696d355083329561399c00856e75