### PR TITLE
Add Rocket Generator item and generator system

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -106,6 +106,8 @@ import goat.minecraft.minecraftnew.other.armorsets.StriderSetBonus;
 
 import goat.minecraft.minecraftnew.other.durability.CustomDurabilityManager;
 import goat.minecraft.minecraftnew.other.durability.HeirloomManager;
+import goat.minecraft.minecraftnew.other.generators.GeneratorManager;
+import goat.minecraft.minecraftnew.other.generators.GeneratorListener;
 import goat.minecraft.minecraftnew.other.skilltree.SwiftStepMasteryBonus;
 import goat.minecraft.minecraftnew.other.skilltree.FastFarmerBonus;
 import goat.minecraft.minecraftnew.other.skilltree.SpectralArmorBonus;
@@ -271,6 +273,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         new SetDurabilityCommand(this);
         CustomDurabilityManager.init(this);
         HeirloomManager.init(this);
+        GeneratorManager.init(this);
         new SetCustomDurabilityCommand(this);
         new AddGoldenDurabilityCommand(this);
         this.getCommand("skin").setExecutor(new SkinCommand());
@@ -285,6 +288,8 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new UltimateEnchantingSystem(), this);
 
         getServer().getPluginManager().registerEvents(new ArmorEquipListener(), this);
+
+        getServer().getPluginManager().registerEvents(new GeneratorListener(), this);
 
         getServer().getPluginManager().registerEvents(new Leap(this), this);
         getServer().getPluginManager().registerEvents(new Comfortable(this), this);

