### PR TITLE
Require damage before Alloy perk activates

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
@@ -1628,8 +1628,10 @@ public class AnvilRepair implements Listener {
             return;
         }
         CustomDurabilityManager customDurabilityManager = CustomDurabilityManager.getInstance();
+        int currentDurability = customDurabilityManager.getCurrentDurability(repairee);
+        int maxDurability = customDurabilityManager.getMaxDurability(repairee);
 
-        if (mgr != null && isDurable(repairee)) {
+        if (mgr != null && isDurable(repairee) && currentDurability < maxDurability) {
             UUID uid = player.getUniqueId();
             Random rng = new Random();
 


### PR DESCRIPTION
## Summary
- Only apply Alloy perk bonuses when the repaired item isn't already at max durability

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a45a94b5dc8332916a27021b098712