### PR TITLE
Fix generator activation not persisting on right-click

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/generators/GeneratorListener.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/generators/GeneratorListener.java
@@ -33,9 +33,11 @@ public class GeneratorListener implements Listener {
             } else {
                 GeneratorService.getInstance().activate(item, clicked, event.getSlot());
             }
+            event.setCurrentItem(item);
             player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 1.0f, 1.0f);
         } else {
             GeneratorService.getInstance().onMove(item);
+            event.setCurrentItem(item);
         }
     }
 


### PR DESCRIPTION
## Summary
- Ensure right-clicking a generator updates its item state in the inventory
- Update item state when generators move to maintain deactivation

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f6ba85dc8332a32b8b37852f89c0