### PR TITLE
Fix forceGeneration timer handling

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/other/generators/ForceGenerationCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/generators/ForceGenerationCommand.java
@@ -19,7 +19,7 @@ public class ForceGenerationCommand implements CommandExecutor {
         GeneratorService service = GeneratorService.getInstance();
         if (service != null) {
             service.forceGeneration();
-            sender.sendMessage(ChatColor.GREEN + "All generators set to 1s timers.");
+            sender.sendMessage(ChatColor.GREEN + "All generators will generate in 1s.");
         }
         return true;
     }

--- a/src/main/java/goat/minecraft/minecraftnew/other/generators/GeneratorService.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/generators/GeneratorService.java
@@ -133,7 +133,8 @@ public class GeneratorService {
 
     public void forceGeneration() {
         for (ActiveGenerator gen : activeGenerators.values()) {
-            gen.restart(20L);
+            long period = computePeriod(gen.tier);
+            gen.reschedule(20L, period);
         }
     }
 
@@ -184,12 +185,12 @@ public class GeneratorService {
 
         void start() {
             long period = computePeriod(tier);
-            task = schedule(period);
+            task = schedule(period, period);
         }
 
-        void restart(long period) {
+        void reschedule(long delay, long period) {
             stop();
-            task = schedule(period);
+            task = schedule(delay, period);
         }
 
         void stop() {
@@ -198,7 +199,7 @@ public class GeneratorService {
             }
         }
 
-        private BukkitTask schedule(long period) {
+        private BukkitTask schedule(long delay, long period) {
             return new BukkitRunnable() {
                 @Override
                 public void run() {
@@ -212,7 +213,7 @@ public class GeneratorService {
                     ItemStack drop = generateItem(current);
                     inventory.addItem(drop);
                 }
-            }.runTaskTimer(plugin, period, period);
+            }.runTaskTimer(plugin, delay, period);
         }
 
         Location getLocation() {


### PR DESCRIPTION
## Summary
- ensure forceGeneration resets only the current timer to 1s without altering cooldowns
- update command message to reflect one-time 1s trigger

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fbf0392883328424bb9a27e544db