### PR TITLE
Ensure flight artifacts replenish remaining flight time

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/Flight.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/pets/perks/Flight.java
@@ -60,6 +60,21 @@ public class Flight implements Listener {
         int flown = dailyFlightTracker.getOrDefault(playerId, 0);
         flown = Math.max(0, flown - seconds);
         dailyFlightTracker.put(playerId, flown);
+
+        // Recalculate and display remaining flight time
+        PetManager.Pet activePet = petManager.getActivePet(player);
+        int maxFlightSeconds = calculateMaxFlightSeconds(player, activePet);
+        int remainingSeconds = maxFlightSeconds - flown;
+        displayFlightProgress(player, flown, remainingSeconds);
+
+        // Re-enable flight if the player is allowed to fly and has time remaining
+        CatalystManager catalystManager = CatalystManager.getInstance();
+        boolean nearCatalyst = catalystManager != null &&
+                catalystManager.isNearCatalyst(player.getLocation(), CatalystType.FLIGHT);
+        boolean hasPerk = activePet != null && activePet.hasPerk(PetManager.PetPerk.FLIGHT);
+        if (remainingSeconds > 0 && (hasPerk || nearCatalyst)) {
+            enableFlight(player);
+        }
     }
 
     @EventHandler


### PR DESCRIPTION
## Summary
- Update Flight perk to refresh remaining time and enable flight after artifacts replenish seconds

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ba9871e08332b87c1e99a03b40b4