### PR TITLE
Add elytra reforging and custom flight mechanics

### DIFF
--- a/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
+++ b/src/main/java/goat/minecraft/minecraftnew/MinecraftNew.java
@@ -89,6 +89,7 @@ import goat.minecraft.minecraftnew.other.trinkets.TrinketManager;
 import goat.minecraft.minecraftnew.other.auras.AuraManager;
 import goat.minecraft.minecraftnew.other.flight.FlightManager;
 import goat.minecraft.minecraftnew.other.armorsets.FlowManager;
+import goat.minecraft.minecraftnew.other.elytra.ElytraFlight;
 import goat.minecraft.minecraftnew.other.armorsets.MonolithSetBonus;
 import goat.minecraft.minecraftnew.other.health.HealthManager;
 import goat.minecraft.minecraftnew.other.armorsets.DuskbloodSetBonus;
@@ -320,6 +321,7 @@ public class MinecraftNew extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new MithrilMiner(this), this);
         getServer().getPluginManager().registerEvents(new EmeraldSeeker(this), this);
         getServer().getPluginManager().registerEvents(new FlightManager(this), this);
+        getServer().getPluginManager().registerEvents(new ElytraFlight(this), this);
         getServer().getPluginManager().registerEvents(new Broomstick(this), this);
         getServer().getPluginManager().registerEvents(new Lullaby(this), this);
         getServer().getPluginManager().registerEvents(new Collector(this), this);

--- a/src/main/java/goat/minecraft/minecraftnew/other/elytra/ElytraFlight.java
+++ b/src/main/java/goat/minecraft/minecraftnew/other/elytra/ElytraFlight.java
@@ -1,0 +1,171 @@
+package goat.minecraft.minecraftnew.other.elytra;
+
+import goat.minecraft.minecraftnew.MinecraftNew;
+import goat.minecraft.minecraftnew.subsystems.smithing.tierreforgelisteners.ReforgeManager;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityToggleGlideEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerToggleSneakEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.util.Vector;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class ElytraFlight implements Listener {
+    private final MinecraftNew plugin;
+    private final ReforgeManager reforgeManager = new ReforgeManager();
+    private final Map<UUID, Integer> gear = new HashMap<>();
+    private final Map<UUID, Long> lastBoost = new HashMap<>();
+    private final Map<UUID, Long> sneakStart = new HashMap<>();
+    private final Map<UUID, Vector> storedVelocity = new HashMap<>();
+    private final Map<UUID, BukkitTask> slowTasks = new HashMap<>();
+
+    private static final long BASE_COOLDOWN_MS = 30_000;
+
+    public ElytraFlight(MinecraftNew plugin) {
+        this.plugin = plugin;
+    }
+
+    private int getMaxGear(Player player) {
+        ItemStack chest = player.getInventory().getChestplate();
+        int tier = reforgeManager.getReforgeTier(chest);
+        return tier + 1;
+    }
+
+    @EventHandler
+    public void onRightClick(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        if (!player.isGliding()) {
+            return;
+        }
+        ItemStack item = event.getItem();
+        if (item != null && item.getType() == Material.FIREWORK_ROCKET && event.getAction().isRightClick()) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onLeftClick(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        if (!player.isGliding()) {
+            return;
+        }
+        if (!event.getAction().isLeftClick()) {
+            return;
+        }
+
+        UUID id = player.getUniqueId();
+        long now = System.currentTimeMillis();
+        int currentGear = gear.getOrDefault(id, 1);
+        int maxGear = getMaxGear(player);
+
+        long cooldown = BASE_COOLDOWN_MS;
+        if (reforgeManager.getReforgeTier(player.getInventory().getChestplate()) == 5 && currentGear <= 2) {
+            cooldown /= 2;
+        }
+
+        long last = lastBoost.getOrDefault(id, 0L);
+        if (now - last < cooldown) {
+            return;
+        }
+
+        double boost = 0.5 * currentGear;
+        Vector velocity = player.getLocation().getDirection().normalize().multiply(boost);
+        player.setVelocity(player.getVelocity().add(velocity));
+
+        lastBoost.put(id, now);
+    }
+
+    @EventHandler
+    public void onSneak(PlayerToggleSneakEvent event) {
+        Player player = event.getPlayer();
+        if (!player.isGliding()) {
+            return;
+        }
+        UUID id = player.getUniqueId();
+        if (event.isSneaking()) {
+            sneakStart.put(id, System.currentTimeMillis());
+            plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
+                if (!player.isOnline() || !player.isGliding() || !player.isSneaking()) {
+                    return;
+                }
+                storedVelocity.put(id, player.getVelocity());
+                BukkitTask task = plugin.getServer().getScheduler().runTaskTimer(plugin, () -> {
+                    if (!player.isOnline() || !player.isGliding() || !player.isSneaking()) {
+                        BukkitTask t = slowTasks.remove(id);
+                        if (t != null) {
+                            t.cancel();
+                        }
+                        return;
+                    }
+                    player.setVelocity(player.getLocation().getDirection().normalize().multiply(0.05));
+                }, 0L, 20L);
+                slowTasks.put(id, task);
+            }, 20L);
+        } else {
+            long start = sneakStart.getOrDefault(id, 0L);
+            long duration = System.currentTimeMillis() - start;
+            sneakStart.remove(id);
+
+            BukkitTask task = slowTasks.remove(id);
+            if (task != null) {
+                task.cancel();
+            }
+            Vector vec = storedVelocity.remove(id);
+            if (vec != null) {
+                player.setVelocity(vec);
+            }
+
+            if (duration < 1000) {
+                int maxGear = getMaxGear(player);
+                int currentGear = gear.getOrDefault(id, 1);
+                currentGear++;
+                if (currentGear > maxGear) {
+                    currentGear = 1;
+                }
+                gear.put(id, currentGear);
+                player.sendMessage(ChatColor.AQUA + "Shifted to gear " + currentGear + ".");
+            }
+        }
+    }
+
+    @EventHandler
+    public void onStopGlide(EntityToggleGlideEvent event) {
+        if (!(event.getEntity() instanceof Player player)) {
+            return;
+        }
+        if (event.isGliding()) {
+            return;
+        }
+        UUID id = player.getUniqueId();
+        gear.remove(id);
+        lastBoost.remove(id);
+        sneakStart.remove(id);
+        BukkitTask task = slowTasks.remove(id);
+        if (task != null) {
+            task.cancel();
+        }
+        storedVelocity.remove(id);
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        UUID id = event.getPlayer().getUniqueId();
+        BukkitTask task = slowTasks.remove(id);
+        if (task != null) {
+            task.cancel();
+        }
+        gear.remove(id);
+        lastBoost.remove(id);
+        sneakStart.remove(id);
+        storedVelocity.remove(id);
+    }
+}