--- a/src/main/java/goat/minecraft/minecraftnew/other/generators/GeneratorListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/generators/GeneratorListener.java
@@ -1,0 +1,32 @@
+package goat.minecraft.minecraftnew.other.generators;
+
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Handles player interaction with generators.
+ */
+public class GeneratorListener implements Listener {
+
+    @EventHandler
+    public void onInteract(PlayerInteractEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) return;
+        Action action = event.getAction();
+        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) return;
+        ItemStack item = event.getItem();
+        if (item == null) return;
+        GeneratorManager mgr = GeneratorManager.getInstance();
+        if (mgr != null && mgr.isGenerator(item)) {
+            mgr.toggleActivation(item);
+            event.setCancelled(true);
+            Player player = event.getPlayer();
+            player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 1.0f, 1.0f);
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/other/generators/GeneratorManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/generators/GeneratorManager.java
@@ -1,0 +1,220 @@
+package goat.minecraft.minecraftnew.other.generators;
+
+import goat.minecraft.minecraftnew.utils.devtools.ItemLoreFormatter;
+import org.bukkit.ChatColor;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Manages power values and tiers for generator items.
+ */
+public class GeneratorManager {
+    private static GeneratorManager instance;
+    private final NamespacedKey powerKey;
+    private final NamespacedKey powerLimitKey;
+    private final NamespacedKey tierKey;
+    private final NamespacedKey activeKey;
+
+    private GeneratorManager(JavaPlugin plugin) {
+        this.powerKey = new NamespacedKey(plugin, "generator_power");
+        this.powerLimitKey = new NamespacedKey(plugin, "generator_power_limit");
+        this.tierKey = new NamespacedKey(plugin, "generator_tier");
+        this.activeKey = new NamespacedKey(plugin, "generator_active");
+    }
+
+    public static void init(JavaPlugin plugin) {
+        if (instance == null) {
+            instance = new GeneratorManager(plugin);
+        }
+    }
+
+    public static GeneratorManager getInstance() {
+        return instance;
+    }
+
+    public boolean isGenerator(ItemStack item) {
+        if (item == null) return false;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return false;
+        PersistentDataContainer data = meta.getPersistentDataContainer();
+        return data.has(tierKey, PersistentDataType.INTEGER);
+    }
+
+    public int getPower(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return 0;
+        Integer val = meta.getPersistentDataContainer().get(powerKey, PersistentDataType.INTEGER);
+        return val != null ? val : 0;
+    }
+
+    public int getPowerLimit(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return 0;
+        Integer val = meta.getPersistentDataContainer().get(powerLimitKey, PersistentDataType.INTEGER);
+        return val != null ? val : 0;
+    }
+
+    public int getTier(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return 0;
+        Integer val = meta.getPersistentDataContainer().get(tierKey, PersistentDataType.INTEGER);
+        return val != null ? val : 0;
+    }
+
+    public boolean isActive(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return false;
+        Integer val = meta.getPersistentDataContainer().get(activeKey, PersistentDataType.INTEGER);
+        return val != null && val == 1;
+    }
+
+    public void setGenerator(ItemStack item, int power, int powerLimit, int tier, boolean active) {
+        if (item == null) return;
+        if (power < 0) power = 0;
+        if (powerLimit < 0) powerLimit = 0;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        PersistentDataContainer data = meta.getPersistentDataContainer();
+        data.set(powerKey, PersistentDataType.INTEGER, power);
+        data.set(powerLimitKey, PersistentDataType.INTEGER, powerLimit);
+        data.set(tierKey, PersistentDataType.INTEGER, tier);
+        data.set(activeKey, PersistentDataType.INTEGER, active ? 1 : 0);
+        item.setItemMeta(meta);
+        updateName(item);
+        updateLore(item);
+        updateDurabilityBar(item);
+    }
+
+    public void addPower(ItemStack item, int amount) {
+        if (!isGenerator(item)) return;
+        int tier = getTier(item);
+        if (tier >= 10) return;
+        int power = getPower(item) + amount;
+        int limit = getPowerLimit(item);
+        if (power >= limit) {
+            tier++;
+            power = 0;
+            if (tier >= 10) {
+                tier = 10;
+                limit = 0;
+            } else {
+                limit += 1 + new Random().nextInt(9);
+            }
+        }
+        setGenerator(item, power, limit, tier, isActive(item));
+    }
+
+    public void toggleActivation(ItemStack item) {
+        if (!isGenerator(item)) return;
+        boolean active = !isActive(item);
+        setGenerator(item, getPower(item), getPowerLimit(item), getTier(item), active);
+    }
+
+    private void updateName(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        int tier = getTier(item);
+        String base = getBaseName(meta.getDisplayName());
+        meta.setDisplayName(base + " Tier " + toRomanNumeral(tier));
+        item.setItemMeta(meta);
+    }
+
+    private String getBaseName(String name) {
+        int idx = name.lastIndexOf(" Tier ");
+        if (idx >= 0) {
+            return name.substring(0, idx);
+        }
+        return name;
+    }
+
+    private String toRomanNumeral(int number) {
+        String[] numerals = {"I","II","III","IV","V","VI","VII","VIII","IX","X"};
+        if (number >= 1 && number <= 10) {
+            return numerals[number - 1];
+        }
+        return String.valueOf(number);
+    }
+
+    private void updateLore(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        List<String> lore = meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
+        boolean active = isActive(item);
+        int power = getPower(item);
+        int limit = getPowerLimit(item);
+        int tier = getTier(item);
+
+        String ioLine = (active ? ChatColor.GREEN + "I/O: Activated" : ChatColor.RED + "I/O: Deactivated");
+        replaceOrAdd(lore, "I/O:", ioLine);
+
+        if (tier >= 10) {
+            removeLine(lore, "Power:");
+            replaceOrAdd(lore, "MAX TIER", ChatColor.GOLD + "MAX TIER");
+        } else {
+            String powerLine = ChatColor.GOLD + "Power: " + power + "/" + limit;
+            replaceOrAdd(lore, "Power:", powerLine);
+            removeLine(lore, "MAX TIER");
+        }
+
+        meta.setLore(lore);
+        item.setItemMeta(meta);
+        ItemLoreFormatter.formatLore(item);
+    }
+
+    private void replaceOrAdd(List<String> lore, String prefix, String line) {
+        int index = findIndex(lore, prefix);
+        if (index >= 0) {
+            lore.set(index, line);
+        } else {
+            lore.add(line);
+        }
+    }
+
+    private void removeLine(List<String> lore, String prefix) {
+        int index = findIndex(lore, prefix);
+        if (index >= 0) {
+            lore.remove(index);
+        }
+    }
+
+    private int findIndex(List<String> lore, String prefix) {
+        for (int i = 0; i < lore.size(); i++) {
+            String stripped = ChatColor.stripColor(lore.get(i));
+            if (stripped.startsWith(prefix)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private void updateDurabilityBar(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta instanceof Damageable damageable) {
+            int tier = getTier(item);
+            int limit = getPowerLimit(item);
+            int power = getPower(item);
+            int vanillaMax = item.getType().getMaxDurability();
+            if (vanillaMax > 0) {
+                int newDamage;
+                if (tier >= 10 || limit <= 0) {
+                    newDamage = 0;
+                } else {
+                    newDamage = vanillaMax - (int)Math.round(((double) power / limit) * vanillaMax);
+                    if (newDamage < 0) newDamage = 0;
+                    if (newDamage > vanillaMax) newDamage = vanillaMax;
+                }
+                damageable.setDamage(newDamage);
+                item.setItemMeta(meta);
+            }
+        }
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/AnvilRepair.java
@@ -4,6 +4,7 @@ import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.other.enchanting.CustomEnchantmentManager;
 import goat.minecraft.minecraftnew.other.durability.CustomDurabilityManager;
 import goat.minecraft.minecraftnew.other.durability.HeirloomManager;
+import goat.minecraft.minecraftnew.other.generators.GeneratorManager;
 import goat.minecraft.minecraftnew.subsystems.mining.MiningGemManager;
 import goat.minecraft.minecraftnew.subsystems.smithing.tierreforgelisteners.ReforgeManager;
 import goat.minecraft.minecraftnew.subsystems.smithing.ReforgeSubsystem;
@@ -847,7 +848,16 @@ public class AnvilRepair implements Listener {
             repairAmount = repairAmount + 150;
         }
         // Determine the type of repair material and set the repair amount accordingly
-        if (billItem.getType() == Material.GOLD_INGOT) {
+        if (billItem.getType() == Material.REDSTONE_BLOCK) {
+            GeneratorManager gm = GeneratorManager.getInstance();
+            if (gm != null && gm.isGenerator(repairee)) {
+                int power = 1 + new Random().nextInt(18);
+                gm.addPower(repairee, power);
+                billItem.setAmount(billItem.getAmount() - 1);
+                player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 10);
+            }
+            return;
+        } else if (billItem.getType() == Material.GOLD_INGOT) {
             if (HeirloomManager.getInstance().isHeirloom(repairee)) {
                 StatsCalculator statsCalculator = StatsCalculator.getInstance(MinecraftNew.getInstance());
                 double quality = statsCalculator.getGoldenRepairQuality(player);

--- a/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/devtools/ItemRegistry.java
@@ -4,6 +4,7 @@ package goat.minecraft.minecraftnew.utils.devtools;
 import goat.minecraft.minecraftnew.MinecraftNew;
 import goat.minecraft.minecraftnew.other.structureblocks.StructureBlockManager;
 import goat.minecraft.minecraftnew.other.durability.HeirloomManager;
+import goat.minecraft.minecraftnew.other.generators.GeneratorManager;
 import goat.minecraft.minecraftnew.utils.stats.DefenseManager;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -4719,6 +4720,27 @@ public class ItemRegistry {
         HeirloomManager mgr = HeirloomManager.getInstance();
         if (mgr != null) {
             mgr.setGild(item, 0, 500);
+        }
+        return item;
+    }
+
+    // ===== Generators =====
+
+    public static ItemStack getRocketGenerator() {
+        ItemStack item = createCustomItem(
+                Material.LEATHER_CHESTPLATE,
+                ChatColor.GOLD + "Rocket Generator Tier I",
+                Arrays.asList(
+                        ChatColor.GRAY + "Generates a random Firework.",
+                        ChatColor.DARK_PURPLE + "Generator"
+                ),
+                1,
+                false,
+                true
+        );
+        GeneratorManager mgr = GeneratorManager.getInstance();
+        if (mgr != null) {
+            mgr.setGenerator(item, 0, 100, 1, false);
         }
         return item;
     }


### PR DESCRIPTION
## Summary
- introduce GeneratorManager for tracking generator power, tiers, and activation
- add Rocket Generator item with toggleable I/O and power leveling
- allow redstone blocks on anvils to charge generators
- register generator listeners and initialization

## Testing
- `mvn -q -e -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4eb67f1fc8332834e8adc7ea2e353