### PR TITLE
feat: add rare elytra production to leatherworker

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerWorkCycleManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/villagers/VillagerWorkCycleManager.java
@@ -980,11 +980,19 @@ public class VillagerWorkCycleManager implements Listener, CommandExecutor {
             harvestYield.put(Material.SADDLE, 1);
         }
 
+        // 0.1% chance to produce an elytra
+        if (rng.nextFloat() < 0.001) {
+            harvestYield.put(Material.ELYTRA, 1);
+        }
+
         // Store or drop the items
         storeOrDropHarvest(villager, harvestYield);        // Play sound effects
         villager.getWorld().playSound(villager.getLocation(), Sound.ITEM_ARMOR_EQUIP_LEATHER, 1.0f, 1.0f);
         if (harvestYield.containsKey(Material.SADDLE)) {
             villager.getWorld().playSound(villager.getLocation(), Sound.ITEM_ARMOR_EQUIP_GENERIC, 1.0f, 0.5f);
+        }
+        if (harvestYield.containsKey(Material.ELYTRA)) {
+            villager.getWorld().playSound(villager.getLocation(), Sound.ITEM_ARMOR_EQUIP_ELYTRA, 1.0f, 1.0f);
         }
     }
 


### PR DESCRIPTION
## Summary
- allow leatherworkers to rarely craft an elytra during their work cycle
- play elytra equip sound when generated

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3f8d14208332b50a9d1445fe72ec