### PR TITLE
Implement GUI-activated persistent rocket generators

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -108,6 +108,8 @@ import goat.minecraft.minecraftnew.other.durability.CustomDurabilityManager;
 import goat.minecraft.minecraftnew.other.durability.HeirloomManager;
 import goat.minecraft.minecraftnew.other.generators.GeneratorManager;
 import goat.minecraft.minecraftnew.other.generators.GeneratorListener;
+import goat.minecraft.minecraftnew.other.generators.GeneratorService;
+import goat.minecraft.minecraftnew.other.generators.ForceGenerationCommand;
 import goat.minecraft.minecraftnew.other.skilltree.SwiftStepMasteryBonus;
 import goat.minecraft.minecraftnew.other.skilltree.FastFarmerBonus;
 import goat.minecraft.minecraftnew.other.skilltree.SpectralArmorBonus;
@@ -274,6 +276,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         CustomDurabilityManager.init(this);
         HeirloomManager.init(this);
         GeneratorManager.init(this);
+        GeneratorService.init(this);
         new SetCustomDurabilityCommand(this);
         new AddGoldenDurabilityCommand(this);
         this.getCommand("skin").setExecutor(new SkinCommand());
@@ -290,6 +293,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new ArmorEquipListener(), this);
 
         getServer().getPluginManager().registerEvents(new GeneratorListener(), this);
+        this.getCommand("forcegeneration").setExecutor(new ForceGenerationCommand());
 
         getServer().getPluginManager().registerEvents(new Leap(this), this);
         getServer().getPluginManager().registerEvents(new Comfortable(this), this);
@@ -804,6 +808,10 @@ public class MinecraftNew extends JavaPlugin implements Listener {
     @Override
     public void onDisable() {
         HealthManager.shutdown();
+        GeneratorService svc = GeneratorService.getInstance();
+        if (svc != null) {
+            svc.shutdown();
+        }
         if (shelfManager != null) {
             shelfManager.onDisable();
         }

--- a/src/main/java/goat/minecraft/minecraftnew/other/generators/ForceGenerationCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/generators/ForceGenerationCommand.java
@@ -1,0 +1,27 @@
+package goat.minecraft.minecraftnew.other.generators;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+/**
+ * Dev command to force all generators to generate items every second.
+ */
+public class ForceGenerationCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.isOp()) {
+            sender.sendMessage(ChatColor.RED + "No permission.");
+            return true;
+        }
+        GeneratorService service = GeneratorService.getInstance();
+        if (service != null) {
+            service.forceGeneration();
+            sender.sendMessage(ChatColor.GREEN + "All generators set to 1s timers.");
+        }
+        return true;
+    }
+}
+

--- a/src/main/java/goat/minecraft/minecraftnew/other/generators/GeneratorManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/generators/GeneratorManager.java
@@ -23,12 +23,14 @@ public class GeneratorManager {
     private final NamespacedKey powerLimitKey;
     private final NamespacedKey tierKey;
     private final NamespacedKey activeKey;
+    private final NamespacedKey idKey;
 
     private GeneratorManager(JavaPlugin plugin) {
         this.powerKey = new NamespacedKey(plugin, "generator_power");
         this.powerLimitKey = new NamespacedKey(plugin, "generator_power_limit");
         this.tierKey = new NamespacedKey(plugin, "generator_tier");
         this.activeKey = new NamespacedKey(plugin, "generator_active");
+        this.idKey = new NamespacedKey(plugin, "generator_id");
     }
 
     public static void init(JavaPlugin plugin) {
@@ -77,6 +79,12 @@ public class GeneratorManager {
         return val != null && val == 1;
     }
 
+    public String getId(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return null;
+        return meta.getPersistentDataContainer().get(idKey, PersistentDataType.STRING);
+    }
+
     public void setGenerator(ItemStack item, int power, int powerLimit, int tier, boolean active) {
         if (item == null) return;
         if (power < 0) power = 0;
@@ -84,6 +92,9 @@ public class GeneratorManager {
         ItemMeta meta = item.getItemMeta();
         if (meta == null) return;
         PersistentDataContainer data = meta.getPersistentDataContainer();
+        if (!data.has(idKey, PersistentDataType.STRING)) {
+            data.set(idKey, PersistentDataType.STRING, java.util.UUID.randomUUID().toString());
+        }
         data.set(powerKey, PersistentDataType.INTEGER, power);
         data.set(powerLimitKey, PersistentDataType.INTEGER, powerLimit);
         data.set(tierKey, PersistentDataType.INTEGER, tier);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -61,6 +61,10 @@ commands:
   forceworkcycle:
     description: Forces the villager work cycle timer to 1 second.
     usage: /<command>
+  forcegeneration:
+    description: Dev command to set all generator timers to 1 second.
+    usage: /forcegeneration
+    permission: continuity.admin
   testdragon:
       description: Summon the initial and strong dragons in the End for testing.
       usage: /testdragon


### PR DESCRIPTION
## Summary
- allow generators to be toggled via right-click in inventory GUIs instead of air clicks
- add persistent GeneratorService that stores inventory location and schedules item production only when players are online
- rocket generators create random fireworks at tier-scaled intervals and a `/forcegeneration` dev command shortens all timers

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f429d7a0833293f3565682b784fd