### PR TITLE
Gate Flight talent behind Flight perk

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/flight/FlightManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/flight/FlightManager.java
@@ -134,16 +134,18 @@ public class FlightManager implements Listener {
 
     private int calculateFlight(Player player, Pet activePet) {
         int seconds = 0;
-        if (activePet != null && activePet.hasPerk(PetPerk.FLIGHT)) {
+        boolean hasFlightPerk = activePet != null && activePet.hasPerk(PetPerk.FLIGHT);
+        if (hasFlightPerk) {
             int perkSeconds = activePet.getLevel(); // 1s per level
             if (meritManager.hasPerk(player.getUniqueId(), "Icarus")) {
                 perkSeconds *= 2;
             }
             seconds += perkSeconds;
-        }
-        if (SkillTreeManager.getInstance() != null) {
-            int talentLevel = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.TAMING, Talent.FLIGHT);
-            seconds += talentLevel * 40;
+
+            if (SkillTreeManager.getInstance() != null) {
+                int talentLevel = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.TAMING, Talent.FLIGHT);
+                seconds += talentLevel * 40;
+            }
         }
         return seconds;
     }

--- a/src/main/java/goat/minecraft/minecraftnew/utils/stats/StatsCalculator.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/stats/StatsCalculator.java
@@ -131,17 +131,19 @@ public class StatsCalculator {
     public int getFlightTime(Player player) {
         PetManager.Pet pet = PetManager.getInstance(plugin).getActivePet(player);
         int seconds = 0;
-        if (pet != null && pet.hasPerk(PetManager.PetPerk.FLIGHT)) {
+        boolean hasFlightPerk = pet != null && pet.hasPerk(PetManager.PetPerk.FLIGHT);
+        if (hasFlightPerk) {
             int perkSeconds = pet.getLevel(); // 1 second per pet level
             PlayerMeritManager merits = PlayerMeritManager.getInstance(plugin);
             if (merits.hasPerk(player.getUniqueId(), "Icarus")) {
                 perkSeconds *= 2;
             }
             seconds += perkSeconds;
-        }
-        if (SkillTreeManager.getInstance() != null) {
-            int talentLevel = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.TAMING, Talent.FLIGHT);
-            seconds += talentLevel * 40; // 40s per talent level
+
+            if (SkillTreeManager.getInstance() != null) {
+                int talentLevel = SkillTreeManager.getInstance().getTalentLevel(player.getUniqueId(), Skill.TAMING, Talent.FLIGHT);
+                seconds += talentLevel * 40; // 40s per talent level
+            }
         }
         return seconds;
     }


### PR DESCRIPTION
## Summary
- Require a pet's Flight perk before adding Flight talent bonus
- Reflect perk check in stats calculation

## Testing
- `mvn -e test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a461c48f98833297a0c1c514448163