--- a/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/tierreforgelisteners/ReforgeManager.java
+++ b/src/main/java/goat/minecraft/minecraftnew/subsystems/smithing/tierreforgelisteners/ReforgeManager.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Manages the reforging system for weapons, armor, tools, and bows.
+ * Manages the reforging system for weapons, armor, tools, bows, and elytras.
  */
 public class ReforgeManager {
 
@@ -27,12 +27,12 @@ public class ReforgeManager {
      * Represents the different tiers of reforging with associated properties.
      */
     public enum ReforgeTier {
-        TIER_0(0, ChatColor.RESET, "Sword", "Armor", "Tool", "Bow", 0, 0, 0, 0),
-        TIER_1(1, ChatColor.WHITE, "Sturdy Blade", "Sturdy Armor", "Sturdy Tool", "Oak Bow", 4, 6, 100, 10),
-        TIER_2(2, ChatColor.GREEN, "Sharpened Blade", "Reinforced Armor", "Enhanced Tool", "Birch Bow", 8, 12, 150, 20),
-        TIER_3(3, ChatColor.BLUE, "Reinforced Blade", "Fortified Armor", "Refined Tool", "Spruce Bow", 12, 18, 200, 30),
-        TIER_4(4, ChatColor.DARK_PURPLE, "Lethal Blade", "Battle Armor", "Superior Tool", "Acacia Bow", 16, 24, 250, 40),
-        TIER_5(5, ChatColor.GOLD, "Fatal Blade", "Legendary Armor", "Masterwork Tool", "Dark Oak Bow", 20, 30, 400, 50);
+        TIER_0(0, ChatColor.RESET, "Sword", "Armor", "Tool", "Bow", "Elytra", 0, 0, 0, 0),
+        TIER_1(1, ChatColor.WHITE, "Sturdy Blade", "Sturdy Armor", "Sturdy Tool", "Oak Bow", "Gustborne Elytra", 4, 6, 100, 10),
+        TIER_2(2, ChatColor.GREEN, "Sharpened Blade", "Reinforced Armor", "Enhanced Tool", "Birch Bow", "Skybound Elytra", 8, 12, 150, 20),
+        TIER_3(3, ChatColor.BLUE, "Reinforced Blade", "Fortified Armor", "Refined Tool", "Spruce Bow", "Stormforged Elytra", 12, 18, 200, 30),
+        TIER_4(4, ChatColor.DARK_PURPLE, "Lethal Blade", "Battle Armor", "Superior Tool", "Acacia Bow", "Tempest Elytra", 16, 24, 250, 40),
+        TIER_5(5, ChatColor.GOLD, "Fatal Blade", "Legendary Armor", "Masterwork Tool", "Dark Oak Bow", "Zephyr Elytra", 20, 30, 400, 50);
 
         private final int tier;
         private final ChatColor color;
@@ -40,6 +40,7 @@ public class ReforgeManager {
         private final String armorName;
         private final String toolName;
         private final String bowName;
+        private final String elytraName;
         private final int weaponDamageIncrease; // In percent
         private final int armorDefenseBonus; // Flat Defense bonus
         private final int toolDurabilityBonus; // Additional max durability
@@ -49,13 +50,14 @@ public class ReforgeManager {
          * Constructs a ReforgeTier enum constant.
          */
         ReforgeTier(int tier, ChatColor color, String swordName, String armorName, String toolName, String bowName,
-                    int weaponDamageIncrease, int armorDefenseBonus, int toolDurabilityBonus, int bowDamageIncrease) {
+                    String elytraName, int weaponDamageIncrease, int armorDefenseBonus, int toolDurabilityBonus, int bowDamageIncrease) {
             this.tier = tier;
             this.color = color;
             this.swordName = swordName;
             this.armorName = armorName;
             this.toolName = toolName;
             this.bowName = bowName;
+            this.elytraName = elytraName;
             this.weaponDamageIncrease = weaponDamageIncrease;
             this.armorDefenseBonus = armorDefenseBonus;
             this.toolDurabilityBonus = toolDurabilityBonus;
@@ -84,6 +86,10 @@ public class ReforgeManager {
 
         public String getBowName() {
             return bowName;
+        }
+
+        public String getElytraName() {
+            return elytraName;
         }
 
         public int getWeaponDamageIncrease() {
@@ -118,8 +124,9 @@ public class ReforgeManager {
         boolean isArmor = isArmor(item);
         boolean isTool = isTool(item);
         boolean isBow = isBow(item);
+        boolean isElytra = isElytra(item);
 
-        if (!isSword && !isArmor && !isTool && !isBow) {
+        if (!isSword && !isArmor && !isTool && !isBow && !isElytra) {
             return item; // Not a valid item for reforging
         }
 
@@ -145,7 +152,9 @@ public class ReforgeManager {
         String newName = isSword ? targetTier.getColor() + targetTier.getSwordName()
                 : isArmor ? targetTier.getColor() + targetTier.getArmorName()
                 : isTool ? targetTier.getColor() + targetTier.getToolName()
-                : isBow ? targetTier.getColor() + targetTier.getBowName() : meta.getDisplayName();
+                : isBow ? targetTier.getColor() + targetTier.getBowName()
+                : isElytra ? targetTier.getColor() + targetTier.getElytraName()
+                : meta.getDisplayName();
         meta.setDisplayName(newName);
 
         // Step 6: Update the item's lore with the appropriate percentage, preserving other lore
@@ -157,7 +166,8 @@ public class ReforgeManager {
                 || line.contains("Defense:")
                 || line.contains("Chance to repair durability:")
                 || line.contains("Max Durability: +")
-                || line.contains("Strength:"));
+                || line.contains("Strength:")
+                || line.contains("Max Gear:"));
 
         // Add the new reforge lore
         if (isSword) {
@@ -170,6 +180,8 @@ public class ReforgeManager {
             lore.add(ChatColor.DARK_GRAY + "Max Durability: " + ChatColor.AQUA + "+" + targetTier.getToolDurabilityBonus());
         } else if (isBow) {
             lore.add(ChatColor.DARK_GRAY + "Damage Increase: " + ChatColor.AQUA + targetTier.getBowDamageIncrease() + "%");
+        } else if (isElytra) {
+            lore.add(ChatColor.DARK_GRAY + "Max Gear: " + ChatColor.AQUA + (targetTier.getTier() + 1));
         }
 
         meta.setLore(lore);
@@ -269,7 +281,8 @@ public class ReforgeManager {
                 || line.contains("Chance to repair durability:")
                 || line.contains("Max Durability: ")
                 || line.contains("Max Durability: +")
-                || line.contains("Strength:"));
+                || line.contains("Strength:")
+                || line.contains("Max Gear:"));
         meta.setLore(lore);
         item.setItemMeta(meta);
 
@@ -323,5 +336,15 @@ public class ReforgeManager {
             return false;
         }
         return item.getType() == Material.BOW;
+    }
+
+    /**
+     * Checks if an ItemStack is an elytra.
+     */
+    public boolean isElytra(ItemStack item) {
+        if (item == null) {
+            return false;
+        }
+        return item.getType() == Material.ELYTRA;
     }
 }

--- a/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/ApplyReforgeCommand.java
+++ b/src/main/java/goat/minecraft/minecraftnew/utils/developercommands/ApplyReforgeCommand.java
@@ -45,6 +45,7 @@ public class ApplyReforgeCommand implements CommandExecutor {
             case "armor" -> reforgeManager.isArmor(item);
             case "tool" -> reforgeManager.isTool(item);
             case "bow" -> reforgeManager.isBow(item);
+            case "elytra" -> reforgeManager.isElytra(item);
             default -> false;
         };
 


### PR DESCRIPTION
## Summary
- Expand reforge system to support elytras with unique upgrade names and gear-based lore
- Support applying elytra reforges via developer command
- Introduce ElytraFlight listener to handle gear shifting, velocity boosts, slow-glide, and to disable rocket boosting
- Register custom elytra flight mechanics in main plugin

## Testing
- `mvn -q -e -DskipTests package` *(fails: The following artifacts could not be resolved: org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae429051d88332a474caf1e044ce85